### PR TITLE
Allow users to configure max delay for SetDirty

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -38,9 +38,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         private DateTimeOffset InitializationCacheExpires = default;
 
         private static readonly TimeSpan MinDelayForUnhandledFailure = TimeSpan.FromSeconds(5);
-
-        // TODO : Make the property private in separate PR that allows overriding this value
-        internal static TimeSpan DefaultMaxSetDirtyDelay = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan DefaultMaxSetDirtyDelay = TimeSpan.FromSeconds(30);
 
         public AzureAppConfigurationProvider(ConfigurationClient client, AzureAppConfigurationOptions options, bool optional)
         {
@@ -144,9 +142,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return true;
         }
 
-        public void SetDirty()
+        public void SetDirty(TimeSpan? maxDelay)
         {
-            DateTimeOffset cacheExpires = AddRandomDelay(DateTimeOffset.UtcNow, DefaultMaxSetDirtyDelay);
+            DateTimeOffset cacheExpires = AddRandomDelay(DateTimeOffset.UtcNow, maxDelay ?? DefaultMaxSetDirtyDelay);
 
             foreach (KeyValueWatcher changeWatcher in _options.ChangeWatchers)
             {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return await _provider.TryRefreshAsync().ConfigureAwait(false);
         }
 
-        public void SetDirty()
+        public void SetDirty(TimeSpan? maxDelay)
         {
             ThrowIfNullProvider();
-            _provider.SetDirty();
+            _provider.SetDirty(maxDelay);
         }
 
         private void ThrowIfNullProvider()

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// Sets the cached value for key-values registered for refresh as dirty.
         /// A random delay is added before the cached value is marked as dirty to reduce potential throttling in case multiple instances refresh at the same time.
-        /// After the cache is marked as dirty, the subsequent call to <see cref="RefreshAsync"/> or <see cref="TryRefreshAsync"/> would cause cached values to be revalidated.
         /// </summary>
         /// <param name="maxDelay">Maximum delay before the cached value is marked as dirty. Default value is 30 seconds.</param>
         void SetDirty(TimeSpan? maxDelay = null);

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -30,8 +30,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         /// <summary>
         /// Sets the cached value for key-values registered for refresh as dirty.
-        /// The next call to <see cref="RefreshAsync"/> or <see cref="TryRefreshAsync"/> would cause cached values to be revalidated.
+        /// A random delay is added before the cached value is marked as dirty to reduce potential throttling in case multiple instances refresh at the same time.
+        /// After the cache is marked as dirty, the subsequent call to <see cref="RefreshAsync"/> or <see cref="TryRefreshAsync"/> would cause cached values to be revalidated.
         /// </summary>
-        void SetDirty();
+        /// <param name="maxDelay">Maximum delay before the cached value is marked as dirty. Default value is 30 seconds.</param>
+        void SetDirty(TimeSpan? maxDelay = null);
     }
 }

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -798,10 +798,7 @@ namespace Tests.AzureAppConfiguration
             refresher.RefreshAsync().Wait();
             Assert.Equal("TestValue1", config["TestKey1"]);
 
-            // TODO : Update this in separate PR that allows overriding this value
-            AzureAppConfigurationProvider.DefaultMaxSetDirtyDelay = TimeSpan.FromSeconds(1);
-
-            refresher.SetDirty();
+            refresher.SetDirty(TimeSpan.FromSeconds(1));
 
             // Wait for the cache to expire based on the randomized delay in SetDirty()
             Thread.Sleep(1200);


### PR DESCRIPTION
This pull request contains the changes to allow users to override the default maximum randomized delay for calls to the `SetDirty` method in `IConfigurationRefresher`.