### PR TITLE
Update TryRefreshAsync to return false for exceptions from Azure.Identity

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 e is RequestFailedException ||
                 ((e as AggregateException)?.InnerExceptions?.All(e => e is RequestFailedException) ?? false) ||
                 e is OperationCanceledException ||
-                e.Source.Equals(AzureIdentityExceptionSource, StringComparison.OrdinalIgnoreCase))
+                (e.Source?.Equals(AzureIdentityExceptionSource, StringComparison.OrdinalIgnoreCase) ?? false))
             {
                 return false;
             }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         private AzureAppConfigurationOptions _options;
         private ConcurrentDictionary<string, ConfigurationSetting> _settings;
 
+        private const string AzureIdentityExceptionSource = "Azure.Identity";
         private static readonly TimeSpan MinDelayForUnhandledFailure = TimeSpan.FromSeconds(5);
 
         public AzureAppConfigurationProvider(ConfigurationClient client, AzureAppConfigurationOptions options, bool optional)
@@ -111,7 +112,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 e is KeyVaultReferenceException ||
                 e is RequestFailedException ||
                 ((e as AggregateException)?.InnerExceptions?.All(e => e is RequestFailedException) ?? false) ||
-                e is OperationCanceledException)
+                e is OperationCanceledException ||
+                e.Source.Equals(AzureIdentityExceptionSource, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }

--- a/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
@@ -284,7 +284,7 @@ namespace Tests.AzureAppConfiguration
             mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
                 .Returns(new MockAsyncPageable(new List<ConfigurationSetting> { _kv }));
 
-            KeyVaultReferenceException ex = Assert.Throws<KeyVaultReferenceException>(() =>
+            Assert.Throws<AuthenticationFailedException>(() =>
             {
                 new ConfigurationBuilder().AddAzureAppConfiguration(options =>
                 {
@@ -293,8 +293,6 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
             });
-
-            Assert.IsType<RequestFailedException>(ex.InnerException);
         }
 
         [Fact]


### PR DESCRIPTION
The package `Azure.Identity` throws `Azure.Identity.AuthenticationFailedException` when it fails to use a `TokenCredential`. For example, when `new DefaultAzureCredentials()` is used to connect to Azure App Configuration but no valid identity could be found, then it throws `AuthenticationFailedException`. This pull request updates `TryRefreshAsync` to handle all exceptions from `Azure.Identity` package without adding an explicit dependency, so the method returns false as the result.