### PR TITLE
Update build pipeline to support multi-targeting

### DIFF
--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -3,14 +3,14 @@ environment:
     os: windows
   runtime:
     provider: appcontainer
-    image: cdpxwinrs5test.azurecr.io/global/vse2019/u3/vse2019u3-winltsc2019
+    image: mcr.microsoft.com/dotnet/core/sdk:3.1
   
 restore:
   commands:
     - !!defaultcommand
       name: 'Restore'
       command: 'build.cmd'
-      arguments: 'RestoreOnly'
+      arguments: '-RestoreOnly'
 
 build:
   commands:
@@ -26,7 +26,7 @@ build:
         - from: 'src'
           to: 'Binaries'
           include:
-            - '*/bin/BuildOutput/**/*AppConfiguration*'
+            - '*/bin/Release/**/*'
 
 package:
   commands:

--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,7 @@
-powershell.exe -ExecutionPolicy Unrestricted -NoProfile -File "%~dp0build.ps1"
+call %~dp0build\ChoosePowerShell.cmd
+
+IF %ERRORLEVEL% NEQ 0 (
+    exit /B 1
+)
+
+%PowerShell% "%~dp0build.ps1" %*

--- a/build.ps1
+++ b/build.ps1
@@ -10,12 +10,14 @@ Indicates whether the build config should be set to Debug or Release. The defaul
 param(
     [Parameter()]
     [ValidateSet('Debug','Release')]
-    [string]$BuildConfig = "Release"
+    [string]$BuildConfig = "Release",
+    
+    [Parameter()]
+    [switch]$RestoreOnly = $false
 )
 
 $ErrorActionPreference = "Stop"
 
-$BuildRelativePath = "bin\BuildOutput"
 $LogDirectory = "$PSScriptRoot\buildlogs"
 $Solution     = "$PSScriptRoot\Microsoft.Extensions.Configuration.AzureAppConfiguration.sln"
 
@@ -24,7 +26,13 @@ if ((Test-Path -Path $LogDirectory) -ne $true) {
     New-Item -ItemType Directory -Path $LogDirectory | Write-Verbose
 }
 
-# Build (We use 'publish' to pull the Microsoft.Azure.AppConfiguration.AzconfigClient.dll to be able to include it in the Microsoft.Extensions.Configuration.AzureAppConfiguration NuGet package)
-dotnet publish -o "$BuildRelativePath" -c $BuildConfig "$Solution" /p:OutDir=$BuildRelativePath | Tee-Object -FilePath "$LogDirectory\build.log"
+if ($RestoreOnly)
+{
+    dotnet restore "$Solution"
+}
+else
+{
+    dotnet build -c $BuildConfig "$Solution" | Tee-Object -FilePath "$LogDirectory\build.log"
+}
 
 exit $LASTEXITCODE

--- a/build/ChoosePowerShell.cmd
+++ b/build/ChoosePowerShell.cmd
@@ -1,0 +1,18 @@
+:: where.exe does not exist in windows container, application specific test must be used to check for existence
+
+pwsh -Command Write-Host "a"
+
+IF %ERRORLEVEL% == 0 (
+    set PowerShell=pwsh
+    exit /B 0
+)
+
+PowerShell -Command Write-Host "a"
+
+IF %ERRORLEVEL% == 0 (
+    set PowerShell=PowerShell
+    exit /B 0
+)
+
+echo Could not find a suitable PowerShell executable.
+EXIT /B 1

--- a/pack.cmd
+++ b/pack.cmd
@@ -1,1 +1,7 @@
-powershell.exe -ExecutionPolicy Unrestricted -NoProfile -File "%~dp0pack.ps1"
+call %~dp0build\ChoosePowerShell.cmd
+
+IF %ERRORLEVEL% NEQ 0 (
+    exit /B 1
+)
+
+%PowerShell% "%~dp0pack.ps1" %*


### PR DESCRIPTION
This pull request contains the following changes.
1. Updated the build pipeline to use the image with .NET Core 3.1 SDK
2. Updated the build and package scripts to support generation of packages with multi-targeting