### PR TITLE
Improve exception handling for manual refresh

### DIFF
--- a/examples/ConsoleApplication/Program.cs
+++ b/examples/ConsoleApplication/Program.cs
@@ -1,12 +1,10 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Examples.ConsoleApplication
-{
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.Configuration.AzureAppConfiguration;
-    using System;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
+﻿using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Examples.ConsoleApplication
+{
     class Program
     {
         static IConfiguration Configuration { get; set; }
@@ -70,8 +68,14 @@
 
             while (!token.IsCancellationRequested)
             {
-                // Trigger an async refresh for registered configuration settings without wait
-                _ = _refresher.Refresh();
+                try
+                {
+                    await _refresher.Refresh();
+                }
+                catch (Exception e) when (e is UnauthorizedAccessException || e is InvalidOperationException || e is RefreshFailedException)
+                {
+                    sb.AppendLine(e.ToString());
+                }
 
                 sb.AppendLine($"{Configuration["AppName"]} has been configured to run in {Configuration["Language"]}");
                 sb.AppendLine();

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Exceptions/RefreshFailedException.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Exceptions/RefreshFailedException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+{
+    /// <summary>
+    /// An exception thrown when configuration refresh fails.
+    /// </summary>
+    public class RefreshFailedException : Exception
+    {
+        /// <summary>Initializes a new instance of the <see cref="RefreshFailedException"></see> class with a specified error message and a reference to the inner exception that is the cause of this exception.</summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        public RefreshFailedException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
@@ -10,6 +11,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// Refreshes the data from the configuration store asynchronously.
         /// </summary>
+        /// <exception cref="UnauthorizedAccessException">The caller is not authorized to perform this operation.</exception>
+        /// <exception cref="InvalidOperationException">The initial configuration is not loaded or the caller does not have the required permission to perform this operation.</exception>
+        /// <exception cref="RefreshFailedException">The refresh operation failed.</exception>
         Task Refresh();
     }
 }


### PR DESCRIPTION
This change defines a public contract for the exceptions that can be thrown during the Refresh operation. This will allow users to handle the known exceptions appropriately instead of catching all exceptions or crashing the application in case of an error during refresh operation.