### PR TITLE
Added suffix only for pre-release builds.

### DIFF
--- a/build/NugetProperties.props
+++ b/build/NugetProperties.props
@@ -1,7 +1,9 @@
 <Project>
   <PropertyGroup>
     <Version Condition="'$(CDP_PATCH_NUMBER)'==''">1.9.9999</Version>
-    <Version Condition="'$(CDP_PATCH_NUMBER)'!=''">1.0.0-preview-$(CDP_PATCH_NUMBER)</Version>
+    <Version Condition="'$(CDP_PATCH_NUMBER)'!=''">1.0.0-preview</Version>
+    <!-- Add suffix for pre-release builds -->
+    <Version Condition="'$(CDP_BUILD_TYPE)'!='Official'">$(Version)-$(CDP_PATCH_NUMBER)</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <RepositoryUrl>https://github.com/Azure/Azconfig-DotnetProvider</RepositoryUrl>


### PR DESCRIPTION
This PR will allow us to release as 1.0.0-preview instead of 1.0.0-preview-007830001. Both are fine, but it might make more sense to keep the incrementing build number off of our package version.