### PR TITLE
Update NuGet package version to 4.0.0

### DIFF
--- a/build/NugetProperties.props
+++ b/build/NugetProperties.props
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'==''">
-    <Version>3.9.9999</Version>
+    <Version>4.9.9999</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'=='Official'">
-    <Version>3.0.1</Version>
+    <Version>4.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'!='Official'">
@@ -29,6 +29,6 @@
     <MinutesSinceMidnight>$([MSBuild]::Divide($(TicksSinceMidnight), 600000000))</MinutesSinceMidnight>
     <Floored>$([System.Math]::Floor($(MinutesSinceMidnight)))</Floored>
     <Revision>$(Floored)</Revision>
-    <Version>3.0.1-preview-$(CDP_PATCH_NUMBER)-$(Revision)</Version>
+    <Version>4.0.0-preview-$(CDP_PATCH_NUMBER)-$(Revision)</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This change updates the NuGet package version to `4.0.0` for official releases and `4.0.0-preview-*` for other releases of the App Configuration provider.