### PR TITLE
Update user agent to use product version instead of assembly version

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -23,14 +22,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public static string GenerateUserAgent(string currentUserAgent = null)
         {
             Assembly assembly = typeof(AzureAppConfigurationOptions).Assembly;
-            var userAgent = new StringBuilder($"{assembly.GetName().Name}/{assembly.GetName().Version}");
+            string informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            var userAgent = new StringBuilder($"{assembly.GetName().Name}/{informationalVersion}");
 
-            //
-            // If currentUserAgent is not null, prepend current assembly name and version to it,
-            // and return without any further processing.
+            // If currentUserAgent is not null, prepend current assembly name and version to it, and return without any further processing.
             if (!string.IsNullOrWhiteSpace(currentUserAgent))
             {
-                 return $"{userAgent.ToString()} {currentUserAgent}";
+                return $"{userAgent.ToString()} {currentUserAgent}";
             }
 
             IEnumerable<TargetFrameworkAttribute> targetFrameworkAttributes = assembly.GetCustomAttributes(true)?.OfType<TargetFrameworkAttribute>();

--- a/tests/Tests.AzureAppConfiguration/Tests.cs
+++ b/tests/Tests.AzureAppConfiguration/Tests.cs
@@ -208,6 +208,10 @@ namespace Tests.AzureAppConfiguration
             MockRequest request = mockTransport.SingleRequest;
 
             string appUserAgent = TracingUtils.GenerateUserAgent("SdkUserAgent");
+
+            // Validate the user agent has information version (3.9.9999) instead of assembly version (3.9.9999.0)
+            Assert.Equal("Microsoft.Extensions.Configuration.AzureAppConfiguration/3.9.9999 SdkUserAgent", appUserAgent);
+
             appUserAgent = appUserAgent.Replace("SdkUserAgent", "");
             Assert.True(request.Headers.TryGetValue("User-Agent", out string userAgentHeader));
             Assert.Contains(appUserAgent, userAgentHeader);

--- a/tests/Tests.AzureAppConfiguration/Tests.cs
+++ b/tests/Tests.AzureAppConfiguration/Tests.cs
@@ -209,8 +209,11 @@ namespace Tests.AzureAppConfiguration
 
             string appUserAgent = TracingUtils.GenerateUserAgent("SdkUserAgent");
 
-            // Validate the user agent has information version (3.9.9999) instead of assembly version (3.9.9999.0)
-            Assert.Equal("Microsoft.Extensions.Configuration.AzureAppConfiguration/3.9.9999 SdkUserAgent", appUserAgent);
+            // Validate the user agent format corresponds to informational version instead of assembly version
+            // Informational version examples : 3.0.0 or 2.1.0-preview-010380001-1099
+            // Assembly version examples : 3.0.0.0 or 2.1.0.0
+            var nugetPackageVersionRegex = @"\d+\.\d+\.\d+(-preview-\d+-\d+)?";
+            Assert.Matches($@"Microsoft\.Extensions\.Configuration\.AzureAppConfiguration/{nugetPackageVersionRegex} SdkUserAgent", appUserAgent);
 
             appUserAgent = appUserAgent.Replace("SdkUserAgent", "");
             Assert.True(request.Headers.TryGetValue("User-Agent", out string userAgentHeader));


### PR DESCRIPTION
This pull request updates the user agent string to include the package version (informational version) instead of the assembly version. Check out [this blog](https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/) for more details on the different versions in .NET.