### PR TITLE
Add missing configure await in LoadAll method

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 }
 
                 // Block current thread for the initial load of key-values registered for refresh that are not already loaded
-                await Task.Run(() => LoadKeyValuesRegisteredForRefresh(data).ConfigureAwait(false).GetAwaiter().GetResult());
+                await Task.Run(() => LoadKeyValuesRegisteredForRefresh(data).ConfigureAwait(false).GetAwaiter().GetResult()).ConfigureAwait(false);
             }
             catch (Exception exception) when (exception.InnerException is RequestFailedException ||
                                               exception.InnerException is HttpRequestException ||


### PR DESCRIPTION
I used the [ConfigureAwaitEnforcer](https://marketplace.visualstudio.com/items?itemName=Rene-Stein.ConfigureAwaitEnforcer) extension for Visual Studio, as suggested by Jimmy, to find missing `ConfigureAwait(false)`. This change adds it for one missing instance found using the tool.