### PR TITLE
Fix optional parameter for AddAzureAppConfiguration

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -177,9 +177,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 // Block current thread for the initial load of key-values registered for refresh that are not already loaded
                 await Task.Run(() => LoadKeyValuesRegisteredForRefresh(data).ConfigureAwait(false).GetAwaiter().GetResult()).ConfigureAwait(false);
             }
-            catch (Exception exception) when (exception.InnerException is RequestFailedException ||
-                                              exception.InnerException is HttpRequestException ||
-                                              exception.InnerException is OperationCanceledException)
+            catch (Exception exception) when (exception is KeyVaultReferenceException ||
+                                              exception is RequestFailedException ||
+                                              ((exception as AggregateException)?.InnerExceptions?.All(e => e is RequestFailedException) ?? false) ||
+                                              exception is OperationCanceledException)
             {
                 if (_options.OfflineCache != null)
                 {

--- a/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
@@ -344,5 +344,20 @@ namespace Tests.AzureAppConfiguration
                 .Build();
             });
         }
+
+        [Fact]
+        public void DoesNotThrowKeyVaultExceptionWhenProviderIsOptional()
+        {
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, TestHelpers.CreateMockEndpointString());
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Throws(new KeyVaultReferenceException("Key vault error", null));
+
+            new ConfigurationBuilder()
+            .AddAzureAppConfiguration(options =>
+            {
+                options.Client = mockClient.Object;
+            }, optional: true)
+            .Build();
+        }
     }
 }


### PR DESCRIPTION
Currently, calling `AddAzureAppConfiguration` with `optional:true` does not work. It still throws any exception thrown for failures in the initial load. This pull request contains the code change to fix that bug and adds a unit test to validate it.