### PR TITLE
Fix issue with refresh on refreshAll failure

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -334,8 +334,14 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                         // Check if a change has been detected in the key-value registered for refresh
                         if (keyValueChange.ChangeType != KeyValueChangeType.None)
                         {
-                            ProcessChanges(Enumerable.Repeat(keyValueChange, 1));
+                            if (changeWatcher.RefreshAll)
+                            {
+                                shouldRefreshAll = true;
+                                break;
+                            }
+
                             hasChanged = true;
+                            ProcessChanges(Enumerable.Repeat(keyValueChange, 1));
                         }
                     }
                     else
@@ -356,25 +362,22 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
                         if (watchedKv != null)
                         {
+                            if (changeWatcher.RefreshAll)
+                            {
+                                shouldRefreshAll = true;
+                                break;
+                            }
+
+                            hasChanged = true;
+
                             // Add the key-value if it is not loaded, or update it if it was loaded with a different label
                             _settings[watchedKey] = watchedKv;
-                            hasChanged = true;
                         }
                     }
 
                     if (hasChanged)
                     {
-                        if (changeWatcher.RefreshAll)
-                        {
-                            shouldRefreshAll = true;
-
-                            // Skip refresh for other key-values since refreshAll will populate configuration from scratch
-                            break;
-                        }
-                        else
-                        {
-                            await SetData(_settings).ConfigureAwait(false);
-                        }
+                        await SetData(_settings).ConfigureAwait(false);
                     }
                 }
                 finally

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -807,6 +807,77 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("newValue", config["TestKey1"]);
         }
 
+        [Fact]
+        public void RefreshTests_SentinelKeyNotUpdatedOnRefreshAllFailure()
+        {
+            var serviceCollection = new List<ConfigurationSetting>(_kvCollection);
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, TestHelpers.CreateMockEndpointString());
+
+            Response<ConfigurationSetting> GetIfChanged(ConfigurationSetting setting, bool cond, CancellationToken ct)
+            {
+                var newSetting = serviceCollection.FirstOrDefault(s => s.Key == setting.Key);
+                var unchanged = (newSetting.Key == setting.Key && newSetting.Label == setting.Label && newSetting.Value == setting.Value);
+                var response = new MockResponse(unchanged ? 304 : 200);
+                return Response.FromValue(newSetting, response);
+            }
+
+            mockClient.SetupSequence(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(new MockAsyncPageable(serviceCollection.Select(setting => TestHelpers.CloneSetting(setting)).ToList()))
+                .Throws(new RequestFailedException(429, "Too many requests"))
+                .Returns(new MockAsyncPageable(serviceCollection.Select(setting =>
+                {
+                    setting.Value = "newValue";
+                    return TestHelpers.CloneSetting(setting);
+                }).ToList()));
+
+            mockClient.Setup(c => c.GetConfigurationSettingAsync(It.IsAny<ConfigurationSetting>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Func<ConfigurationSetting, bool, CancellationToken, Response<ConfigurationSetting>>)GetIfChanged);
+
+            IConfigurationRefresher refresher = null;
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = mockClient.Object;
+                    options.Select("TestKey*", "label");
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.Register("TestKey1", "label", refreshAll: true)
+                            .SetCacheExpiration(TimeSpan.FromSeconds(1));
+                    });
+
+                    refresher = options.GetRefresher();
+                })
+                .Build();
+
+            Assert.Equal("TestValue1", config["TestKey1"]);
+            Assert.Equal("TestValue2", config["TestKey2"]);
+            Assert.Equal("TestValue3", config["TestKey3"]);
+
+            serviceCollection.ForEach(kv => kv.Value = "newValue");
+
+            // Wait for the cache to expire
+            Thread.Sleep(1500);
+
+            bool firstRefreshResult = refresher.TryRefreshAsync().Result;
+            Assert.False(firstRefreshResult);
+
+            Assert.Equal("TestValue1", config["TestKey1"]);
+            Assert.Equal("TestValue2", config["TestKey2"]);
+            Assert.Equal("TestValue3", config["TestKey3"]);
+
+            // Wait for the cache to expire
+            Thread.Sleep(1500);
+
+            bool secondRefreshResult = refresher.TryRefreshAsync().Result;
+            Assert.True(secondRefreshResult);
+
+            Assert.Equal("newValue", config["TestKey1"]);
+            Assert.Equal("newValue", config["TestKey2"]);
+            Assert.Equal("newValue", config["TestKey3"]);
+        }
+
         private void WaitAndRefresh(IConfigurationRefresher refresher, int millisecondsDelay)
         {
             Task.Delay(millisecondsDelay).Wait();


### PR DESCRIPTION
When a change is detected in a sentinel key-value with `refreshAll` set to `true`, a `refreshAll` operation is triggered to populate the entire configuration from scratch. However, in case we fail to complete that operation and all retry attempts fail, the subsequent calls to `TryRefreshAsync` fail to detect changes and do not attempt to retry the failed operation. This pull request updates code to ensure that failed `refreshAll` operations do not leave the internal configuration cache in an inconsistent state. https://github.com/Azure/AppConfiguration-DotnetProvider/issues/178