### PR TITLE
Update exception handling to take into account TaskCanceledException.

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzconfigClientExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzconfigClientExtensions.cs
@@ -225,6 +225,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 || ex is HttpRequestException
                 || ex is SocketException
                 || ex is TimeoutException
+                || ex is OperationCanceledException
                 || ex is AzconfigException)
             {
                 return true;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -128,6 +128,7 @@
                 }
             }
             catch (Exception exception) when (exception.InnerException is HttpRequestException ||
+                                              exception.InnerException is OperationCanceledException ||
                                               exception.InnerException is UnauthorizedAccessException)
             {
                 if (_options.OfflineCache != null)


### PR DESCRIPTION
Update exception handling to take into account TaskCanceledException which can occur due to a network timeout. This is necessary for offline file cache and for the _safe-observable_ fix.