### PR TITLE
Limit user agent header policy to be executed once per call to SDK

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             clientOptions.Retry.MaxRetries = MaxRetries;
             clientOptions.Retry.MaxDelay = MaxRetryDelay;
             clientOptions.Retry.Mode = RetryMode.Exponential;
-            clientOptions.AddPolicy(new UserAgentHeaderPolicy(), HttpPipelinePosition.PerRetry);
+            clientOptions.AddPolicy(new UserAgentHeaderPolicy(), HttpPipelinePosition.PerCall);
 
             return clientOptions;
         }


### PR DESCRIPTION
This pull requests contains changes to fix the following bug in the configuration provider.

**Problem**
The user agent string that is logged for calls made to App Configuration using the .NET Core configuration provider could contain the package name and version multiple times. This behavior can be noticed for around 0.5% of the total requests. This makes it harder to group these requests for analysis.

**Example 1**
`Microsoft.Extensions.Configuration.AzureAppConfiguration/2.1.0.0 Microsoft.Extensions.Configuration.AzureAppConfiguration/2.1.0.0 azsdk-net-Data.AppConfiguration/1.0.0-preview.4,(.NET Framework 4.7.3468.0; Microsoft Windows 10.0.17134 )`

**Example 2**
`Microsoft.Extensions.Configuration.AzureAppConfiguration/2.1.0.0 Microsoft.Extensions.Configuration.AzureAppConfiguration/2.1.0.0 Microsoft.Extensions.Configuration.AzureAppConfiguration/2.1.0.0 azsdk-net-Data.AppConfiguration/1.0.0-preview.4,(.NET Framework 4.7.3468.0; Microsoft Windows 10.0.17134 )`

**Observations**
1. Based on analysis of the logs with such unexpected values of user agent, the issue seems to be limited to calls that are made by the SDK as a part of retry mechanism when the initial call to the server fails with a retriable error.
2. The issue is limited to version `2.1.0-preview-010380001-1099` and higher of the configuration provider, which include changes to migrate to the `Azure.Data.AppConfiguration` SDK.

**Root Cause**
A further analysis of the code revealed that we process the user agent header policy once per retry attempt instead of once per call. This causes the name and version of the provider package to be prepended to the header from the previous attempt for each successive retry attempt, leading to this issue.