### PR TITLE
Add ResetCache to IConfigurationRefresher for Push Refresh

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 {
                     Key = FeatureManagementConstants.FeatureFlagMarker,
                     Label = options.Label,
-                    CacheExpirationTime = options.CacheExpirationTime
+                    CacheExpirationInterval = options.CacheExpirationTime
                 });
             }
 
@@ -258,7 +258,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
             foreach (var item in refreshOptions.RefreshRegistrations)
             {
-                item.Value.CacheExpirationTime = refreshOptions.CacheExpirationTime;
+                item.Value.CacheExpirationInterval = refreshOptions.CacheExpirationInterval;
                 _changeWatchers[item.Key] = item.Value;
             }
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     /// </summary>
     public class AzureAppConfigurationOptions
     {
-        internal static readonly TimeSpan DefaultFeatureFlagsCacheExpiration = TimeSpan.FromSeconds(30);
-        internal static readonly TimeSpan MinimumFeatureFlagsCacheExpiration = TimeSpan.FromMilliseconds(1000);
+        internal static readonly TimeSpan DefaultFeatureFlagsCacheExpirationInterval = TimeSpan.FromSeconds(30);
+        internal static readonly TimeSpan MinimumFeatureFlagsCacheExpirationInterval = TimeSpan.FromMilliseconds(1000);
 
         private const int MaxRetries = 2;
         private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(1);
@@ -140,10 +140,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             FeatureFlagOptions options = new FeatureFlagOptions();
             configure?.Invoke(options);
 
-            if (options.CacheExpirationTime < MinimumFeatureFlagsCacheExpiration)
+            if (options.CacheExpirationInterval < MinimumFeatureFlagsCacheExpirationInterval)
             {
-                throw new ArgumentOutOfRangeException(nameof(options.CacheExpirationTime), options.CacheExpirationTime.TotalMilliseconds,
-                    string.Format(ErrorMessages.CacheExpirationTimeTooShort, MinimumFeatureFlagsCacheExpiration.TotalMilliseconds));
+                throw new ArgumentOutOfRangeException(nameof(options.CacheExpirationInterval), options.CacheExpirationInterval.TotalMilliseconds,
+                    string.Format(ErrorMessages.CacheExpirationTimeTooShort, MinimumFeatureFlagsCacheExpirationInterval.TotalMilliseconds));
             }
 
             if (!(_kvSelectors.Any(selector => selector.KeyFilter.StartsWith(FeatureManagementConstants.FeatureFlagMarker) && selector.LabelFilter.Equals(options.Label))))
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 {
                     Key = FeatureManagementConstants.FeatureFlagMarker,
                     Label = options.Label,
-                    CacheExpirationInterval = options.CacheExpirationTime
+                    CacheExpirationInterval = options.CacheExpirationInterval
                 });
             }
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return true;
         }
 
-        public void ResetCache()
+        public void SetDirty()
         {
             DateTimeOffset currentTime = DateTimeOffset.UtcNow;
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -141,6 +141,19 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return true;
         }
 
