### PR TITLE
Decoupled the App Configuration ASP.NET Core package from Microsoft.FeatureManagement

### DIFF
--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
@@ -17,6 +17,5 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="2.0.0-preview-009470001-1371" />
-    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="1.0.0-preview-008560001-910" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Microsoft.FeatureManagement was originally bundled into the Azure App Configuration ASP.NET Core package for ease of reference. This would remove the need to add a reference to Microsoft.FeatureManagement for those wishing to use feature management. It was reasonable because the Azure App Configuration Provider provides feature flag configuration.

This approach brought two problems:
1. Unnecessary references to ASP.NET Core MVC packages like `TagHelpers` for those who just wanted to use the refresh middleware.
2. A dependency on the `Microsoft.FeatureManagement` **preview** package. The problem here is that the Azure App Configuration provider stable release is not necessarily tied to the Microsoft.FeatureManagement release. This means that the provider **cannot** depend on the feature management package.

