### PR TITLE
Added license header to all files.

### DIFF
--- a/Microsoft.Extensions.Configuration.AzureAppConfiguration.sln.licenseheader
+++ b/Microsoft.Extensions.Configuration.AzureAppConfiguration.sln.licenseheader
@@ -1,0 +1,4 @@
+﻿extensions: .cs
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//

--- a/examples/ConfigStoreDemo/Pages/About.cshtml.cs
+++ b/examples/ConfigStoreDemo/Pages/About.cshtml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/examples/ConfigStoreDemo/Pages/Contact.cshtml.cs
+++ b/examples/ConfigStoreDemo/Pages/Contact.cshtml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/examples/ConfigStoreDemo/Pages/Error.cshtml.cs
+++ b/examples/ConfigStoreDemo/Pages/Error.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/examples/ConfigStoreDemo/Pages/Index.cshtml.cs
+++ b/examples/ConfigStoreDemo/Pages/Index.cshtml.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Examples.ConfigStoreDemo.Pages
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Examples.ConfigStoreDemo.Pages
 {
     using Microsoft.AspNetCore.Mvc.RazorPages;
     using Microsoft.Extensions.Options;

--- a/examples/ConfigStoreDemo/Program.cs
+++ b/examples/ConfigStoreDemo/Program.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using System;
 

--- a/examples/ConfigStoreDemo/Settings.cs
+++ b/examples/ConfigStoreDemo/Settings.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Examples.ConfigStoreDemo
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Examples.ConfigStoreDemo
 {
     public class Settings
     {

--- a/examples/ConfigStoreDemo/Startup.cs
+++ b/examples/ConfigStoreDemo/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;

--- a/examples/ConsoleApplication/Program.cs
+++ b/examples/ConsoleApplication/Program.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Examples.ConsoleApplication
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Examples.ConsoleApplication
 {
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Configuration.AzureAppConfiguration;

--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Runtime.CompilerServices;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System.Runtime.CompilerServices;
 
 // Tests
 [assembly: InternalsVisibleTo("Tests.AzureAppConfiguration,PublicKey=" +

--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/AzureAppConfigurationRefreshExtensions.cs
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/AzureAppConfigurationRefreshExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Azure.AppConfiguration.AspNetCore;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.Azure.AppConfiguration.AspNetCore;
 
 namespace Microsoft.AspNetCore.Builder
 {

--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/AzureAppConfigurationRefreshMiddleware.cs
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/AzureAppConfigurationRefreshMiddleware.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using System;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AssemblyInfo.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Runtime.CompilerServices;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System.Runtime.CompilerServices;
 
 // Tests
 [assembly: InternalsVisibleTo("Tests.AzureAppConfiguration,PublicKey=" +

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using System;
 
 namespace Microsoft.Extensions.Configuration

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationKeyVaultOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationKeyVaultOptions.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Core;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Core;
 using Azure.Security.KeyVault.Secrets;
 using System.Collections.Generic;
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Core;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Core;
 using Azure.Data.AppConfiguration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -1,4 +1,7 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure;
 using Azure.Core;
 using Azure.Data.AppConfiguration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.Constants;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefreshOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefreshOptions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Configuration.AzureAppConfiguration.Constants;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.Extensions.Configuration.AzureAppConfiguration.Constants;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.Models;
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationSource.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationSource.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Data.AppConfiguration;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Data.AppConfiguration;
 using System;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
@@ -1,4 +1,7 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure;
 using Azure.Data.AppConfiguration;
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultSecretProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultSecretProvider.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Core;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Core;
 using Azure.Security.KeyVault.Secrets;
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/KeyVaultConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/KeyVaultConstants.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
 {
     internal class KeyVaultConstants
     {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/KeyVaultSecretReference.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/KeyVaultSecretReference.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.Json.Serialization;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/ConfigurationClientFactory.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/ConfigurationClientFactory.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Core;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Core;
 using Azure.Data.AppConfiguration;
 using System;
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/ConnectionStringParser.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/ConnectionStringParser.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/ErrorMessages.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/ErrorMessages.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Constants
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Constants
 {
     internal class ErrorMessages
     {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Constants
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Constants
 {
     internal class RequestTracingConstants
     {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/CryptoService.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/CryptoService.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/EmptyConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/EmptyConfigurationProvider.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     class EmptyConfigurationProvider : ConfigurationProvider
     {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Exceptions/KeyVaultReferenceException.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Exceptions/KeyVaultReferenceException.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure;
 using Azure.Data.AppConfiguration;
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/StringExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/StringExtensions.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
 {
     internal static class LabelFilters
     {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/Utf8JsonReaderExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/Utf8JsonReaderExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.Json;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System.Text.Json;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/ClientFilter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/ClientFilter.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.Json;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureConditions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureConditions.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlag.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlag.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.Json.Serialization;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
     internal class FeatureManagementConstants
     {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Data.AppConfiguration;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Data.AppConfiguration;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/JsonFlattener.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/JsonFlattener.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/GetKeyValueChangeCollectionOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/GetKeyValueChangeCollectionOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     internal class GetKeyValueChangeCollectionOptions
     {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/HostType.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/HostType.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     internal enum HostType

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationClientFactory.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationClientFactory.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Core;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Core;
 using Azure.Data.AppConfiguration;
 using System;
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -1,4 +1,7 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure;
 using System;
 using System.Threading.Tasks;
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Data.AppConfiguration;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Data.AppConfiguration;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IOfflineCache.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IOfflineCache.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     /// <summary>
     /// Defines the necessary interface to perform offline caching of Azure App Configuration data.

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/KeyFilter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/KeyFilter.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     /// <summary>
     /// Defines well known key filters that are used within Azure App Configuration.

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/KeyValueChange.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/KeyValueChange.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Data.AppConfiguration;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Data.AppConfiguration;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/LabelFilter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/LabelFilter.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     /// <summary>
     /// Defines well known label filters that are used within Azure App Configuration.

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueSelector.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueSelector.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
 {
     /// <summary>
     /// A selector used to control what key-values are retrieved from Azure App Configuration.

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.Threading;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/OfflineFileCache.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/OfflineFileCache.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions;
 using System;
 using System.IO;
 using System.Linq;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/OfflineFileCacheOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/OfflineFileCacheOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     /// <summary>
     /// Options for controlling the behavior of an <see cref="OfflineFileCache"/>.

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/RequestType.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/RequestType.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     /// <summary>
     /// Types of read requests.

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Configuration.AzureAppConfiguration.Constants;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.Extensions.Configuration.AzureAppConfiguration.Constants;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/UserAgentHeaderPolicy.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/UserAgentHeaderPolicy.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Core;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Core;
 using Azure.Core.Pipeline;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.Constants;
 using System;

--- a/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/AsyncGate.cs
+++ b/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/AsyncGate.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.Threading.Tasks;
 
 namespace Azure.Core.Testing

--- a/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/AsyncValidatingStream.cs
+++ b/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/AsyncValidatingStream.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/MockRequest.cs
+++ b/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/MockRequest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/MockResponse.cs
+++ b/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/MockResponse.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/MockTransport.cs
+++ b/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/MockTransport.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Core.Pipeline;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Core.Pipeline;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/TaskExtensions.cs
+++ b/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/TaskExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/tests/Tests.AzureAppConfiguration/Azure.Data.AppConfiguration.Testing/ArrayBufferWriter.cs
+++ b/tests/Tests.AzureAppConfiguration/Azure.Data.AppConfiguration.Testing/ArrayBufferWriter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.Buffers;
 using System.Diagnostics;
 

--- a/tests/Tests.AzureAppConfiguration/Azure.Data.AppConfiguration.Testing/SerializationHelpers.cs
+++ b/tests/Tests.AzureAppConfiguration/Azure.Data.AppConfiguration.Testing/SerializationHelpers.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Core;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Core;
 using System.Text.Json;
 
 namespace Azure.Data.AppConfiguration.Tests

--- a/tests/Tests.AzureAppConfiguration/CallbackMessageHandler.cs
+++ b/tests/Tests.AzureAppConfiguration/CallbackMessageHandler.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;

--- a/tests/Tests.AzureAppConfiguration/ConnectTests.cs
+++ b/tests/Tests.AzureAppConfiguration/ConnectTests.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Core;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Core;
 using Azure.Data.AppConfiguration;
 using Microsoft.Extensions.Configuration;
 using Moq;

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -1,4 +1,7 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure;
 using Azure.Core.Testing;
 using Azure.Data.AppConfiguration;
 using Azure.Data.AppConfiguration.Tests;

--- a/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
@@ -1,4 +1,7 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure;
 using Azure.Core.Testing;
 using Azure.Data.AppConfiguration;
 using Azure.Identity;

--- a/tests/Tests.AzureAppConfiguration/MockedConfigurationClientFactory.cs
+++ b/tests/Tests.AzureAppConfiguration/MockedConfigurationClientFactory.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Core;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Core;
 using Azure.Data.AppConfiguration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Moq;

--- a/tests/Tests.AzureAppConfiguration/OfflineCacheTests.cs
+++ b/tests/Tests.AzureAppConfiguration/OfflineCacheTests.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Data.AppConfiguration;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure.Data.AppConfiguration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using System;
 using System.Collections.Generic;

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -1,4 +1,7 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure;
 using Azure.Core.Testing;
 using Azure.Data.AppConfiguration;
 using Microsoft.AspNetCore.Http;

--- a/tests/Tests.AzureAppConfiguration/TestHelper.cs
+++ b/tests/Tests.AzureAppConfiguration/TestHelper.cs
@@ -1,4 +1,7 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure;
 using Azure.Data.AppConfiguration;
 using Moq;
 using System;

--- a/tests/Tests.AzureAppConfiguration/Tests.cs
+++ b/tests/Tests.AzureAppConfiguration/Tests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
 using Azure;
 using Azure.Core;
 using Azure.Core.Testing;


### PR DESCRIPTION
This PR adds required license headers to all .cs files. 

This PR also adds the Microsoft.Extensions.Configuration.AzureAppConfiguration.sln.licenseheader file which is used by the [License Header Manager](https://marketplace.visualstudio.com/items?itemName=StefanWenig.LicenseHeaderManager) Visual Studio extension to populate license header files.