### PR TITLE
Fix NugetProperties.props

### DIFF
--- a/build/NugetProperties.props
+++ b/build/NugetProperties.props
@@ -31,6 +31,4 @@
     <Revision>$(Floored)</Revision>
     <Version>3.0.0-$(CDP_PATCH_NUMBER)-$(Revision)</Version>
   </PropertyGroup>
-
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Remove unmatched `PropertyGroup` tag from NugetProperties.props