### PR TITLE
Update provider version to 4.0.0 in AspNetCore package

### DIFF
--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
@@ -14,6 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="4.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This change updates the project for the NuGet package `Microsoft.Azure.AppConfiguration.AspNetCore` to reference version `4.0.0` of the package `Microsoft.Extensions.Configuration.AzureAppConfiguration` instead of version `3.0.1`.