### PR TITLE
Add support to retrieve IConfigurationRefresher through dependency injection

### DIFF
--- a/examples/ConfigStoreDemo/Startup.cs
+++ b/examples/ConfigStoreDemo/Startup.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Examples.Conf
         public void ConfigureServices(IServiceCollection services)
         {
             services.Configure<Settings>(Configuration.GetSection("Settings"));
+            services.AddAzureAppConfiguration();
             services.AddMvc();
         }
 

--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/AzureAppConfigurationRefreshExtensions.cs
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/AzureAppConfigurationRefreshExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 //
 using Microsoft.Azure.AppConfiguration.AspNetCore;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using System;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -16,6 +18,18 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="builder">An instance of <see cref="IApplicationBuilder"/></param>
         public static IApplicationBuilder UseAzureAppConfiguration(this IApplicationBuilder builder)
         {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            // Verify if AddAzureAppConfiguration was done before calling UseAzureAppConfiguration.
+            // We use the IConfigurationRefresherProvider to make sure if the required services were added.
+            if (builder.ApplicationServices.GetService(typeof(IConfigurationRefresherProvider)) == null)
+            {
+                throw new InvalidOperationException("Unable to find the required services. Please add all the required services by calling 'IServiceCollection.AddAzureAppConfiguration' inside the call to 'ConfigureServices(...)' in the application startup code.");
+            }
+
             return builder.UseMiddleware<AzureAppConfigurationRefreshMiddleware>();
         }
     }

--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/AzureAppConfigurationRefreshMiddleware.cs
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/AzureAppConfigurationRefreshMiddleware.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license.
 //
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -16,26 +14,12 @@ namespace Microsoft.Azure.AppConfiguration.AspNetCore
     class AzureAppConfigurationRefreshMiddleware
     {
         private readonly RequestDelegate _next;
-        public IList<IConfigurationRefresher> Refreshers { get; private set; }
+        public IEnumerable<IConfigurationRefresher> Refreshers { get; }
 
-        public AzureAppConfigurationRefreshMiddleware(RequestDelegate next, IConfiguration configuration)
+        public AzureAppConfigurationRefreshMiddleware(RequestDelegate next, IConfigurationRefresherProvider refresherProvider)
         {
             _next = next;
-            Refreshers = new List<IConfigurationRefresher>();
-            var configurationRoot = configuration as IConfigurationRoot;
-
-            if (configurationRoot == null)
-            {
-                throw new InvalidOperationException("Unable to access the Azure App Configuration provider. Please ensure that it has been configured correctly.");
-            }
-
-            foreach (var provider in configurationRoot.Providers)
-            {
-                if (provider is IConfigurationRefresher refresher)
-                {
-                    Refreshers.Add(refresher);
-                }
-            }
+            Refreshers = refresherProvider.Refreshers;
         }
 
         public async Task InvokeAsync(HttpContext context)

--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
@@ -14,6 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="4.0.0-preview-012940002-1111" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs
@@ -3,10 +3,7 @@
 //
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
-using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs
@@ -2,7 +2,11 @@
 // Licensed under the MIT license.
 //
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.Configuration
 {
@@ -39,6 +43,22 @@ namespace Microsoft.Extensions.Configuration
             bool optional = false)
         {
             return configurationBuilder.Add(new AzureAppConfigurationSource(action, optional));
+        }
+
+        /// <summary>
+        /// Adds Azure App Configuration services to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddAzureAppConfiguration(this IServiceCollection services)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.AddSingleton<IConfigurationRefresherProvider, AzureAppConfigurationRefresherProvider>();
+            return services;
         }
 
         internal static IConfigurationBuilder AddAzureAppConfiguration(

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     return new Uri(ConnectionStringParser.Parse(_options.ConnectionString, "Endpoint"));
                 }
 
-                throw new InvalidOperationException($"Please call {nameof(AzureAppConfigurationOptions)}.{nameof(AzureAppConfigurationOptions.Connect)} to specify how to connect to Azure App Configuration.");
+                return null;
             }
         }
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -40,6 +40,24 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         private static readonly TimeSpan MinDelayForUnhandledFailure = TimeSpan.FromSeconds(5);
         private static readonly TimeSpan DefaultMaxSetDirtyDelay = TimeSpan.FromSeconds(30);
 
