### PR TITLE
Update refresh to use SetCacheExpiration time to recover from initial load failures

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -89,6 +89,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         internal ConfigurationClientOptions ClientOptions { get; } = GetDefaultClientOptions();
 
         /// <summary>
+        /// Cache expiration time for refresh when no settings were registered for refresh and initial configuration failed to load.
+        /// </summary>
+        internal TimeSpan RefreshCacheExpirationTime { get; private set; } = AzureAppConfigurationRefreshOptions.DefaultCacheExpirationTime;
+
+        /// <summary>
         /// Specify what key-values to include in the configuration provider.
         /// <see cref="Select"/> can be called multiple times to include multiple sets of key-values.
         /// </summary>
@@ -255,6 +260,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         {
             var refreshOptions = new AzureAppConfigurationRefreshOptions();
             configure?.Invoke(refreshOptions);
+            RefreshCacheExpirationTime = refreshOptions.CacheExpirationTime;
 
             foreach (var item in refreshOptions.RefreshRegistrations)
             {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
             else
             {
-                MinCacheExpirationTime = AzureAppConfigurationRefreshOptions.DefaultCacheExpirationTime;
+                MinCacheExpirationTime = options.RefreshCacheExpirationTime;
             }
 
             // Enable request tracing if not opt-out


### PR DESCRIPTION
The `RefreshAsync` and `TryRefreshAsync` methods were updated to be able to detect a failure and re-attempt to load the initial settings from App Configuration. It is possible to leverage this feature even when there are no settings registered for refresh. In this case, the current behavior is to use a default cache expiration time of 30 seconds for auto-recovery of the initial configuration load.

In such cases, if a custom value of the cache expiration time has been specified by the user through the `SetCacheExpiration` method, we would like to use it as the cache expiration time for recovery of initial configuration load, instead of the default cache expiration time. For example, a cache expiration time of `10 seconds` would be used for the following code snippet, instead of the default cache expiration time of `30 seconds`.

```` csharp
IConfiguration configuration = builder.Build();

builder.AddAzureAppConfiguration(options =>
{
    options.Connect(configuration["connection_string"])
            .ConfigureRefresh(refresh =>
            {
                refresh.SetCacheExpiration(TimeSpan.FromSeconds(10));
            });

    _refresher = options.GetRefresher();
});
````