### PR TITLE
Update max retry count for calls to AppConfig SDK

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         private bool _isInitialLoadComplete = false;
         private readonly bool _requestTracingEnabled;
 
-        private const int MaxRetries = 12;
+        private const int MaxRetries = 2;
         private const int RetryWaitMinutes = 1;
 
         private readonly HostType _hostType;


### PR DESCRIPTION
This change reduces the maximum number of retries for each SDK call from 12 to 2, resulting in at most 3 attempts for each call. This would help limit the maximum time that the users need to wait before the receive the error messages in case of failures on initial app startup. In future, users will also have the option to override this value using `ConfigurationClientOptions`.