### PR TITLE
Update build image to add support for C# 8.0

### DIFF
--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -3,7 +3,7 @@ environment:
     os: windows
   runtime:
     provider: appcontainer
-    image: cdpxwin.azurecr.io/global/vse2017u5-external-azsdk-ext-win14393.1884:4.2
+    image: cdpxwinrs5test.azurecr.io/global/vse2019/u3/vse2019u3-winltsc2019
   
 restore:
   commands:


### PR DESCRIPTION
This change fixes the current broken build for configuration provider that uses C# 8.0 features. The new Windows image has Visual Studio 2019 and .NET SDK 3.0 installed.