### PR TITLE
Add a delay on unhandled failure in initial load to slow down crash loops

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -60,9 +60,6 @@
 
         /// <summary>
         /// Loads (or reloads) the data for this provider.
-        /// This method is normally called in the application's startup code path.
-        /// Unhandled exceptions cause application crash which can result in crash loops as orchestrators attempt to restart the application.
-        /// Knowing the intended usage of the provider in startup code path, we mitigate back-to-back crash loops from overloading the server with requests by waiting a minimum time to propogate fatal errors.
         /// </summary>
         public override void Load()
         {
@@ -81,6 +78,10 @@
             }
             catch
             {
+                // AzureAppConfigurationProvider.Load() method is called in the application's startup code path.
+                // Unhandled exceptions cause application crash which can result in crash loops as orchestrators attempt to restart the application.
+                // Knowing the intended usage of the provider in startup code path, we mitigate back-to-back crash loops from overloading the server with requests by waiting a minimum time to propogate fatal errors.
+
                 var waitTime = MinDelayForUnhandledFailure.Subtract(watch.Elapsed);
 
                 if (waitTime.Ticks > 0)


### PR DESCRIPTION
An unhandled exception encountered during the initial configuration load in the provider can cause an Azure function or web application to crash. In such a case, it is possible that the application is restarted repeatedly if the error persists and result in a large number of calls made to the server. This change adds a delay in throwing an exception that is likely to cause the app to fail in order to slow down any further attempts of re-loading the application.