+        public void ResetCache()
+        {
+            foreach (KeyValueWatcher changeWatcher in _options.ChangeWatchers)
+            {
+                changeWatcher.LastRefreshTime = DateTimeOffset.MinValue;
+            }
+
+            foreach (KeyValueWatcher changeWatcher in _options.MultiKeyWatchers)
+            {
+                changeWatcher.LastRefreshTime = DateTimeOffset.MinValue;
+            }
+        }
+
         private async Task LoadAll(bool ignoreFailures)
         {
             IDictionary<string, ConfigurationSetting> data = new Dictionary<string, ConfigurationSetting>(StringComparer.OrdinalIgnoreCase);

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefreshOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefreshOptions.cs
@@ -52,16 +52,16 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// Sets the cache expiration time for the key-values registered for refresh. Default value is 30 seconds. Must be greater than 1 second.
         /// Any refresh operation triggered using <see cref="IConfigurationRefresher"/> will not update the value for a key until the cached value for that key has expired.
         /// </summary>
-        /// <param name="cacheExpirationTime">Minimum time that must elapse before the cache is expired.</param>
-        public AzureAppConfigurationRefreshOptions SetCacheExpiration(TimeSpan cacheExpirationTime)
+        /// <param name="cacheExpiration">Minimum time that must elapse before the cache is expired.</param>
+        public AzureAppConfigurationRefreshOptions SetCacheExpiration(TimeSpan cacheExpiration)
         {
-            if (cacheExpirationTime < MinimumCacheExpirationInterval)
+            if (cacheExpiration < MinimumCacheExpirationInterval)
             {
-                throw new ArgumentOutOfRangeException(nameof(cacheExpirationTime), cacheExpirationTime.TotalMilliseconds,
+                throw new ArgumentOutOfRangeException(nameof(cacheExpiration), cacheExpiration.TotalMilliseconds,
                     string.Format(ErrorMessages.CacheExpirationTimeTooShort, MinimumCacheExpirationInterval.TotalMilliseconds));
             }
 
-            CacheExpirationInterval = cacheExpirationTime;
+            CacheExpirationInterval = cacheExpiration;
             return this;
         }
     }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefreshOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefreshOptions.cs
@@ -12,10 +12,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     /// </summary>
     public class AzureAppConfigurationRefreshOptions
     {
-        internal static readonly TimeSpan DefaultCacheExpirationTime = TimeSpan.FromSeconds(30);
-        internal static readonly TimeSpan MinimumCacheExpirationTime = TimeSpan.FromMilliseconds(1000);
+        internal static readonly TimeSpan DefaultCacheExpirationInterval = TimeSpan.FromSeconds(30);
+        internal static readonly TimeSpan MinimumCacheExpirationInterval = TimeSpan.FromMilliseconds(1000);
 
-        internal TimeSpan CacheExpirationTime { get; private set; } = DefaultCacheExpirationTime;
+        internal TimeSpan CacheExpirationInterval { get; private set; } = DefaultCacheExpirationInterval;
         internal IDictionary<string, KeyValueWatcher> RefreshRegistrations = new Dictionary<string, KeyValueWatcher>();
 
         /// <summary>
@@ -55,13 +55,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <param name="cacheExpirationTime">Minimum time that must elapse before the cache is expired.</param>
         public AzureAppConfigurationRefreshOptions SetCacheExpiration(TimeSpan cacheExpirationTime)
         {
-            if (cacheExpirationTime < MinimumCacheExpirationTime)
+            if (cacheExpirationTime < MinimumCacheExpirationInterval)
             {
                 throw new ArgumentOutOfRangeException(nameof(cacheExpirationTime), cacheExpirationTime.TotalMilliseconds,
-                    string.Format(ErrorMessages.CacheExpirationTimeTooShort, MinimumCacheExpirationTime.TotalMilliseconds));
+                    string.Format(ErrorMessages.CacheExpirationTimeTooShort, MinimumCacheExpirationInterval.TotalMilliseconds));
             }
 
-            CacheExpirationTime = cacheExpirationTime;
+            CacheExpirationInterval = cacheExpirationTime;
             return this;
         }
     }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
@@ -17,11 +17,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         public async Task RefreshAsync()
         {
-            if (_provider == null)
-            {
-                throw new InvalidOperationException("ConfigurationBuilder.Build() must be called before this operation can be performed.");
-            }
-
+            ThrowIfNullProvider();
             await _provider.RefreshAsync().ConfigureAwait(false);
         }
 
@@ -33,6 +29,20 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
 
             return await _provider.TryRefreshAsync().ConfigureAwait(false);
+        }
+
+        public void ResetCache()
+        {
+            ThrowIfNullProvider();
+            _provider.ResetCache();
+        }
+
+        private void ThrowIfNullProvider()
+        {
+            if (_provider == null)
+            {
+                throw new InvalidOperationException("ConfigurationBuilder.Build() must be called before this operation can be performed.");
+            }
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return await _provider.TryRefreshAsync().ConfigureAwait(false);
         }
 
-        public void ResetCache()
+        public void SetDirty()
         {
             ThrowIfNullProvider();
-            _provider.ResetCache();
+            _provider.SetDirty();
         }
 
         private void ThrowIfNullProvider()

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
@@ -18,6 +18,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         /// <summary>
         /// The time after which the cached values of the feature flags expire.  Must be greater than or equal to 1 second.
         /// </summary>
-        public TimeSpan CacheExpirationTime { get; set; } = AzureAppConfigurationOptions.DefaultFeatureFlagsCacheExpiration;
+        public TimeSpan CacheExpirationInterval { get; set; } = AzureAppConfigurationOptions.DefaultFeatureFlagsCacheExpirationInterval;
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         Task<bool> TryRefreshAsync();
 
         /// <summary>
-        /// Resets the cache for the key-values registered for refresh.
-        /// The next call to <see cref="RefreshAsync"/> or <see cref="TryRefreshAsync"/> would force settings to be refreshed from the server.
+        /// Sets the cached value for key-values registered for refresh as dirty.
+        /// The next call to <see cref="RefreshAsync"/> or <see cref="TryRefreshAsync"/> would cause cached values to be revalidated.
         /// </summary>
