### PR TITLE
Fix issue with user agent header policy

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -6,10 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using System.Security;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
@@ -18,32 +15,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     {
         static private HostType? _hostType = null;
 
-        public static string GenerateUserAgent(string currentUserAgent = null)
+        public static string GenerateUserAgent()
         {
             Assembly assembly = typeof(AzureAppConfigurationOptions).Assembly;
             string informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
-            var userAgent = new StringBuilder($"{assembly.GetName().Name}/{informationalVersion}");
-
-            // If currentUserAgent is not null, prepend current assembly name and version to it, and return without any further processing.
-            if (!string.IsNullOrWhiteSpace(currentUserAgent))
-            {
-                return $"{userAgent.ToString()} {currentUserAgent}";
-            }
-
-            IEnumerable<TargetFrameworkAttribute> targetFrameworkAttributes = assembly.GetCustomAttributes(true)?.OfType<TargetFrameworkAttribute>();
-            if (targetFrameworkAttributes != null && targetFrameworkAttributes.Any())
-            {
-                var frameworkName = new FrameworkName(targetFrameworkAttributes.First().FrameworkName);
-                userAgent.Append($" {frameworkName.Identifier}/{frameworkName.Version}");
-            }
-
-            string comment = RuntimeInformation.OSDescription;
-            if (!string.IsNullOrEmpty(comment))
-            {
-                userAgent.Append($" ({comment})");
-            }
-
-            return userAgent.ToString();
+            return $"{assembly.GetName().Name}/{informationalVersion}";
         }
 
         public static HostType GetHostType()

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using System.Security;
 using System.Threading.Tasks;
 
@@ -14,13 +13,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     internal static class TracingUtils
     {
         static private HostType? _hostType = null;
-
-        public static string GenerateUserAgent()
-        {
-            Assembly assembly = typeof(AzureAppConfigurationOptions).Assembly;
-            string informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
-            return $"{assembly.GetName().Name}/{informationalVersion}";
-        }
 
         public static HostType GetHostType()
         {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/UserAgentHeaderPolicy.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/UserAgentHeaderPolicy.cs
@@ -23,9 +23,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
         {
-            string headerValue = message.Request.Headers.TryGetValue(RequestTracingConstants.UserAgentHeader, out string sdkUserAgent)
-                ? TracingUtils.GenerateUserAgent(sdkUserAgent) : TracingUtils.GenerateUserAgent();
-            message.Request.Headers.SetValue(RequestTracingConstants.UserAgentHeader, headerValue);
+            message.Request.Headers.Add(RequestTracingConstants.UserAgentHeader, TracingUtils.GenerateUserAgent());
 
             if (async)
             {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/UserAgentHeaderPolicy.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/UserAgentHeaderPolicy.cs
@@ -5,6 +5,7 @@ using Azure.Core;
 using Azure.Core.Pipeline;
 using System;
 using System.Diagnostics;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
@@ -21,9 +22,16 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return ProcessAsync(message, pipeline, true);
         }
 
+        internal static string GenerateUserAgent()
+        {
+            Assembly assembly = typeof(AzureAppConfigurationOptions).Assembly;
+            string informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            return $"{assembly.GetName().Name}/{informationalVersion}";
+        }
+
         private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
         {
-            message.Request.Headers.Add(RequestTracingConstants.UserAgentHeader, TracingUtils.GenerateUserAgent());
+            message.Request.Headers.Add(RequestTracingConstants.UserAgentHeader, GenerateUserAgent());
 
             if (async)
             {

--- a/tests/Tests.AzureAppConfiguration/Tests.cs
+++ b/tests/Tests.AzureAppConfiguration/Tests.cs
@@ -207,7 +207,7 @@ namespace Tests.AzureAppConfiguration
                 }).Build();
 
             MockRequest request = mockTransport.SingleRequest;
-            string appUserAgent = TracingUtils.GenerateUserAgent();
+            string appUserAgent = UserAgentHeaderPolicy.GenerateUserAgent();
             Assert.True(request.Headers.TryGetValue("User-Agent", out string userAgentHeader));
             Assert.Matches(userAgentRegex, userAgentHeader);
         }


### PR DESCRIPTION
The change in the user agent header policy resulted in [our code](https://msazure.visualstudio.com/Azure%20AppConfig/_git/Azconfig-DotnetProvider?path=%2Fsrc%2FMicrosoft.Extensions.Configuration.AzureAppConfiguration%2FTracingUtils.cs&version=GBmaster) in the configuration provider to add this substring to the user agent. With this change, the order of user agent substring generation in the configuration provider and the SDK was reversed.

https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/Pipeline/HttpPipelineBuilder.cs

![image](https://user-images.githubusercontent.com/47916289/89574493-16e5e500-d7e1-11ea-9a07-467fc192e182.png)
![image](https://user-images.githubusercontent.com/47916289/89574316-ca020e80-d7e0-11ea-83a7-4a1fbbd16cfe.png)
![image](https://user-images.githubusercontent.com/47916289/89574367-df773880-d7e0-11ea-966a-e1667048189f.png)
