### PR TITLE
Update SetDirty to use randomized delay to reduce potential throttling

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/RandomGenerator.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/RandomGenerator.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading;
+
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+{
+    static class RandomGenerator
+    {
+        private static readonly Random _global = new Random();
+        private static readonly ThreadLocal<Random> _rnd = new ThreadLocal<Random>(() =>
+        {
+            int seed;
+
+            lock (_global)
+            {
+                seed = _global.Next();
+            }
+
+            return new Random(seed);
+        });
+
+        public static double NextDouble()
+        {
+            return _rnd.Value.NextDouble();
+        }
+    }
+}

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -772,7 +772,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void RefreshTests_ResetCacheForcesNextRefresh()
+        public void RefreshTests_SetDirtyForcesNextRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -798,7 +798,13 @@ namespace Tests.AzureAppConfiguration
             refresher.RefreshAsync().Wait();
             Assert.Equal("TestValue1", config["TestKey1"]);
 
+            // TODO : Update this in separate PR that allows overriding this value
+            AzureAppConfigurationProvider.DefaultMaxSetDirtyDelay = TimeSpan.FromSeconds(1);
+
             refresher.SetDirty();
+
+            // Wait for the cache to expire based on the randomized delay in SetDirty()
+            Thread.Sleep(1200);
 
             refresher.RefreshAsync().Wait();
             Assert.Equal("newValue", config["TestKey1"]);


### PR DESCRIPTION
This pull request adds a randomized delay to the cache expiration time that is set by the call to `SetDirty` method. It uses a delay between 0 to 30 seconds by default. I will send a separate PR that adds support to allow users to override the default maximum delay.