### PR TITLE
Added a way to label-based filtering for feature management.

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -172,9 +172,10 @@
         /// Enables Azure App Configuration feature flags to be parsed and transformed into feature management configuration.
         /// </summary>
         /// <param name="configure">A callback used to configure feature flag options.</param>
-        public AzureAppConfigurationOptions UseFeatureFlags(Action<FeatureFlagOptions> configure = null)
+        /// <param name="label">Label to filter.</param>
+        public AzureAppConfigurationOptions UseFeatureFlags(Action<FeatureFlagOptions> configure = null, string label = LabelFilter.Null)
         {
-            FeatureFlagOptions options = new FeatureFlagOptions();
+            FeatureFlagOptions options = new FeatureFlagOptions() { Label = label };
 
             configure?.Invoke(options);
 

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -224,5 +224,37 @@ namespace Tests.AzureAppConfiguration
                 Assert.True(queriedFeatureFlags);
             }
         }
+
+        [Fact]
+        public void UsesFeatureFlagsWithLabel()
+        {
+            var testLabel = "TestLabel";
+            _kv.Label = testLabel;
+            IEnumerable<IKeyValue> featureFlags = new List<IKeyValue> { _kv };
+
+            using (var testClient = new AzconfigClient(TestHelpers.CreateMockEndpointString(), new MockedGetKeyValueRequest(_kv, featureFlags)))
+            {
+                var builder = new ConfigurationBuilder();
+
+                var options = new AzureAppConfigurationOptions()
+                {
+                    Client = testClient
+                };
+
+                options.UseFeatureFlags(label: testLabel);
+
+                builder.AddAzureAppConfiguration(options);
+
+                var config = builder.Build();
+
+                Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
+                Assert.Equal("Firefox", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
+                Assert.Equal("Safari", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
+                Assert.Equal("RollOut", config["FeatureManagement:Beta:EnabledFor:1:Name"]);
+                Assert.Equal("20", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Percentage"]);
+                Assert.Equal("US", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Region"]);
+                Assert.Equal("SuperUsers", config["FeatureManagement:Beta:EnabledFor:2:Name"]);
+            }
+        }
     }
 }


### PR DESCRIPTION
Feature flags are stored internally as regular App Config key-values, with specific values for ContentType, Value, and Key-Prefix. To fully use labels with Feature flags, we would need to allow filtering with those labels.