### PR TITLE
Added helm files for deployment of the ConfigStoreDemo to Kubernetes.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.dockerignore
+.env
+.git
+.gitignore
+.vs
+.vscode
+*/bin
+*/obj
+**/.toolstarget

--- a/examples/ConfigStoreDemo/Build.cmd
+++ b/examples/ConfigStoreDemo/Build.cmd
@@ -1,0 +1,5 @@
+set ROOT=%~dp0
+
+dotnet publish -c Release %ROOT%ConfigStoreDemo.csproj -o bin\PublishOut
+
+docker build -t configstoredemo -f %ROOT%Dockerfile %ROOT%

--- a/examples/ConfigStoreDemo/Charts/configstoredemo/Chart.yaml
+++ b/examples/ConfigStoreDemo/Charts/configstoredemo/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: "v1"
+name: configstoredemo
+version: 0.90000.90000

--- a/examples/ConfigStoreDemo/Charts/configstoredemo/templates/_helpers.tpl
+++ b/examples/ConfigStoreDemo/Charts/configstoredemo/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Create secret for pulling image.
+*/}}
+{{- define "imagePullSecret" }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.imageRegistry (printf "%s:%s" .Values.registryUsername .Values.registryPassword | b64enc) | b64enc }}
+{{- end }}

--- a/examples/ConfigStoreDemo/Charts/configstoredemo/templates/configstoredemo.yaml
+++ b/examples/ConfigStoreDemo/Charts/configstoredemo/templates/configstoredemo.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: configstoredemo
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: configstoredemo
+    spec:
+      containers:
+      - name: configstoredemo
+        image: {{ .Values.imageRegistry }}/configstoredemo
+        ports:
+        - containerPort: 80
+        env:
+        - name: ConfigurationStore__ConnectionString
+          value: {{ .Values.AzconfigConnectionString }}
+# Uncomment to support pulling environment variables from a config map		  
+#        envFrom:
+#        - configMapRef:
+#            name: my-config-store
+      imagePullSecrets:
+      - name: registry-auth
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: configstoredemo
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+  selector:
+    app: configstoredemo

--- a/examples/ConfigStoreDemo/Charts/configstoredemo/templates/secrets.yaml
+++ b/examples/ConfigStoreDemo/Charts/configstoredemo/templates/secrets.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-auth
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}

--- a/examples/ConfigStoreDemo/Charts/configstoredemo/values.yaml
+++ b/examples/ConfigStoreDemo/Charts/configstoredemo/values.yaml
@@ -1,0 +1,3 @@
+imageRegistry:
+registryUsername:
+registryPassword:

--- a/examples/ConfigStoreDemo/Dockerfile
+++ b/examples/ConfigStoreDemo/Dockerfile
@@ -1,0 +1,6 @@
+FROM microsoft/aspnetcore:2.0
+WORKDIR /app
+EXPOSE 80
+ENV ASPNETCORE_URLS=http://*:80
+COPY ["bin/PublishOut", "."]
+ENTRYPOINT ["dotnet", "ConfigStoreDemo.dll"]

--- a/examples/ConfigStoreDemo/Startup.cs
+++ b/examples/ConfigStoreDemo/Startup.cs
@@ -10,15 +10,23 @@ namespace ConfigStoreDemo
     {
         public Startup(IConfiguration configuration)
         {
-            // load configurations from local json file and remote config store.
-            // load all key-values with null label and listen one key.
-            // Pull configuration connection string from environment variable
+            //
+            // load configuration from local json file and environment variables.
             var builder = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
-                .AddRemoteAppConfiguration(o => {
-                    o.Connect(configuration["connection_string"])
-                     .Watch("Settings:BackgroundColor", 1000);
-                });
+                .AddEnvironmentVariables();
+
+            var config = builder.Build();
+
+            //
+            // Add remote configuration using intermediate configuration
+            // load all key-values with null label and listen to one key.
+            builder.AddRemoteAppConfiguration(o => {
+
+                o.Connect(configuration["ConfigurationStore__ConnectionString"])
+                    .Watch("Settings__BackgroundColor", 1000);
+            });
+
             Configuration = builder.Build();
         }
 


### PR DESCRIPTION
The ConfigStoreDemo project is used to demo the provider's integration into .NET Core. This PR adds helm deployment templates for this project so that we can demonstrate it as it runs containerized within Kubernetes.