### PR TITLE
Update logic for Nuget package version generation

### DIFF
--- a/build/NugetProperties.props
+++ b/build/NugetProperties.props
@@ -8,7 +8,6 @@
     <PackageProjectUrl>https://github.com/Azure/AppConfiguration</PackageProjectUrl>
     <PackageLicenseUrl>https://aka.ms/AzureAppConfigurationDotnetCorePublicPreviewEula</PackageLicenseUrl>
     <PackageIconUrl>https://aka.ms/AzureAppConfigurationPackageIcon</PackageIconUrl>
-    <Preview>true</Preview>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'==''">
@@ -16,10 +15,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'=='Official'">
-    <Version>4.0.0</Version>
+    <Version>4.0.0-preview</Version>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND ('$(CDP_BUILD_TYPE)'!='Official' OR '$(Preview)'=='true')">
+  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'!='Official'">
     <!-- Note that CDP_PACKAGE_VERSION_NUMERIC uses format Major.Minor.MMddyyrrrr, which causes compile error CS7034 because .NET Core doesn't allow version numbers higher than 65534. -->
     <!-- CDP_PATCH_NUMBER is updated daily by the build system, the addition of a revision number makes the build number unique by the minute -->
     <!-- The revision number is the number of minutes since midnight [0, 1440) -->

--- a/build/NugetProperties.props
+++ b/build/NugetProperties.props
@@ -8,6 +8,7 @@
     <PackageProjectUrl>https://github.com/Azure/AppConfiguration</PackageProjectUrl>
     <PackageLicenseUrl>https://aka.ms/AzureAppConfigurationDotnetCorePublicPreviewEula</PackageLicenseUrl>
     <PackageIconUrl>https://aka.ms/AzureAppConfigurationPackageIcon</PackageIconUrl>
+    <Preview>true</Preview>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'==''">
@@ -18,7 +19,7 @@
     <Version>4.0.0</Version>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'!='Official'">
+  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND ('$(CDP_BUILD_TYPE)'!='Official' OR '$(Preview)'=='true')">
     <!-- Note that CDP_PACKAGE_VERSION_NUMERIC uses format Major.Minor.MMddyyrrrr, which causes compile error CS7034 because .NET Core doesn't allow version numbers higher than 65534. -->
     <!-- CDP_PATCH_NUMBER is updated daily by the build system, the addition of a revision number makes the build number unique by the minute -->
     <!-- The revision number is the number of minutes since midnight [0, 1440) -->


### PR DESCRIPTION
This pull request adds a `Preview` property to allow generation of preview versions for Nuget packages generated in official builds.