### PR TITLE
Remove preview tag from package version

### DIFF
--- a/build/NugetProperties.props
+++ b/build/NugetProperties.props
@@ -14,7 +14,11 @@
     <Version>3.9.9999</Version>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!=''">
+  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'=='Official'">
+    <Version>3.0.0</Version>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'!='Official'">
     <!-- Note that CDP_PACKAGE_VERSION_NUMERIC uses format Major.Minor.MMddyyrrrr, which causes compile error CS7034 because .NET Core doesn't allow version numbers higher than 65534. -->
     <!-- CDP_PATCH_NUMBER is updated daily by the build system, the addition of a revision number makes the build number unique by the minute -->
     <!-- The revision number is the number of minutes since midnight [0, 1440) -->
@@ -26,5 +30,7 @@
     <Floored>$([System.Math]::Floor($(MinutesSinceMidnight)))</Floored>
     <Revision>$(Floored)</Revision>
     <Version>3.0.0-$(CDP_PATCH_NUMBER)-$(Revision)</Version>
+  </PropertyGroup>
+
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This pull request removes the "preview" substring from the auto-generated package version for the configuration provider to prepare for release of the first stable version of the configuration provider.