### PR TITLE
Add package source for official SDK

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <add key="azure-sdk-for-net" value="https://azuresdkartifacts.blob.core.windows.net/azure-sdk-for-net/index.json" />
     <add key="Dev" value="https://msazure.pkgs.visualstudio.com/_packaging/Dev/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
Add package source for official SDK as requested by Anne from Azure SDK Team
Validated that the build pipeline is able to load the service index for the newly added package source