-        void ResetCache();
+        void SetDirty();
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -27,5 +27,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// Refreshes the data from the configuration store asynchronously. A return value indicates whether the operation succeeded.
         /// </summary>
         Task<bool> TryRefreshAsync();
+
+        /// <summary>
+        /// Resets the cache for the key-values registered for refresh.
+        /// The next call to <see cref="RefreshAsync"/> or <see cref="TryRefreshAsync"/> would force settings to be refreshed from the server.
+        /// </summary>
+        void ResetCache();
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
@@ -26,12 +26,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
         /// <summary>
         /// The minimum time that must elapse before the key-value is refreshed.
         /// </summary>
-        public TimeSpan CacheExpirationTime { get; set; }
+        public TimeSpan CacheExpirationInterval { get; set; }
 
         /// <summary>
-        /// The most-recent time when the key-value was refreshed.
+        /// The cache expiration time for the key-value.
         /// </summary>
-        public DateTimeOffset LastRefreshTime { get; set; }
+        public DateTimeOffset CacheExpirationTime { get; set; }
 
         /// <summary>
         /// Semaphore that can be used to prevent simultaneous refresh of the key-value from multiple threads.

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
         /// <summary>
         /// The cache expiration time for the key-value.
         /// </summary>
-        public DateTimeOffset CacheExpirationTime { get; set; }
+        public DateTimeOffset CacheExpires { get; set; }
 
         /// <summary>
         /// Semaphore that can be used to prevent simultaneous refresh of the key-value from multiple threads.

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -130,7 +130,7 @@ namespace Tests.AzureAppConfiguration
                 .AddAzureAppConfiguration(options =>
                 {
                     options.Client = mockClient.Object; ;
-                    options.UseFeatureFlags(o => o.CacheExpirationTime = TimeSpan.FromSeconds(1));
+                    options.UseFeatureFlags(o => o.CacheExpirationInterval = TimeSpan.FromSeconds(1));
 
                     refresher = options.GetRefresher();
                 })

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -795,6 +795,9 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("TestValue1", config["TestKey1"]);
             FirstKeyValue.Value = "newValue";
 
+            refresher.RefreshAsync().Wait();
+            Assert.Equal("TestValue1", config["TestKey1"]);
+
             // Invalidate the cache to force next refresh
             refresher.ResetCache();
 

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -798,8 +798,7 @@ namespace Tests.AzureAppConfiguration
             refresher.RefreshAsync().Wait();
             Assert.Equal("TestValue1", config["TestKey1"]);
 
-            // Invalidate the cache to force next refresh
-            refresher.ResetCache();
+            refresher.SetDirty();
 
             refresher.RefreshAsync().Wait();
             Assert.Equal("newValue", config["TestKey1"]);

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -771,6 +771,37 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("TestValue3", configuration["TestKey3"]);
         }
 
+        [Fact]
+        public void RefreshTests_ResetCacheForcesNextRefresh()
+        {
+            IConfigurationRefresher refresher = null;
+            var mockClient = GetMockConfigurationClient();
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = mockClient.Object;
+                    options.Select("TestKey*");
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.Register("TestKey1")
+                            .SetCacheExpiration(TimeSpan.FromDays(1));
+                    });
+
+                    refresher = options.GetRefresher();
+                })
+                .Build();
+
+            Assert.Equal("TestValue1", config["TestKey1"]);
+            FirstKeyValue.Value = "newValue";
+
+            // Invalidate the cache to force next refresh
+            refresher.ResetCache();
+
+            refresher.RefreshAsync().Wait();
+            Assert.Equal("newValue", config["TestKey1"]);
+        }
+
         private void WaitAndRefresh(IConfigurationRefresher refresher, int millisecondsDelay)
         {
             Task.Delay(millisecondsDelay).Wait();


### PR DESCRIPTION
This pull request adds `ResetCache` method to the interface `IConfigurationRefresher` to allow users to invalidate the cache for the key-values. This will ensure that the subsequence call to `RefreshAsync` or `TryRefreshAsync` would not use the cached value and instead retrieve the updated configuration from the server. When a user received a push notification from the event grid indicating that a key-value has been updated or deleted, this method will reset the cache to allow the configuration to be updated.

This change also renames `TimeSpan CacheExpirationTime` to `TimeSpan CacheExpirationInterval` and instead uses `DateTimeOffset CacheExpirationTime` to indicate the time when the cached value for a specific key would expire.