### PR TITLE
Fix bug that causes feature flag refresh even when there is no change

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                 {
                     await foreach(ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector).ConfigureAwait(false))
                     {
-                        if (!eTagMap.TryGetValue(setting.Key, out string etag) || !etag.Equals(setting.ETag))
+                        if (!eTagMap.TryGetValue(setting.Key, out string etag) || !setting.ETag.Equals(etag))
                         {
                             hasKeyValueCollectionChanged = true;
                             break;
@@ -152,7 +152,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                     {
                         await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector).ConfigureAwait(false))
                         {
-                            if (!eTagMap.TryGetValue(setting.Key, out string etag) || !etag.Equals(setting.ETag))
+                            if (!eTagMap.TryGetValue(setting.Key, out string etag) || !setting.ETag.Equals(etag))
                             {
                                 changes.Add(new KeyValueChange
                                 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
             };
 
             // Dictionary of eTags that we write to and use for comparison
-            var eTagMap = keyValues.ToDictionary(kv => kv.Key, kv => kv.ETag.ToString());
+            var eTagMap = keyValues.ToDictionary(kv => kv.Key, kv => kv.ETag);
 
             // Fetch e-tags for prefixed key-values that can be used to detect changes
             await TracingUtils.CallWithRequestTracing(options.RequestTracingEnabled, RequestType.Watch, options.HostType,
@@ -119,7 +119,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                 {
                     await foreach(ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector).ConfigureAwait(false))
                     {
-                        if (!eTagMap.TryGetValue(setting.Key, out string etag) || !setting.ETag.Equals(etag))
+                        if (!eTagMap.TryGetValue(setting.Key, out ETag etag) || !etag.Equals(setting.ETag))
                         {
                             hasKeyValueCollectionChanged = true;
                             break;
@@ -146,13 +146,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                     LabelFilter = string.IsNullOrEmpty(options.Label) ? LabelFilter.Null : options.Label
                 };
 
-                eTagMap = keyValues.ToDictionary(kv => kv.Key, kv => kv.ETag.ToString());
+                eTagMap = keyValues.ToDictionary(kv => kv.Key, kv => kv.ETag);
                 await TracingUtils.CallWithRequestTracing(options.RequestTracingEnabled, RequestType.Watch, options.HostType,
                     async () =>
                     {
                         await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector).ConfigureAwait(false))
                         {
-                            if (!eTagMap.TryGetValue(setting.Key, out string etag) || !setting.ETag.Equals(etag))
+                            if (!eTagMap.TryGetValue(setting.Key, out ETag etag) || !etag.Equals(setting.ETag))
                             {
                                 changes.Add(new KeyValueChange
                                 {

--- a/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
@@ -284,7 +284,7 @@ namespace Tests.AzureAppConfiguration
             mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
                 .Returns(new MockAsyncPageable(new List<ConfigurationSetting> { _kv }));
 
-            Assert.Throws<AuthenticationFailedException>(() =>
+            KeyVaultReferenceException ex = Assert.Throws<KeyVaultReferenceException>(() =>
             {
                 new ConfigurationBuilder().AddAzureAppConfiguration(options =>
                 {
@@ -293,6 +293,8 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
             });
+
+            Assert.IsType<RequestFailedException>(ex.InnerException);
         }
 
         [Fact]

--- a/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
@@ -284,7 +284,7 @@ namespace Tests.AzureAppConfiguration
             mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
                 .Returns(new MockAsyncPageable(new List<ConfigurationSetting> { _kv }));
 
-            KeyVaultReferenceException ex = Assert.Throws<KeyVaultReferenceException>(() =>
+            Assert.Throws<AuthenticationFailedException>(() =>
             {
                 new ConfigurationBuilder().AddAzureAppConfiguration(options =>
                 {
@@ -293,8 +293,6 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
             });
-
-            Assert.IsType<RequestFailedException>(ex.InnerException);
         }
 
         [Fact]


### PR DESCRIPTION
When a refresh operation is invoked for feature flags, the etags for the feature flags are fetched first. In case there is a change in the etag for any of the key-values, a call to fetch all the feature flags along with values is made to the configuration store. The current logic has a bug that causes the call to fetch all feature flags along with values to be made to the configuration store even when the etag hasn't changed for any of the key-values. This bug was introduced starting version `2.1.0-preview-010380001-1099` with the change to migrate to the `Azure.Data.AppConfiguration` SDK.

This pull request fixes the bug and would significantly reduce the volume of calls made to App Configuration when refresh operation is invoked for feature flags.