+        public Uri AppConfigurationEndpoint
+        {
+            get
+            {
+                if (_options.Endpoint != null)
+                {
+                    return _options.Endpoint;
+                }
+
+                if (_options.ConnectionString != null)
+                {
+                    return new Uri(ConnectionStringParser.Parse(_options.ConnectionString, "Endpoint"));
+                }
+
+                throw new InvalidOperationException($"Please call {nameof(AzureAppConfigurationOptions)}.{nameof(AzureAppConfigurationOptions.Connect)} to specify how to connect to Azure App Configuration.");
+            }
+        }
+
         public AzureAppConfigurationProvider(ConfigurationClient client, AzureAppConfigurationOptions options, bool optional)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
@@ -10,9 +10,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     {
         private AzureAppConfigurationProvider _provider = null;
 
+        public Uri AppConfigurationEndpoint { get; } = null;
+
         public void SetProvider(AzureAppConfigurationProvider provider)
         {
-            _provider = provider;
+            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            AppConfigurationEndpoint = _provider.AppConfigurationEndpoint;
         }
 
         public async Task RefreshAsync()

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     {
         private AzureAppConfigurationProvider _provider = null;
 
-        public Uri AppConfigurationEndpoint { get; } = null;
+        public Uri AppConfigurationEndpoint { get; private set; } = null;
 
         public void SetProvider(AzureAppConfigurationProvider provider)
         {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresherProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresherProvider.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+{
+    class AzureAppConfigurationRefresherProvider : IConfigurationRefresherProvider
+    {
+        public IEnumerable<IConfigurationRefresher> Refreshers { get; }
+
+        public AzureAppConfigurationRefresherProvider(IConfiguration configuration)
+        {
+            var configurationRoot = configuration as IConfigurationRoot;
+
+            if (configurationRoot == null)
+            {
+                throw new InvalidOperationException("Unable to access the Azure App Configuration provider. Please ensure that it has been configured correctly.");
+            }
+
+            var refreshers = new List<IConfigurationRefresher>();
+
+            foreach (IConfigurationProvider provider in configurationRoot.Providers)
+            {
+                if (provider is IConfigurationRefresher refresher)
+                {
+                    refreshers.Add(refresher);
+                }
+            }
+
+            Refreshers = refreshers;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     public interface IConfigurationRefresher
     {
         /// <summary>
-        /// Uri of the App Configuration endpoint.
+        /// The App Configuration endpoint.
         /// </summary>
         Uri AppConfigurationEndpoint { get; }
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -8,12 +8,17 @@ using System.Threading.Tasks;
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     /// <summary>
-    /// An interface used to trigger an update for the data registered for refresh with the configuration store.
+    /// An interface used to trigger an update for the data registered for refresh with App Configuration.
     /// </summary>
     public interface IConfigurationRefresher
     {
         /// <summary>
-        /// Refreshes the data from the configuration store asynchronously.
+        /// Uri of the App Configuration endpoint.
+        /// </summary>
+        Uri AppConfigurationEndpoint { get; }
+
+        /// <summary>
+        /// Refreshes the data from App Configuration asynchronously.
         /// </summary>
         /// <exception cref="KeyVaultReferenceException">An error occurred when resolving a reference to an Azure Key Vault resource.</exception>
         /// <exception cref="RequestFailedException">The request failed with an error code from the server.</exception>
@@ -24,7 +29,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         Task RefreshAsync();
 
         /// <summary>
-        /// Refreshes the data from the configuration store asynchronously. A return value indicates whether the operation succeeded.
+        /// Refreshes the data from App Configuration asynchronously. A return value indicates whether the operation succeeded.
         /// </summary>
         Task<bool> TryRefreshAsync();
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresherProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresherProvider.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+{
+    /// <summary>
+    /// An interface used to retrieve refresher instances for App Configuration.
+    /// </summary>
+    public interface IConfigurationRefresherProvider
+    {
+        /// <summary>
+        /// List of instances of <see cref="IConfigurationRefresher"/> for App Configuration.
+        /// </summary>
+        IEnumerable<IConfigurationRefresher> Refreshers { get; }
+    }
+}

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.2" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 

--- a/tests/Tests.AzureAppConfiguration.AspNetCore/AzureAppConfigurationExtensionsTests.cs
+++ b/tests/Tests.AzureAppConfiguration.AspNetCore/AzureAppConfigurationExtensionsTests.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System;
+using Xunit;
+
+namespace Tests.AzureAppConfiguration.AspNetCore
+{
+    public class AzureAppConfigurationExtensionsTests
+    {
+        [Fact]
+        public void UseAzureAppConfiguration_ThrowsOnMissingAddAzureAppConfiguration()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            var mockApplicationBuilder = new Mock<IApplicationBuilder>(MockBehavior.Strict);
+            mockApplicationBuilder.SetupGet(builder => builder.ApplicationServices).Returns(services.BuildServiceProvider());
+            void action() => mockApplicationBuilder.Object.UseAzureAppConfiguration();
+
+            // Act and Assert
+            var exception = Assert.Throws<InvalidOperationException>(action);
+            Assert.Contains("AddAzureAppConfiguration", exception.Message);
+        }
+    }
+}

--- a/tests/Tests.AzureAppConfiguration.AspNetCore/RefreshMiddlewareTests.cs
+++ b/tests/Tests.AzureAppConfiguration.AspNetCore/RefreshMiddlewareTests.cs
@@ -45,11 +45,6 @@ namespace Tests.AzureAppConfiguration.AspNetCore
         public void RefreshMiddlewareTests_MiddlewareConstructorRetrievesIConfigurationRefresher()
         {
             // Arrange
-            var mockResponse = new Mock<Response>();
-            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, CreateMockEndpointString());
-            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
-                .Returns(new MockAsyncPageable(_kvCollection));
-
             IConfigurationRefresher[] refreshers = { new AzureAppConfigurationRefresher() };
             var mockRefresherProvider = new Mock<IConfigurationRefresherProvider>(MockBehavior.Strict);
             mockRefresherProvider.SetupGet(provider => provider.Refreshers).Returns(refreshers);
@@ -67,11 +62,6 @@ namespace Tests.AzureAppConfiguration.AspNetCore
         public void RefreshMiddlewareTests_MiddlewareConstructorRetrievesMultipleIConfigurationRefreshers()
         {
             // Arrange
-            var mockResponse = new Mock<Response>();
-            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, CreateMockEndpointString());
-            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
-                .Returns(new MockAsyncPageable(_kvCollection));
-
             IConfigurationRefresher[] refreshers = { new AzureAppConfigurationRefresher(), new AzureAppConfigurationRefresher() };
             var mockRefresherProvider = new Mock<IConfigurationRefresherProvider>(MockBehavior.Strict);
             mockRefresherProvider.SetupGet(provider => provider.Refreshers).Returns(refreshers);

--- a/tests/Tests.AzureAppConfiguration.AspNetCore/Tests.AzureAppConfiguration.AspNetCore.csproj
+++ b/tests/Tests.AzureAppConfiguration.AspNetCore/Tests.AzureAppConfiguration.AspNetCore.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -878,6 +878,28 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("newValue", config["TestKey3"]);
         }
 
+        [Fact]
+        public void RefreshTests_AzureAppConfigurationRefresherProviderReturnsRefreshers()
+        {
+            IConfiguration configuration = new ConfigurationBuilder().Build();
+            IConfigurationRefresherProvider refresherProvider = new AzureAppConfigurationRefresherProvider(configuration);
+            Assert.Empty(refresherProvider.Refreshers);
+
+            static void optionsInitializer(AzureAppConfigurationOptions options)
+            {
+                options.Connect(TestHelpers.CreateMockEndpointString());
+                options.ConfigureClientOptions(clientOptions => clientOptions.Retry.MaxRetries = 0);
+            }
+
+            configuration = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(optionsInitializer, optional: true)
+                .AddAzureAppConfiguration(optionsInitializer, optional: true)
+                .Build();
+
+            refresherProvider = new AzureAppConfigurationRefresherProvider(configuration);
+            Assert.Equal(2, refresherProvider.Refreshers.Count());
+        }
+
         private void WaitAndRefresh(IConfigurationRefresher refresher, int millisecondsDelay)
         {
             Task.Delay(millisecondsDelay).Wait();


### PR DESCRIPTION
More details about the changes can be found at https://github.com/Azure/AppConfiguration-DotnetProvider/issues/167.