### PR TITLE
Add tags to nuget packages

### DIFF
--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
@@ -10,6 +10,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Microsoft.Azure.AppConfiguration.AspNetCore</AssemblyName>
     <PackageReleaseNotes>https://aka.ms/MicrosoftAzureAppConfigurationAspNetCoreReleaseNotes</PackageReleaseNotes>
+    <PackageTags>Microsoft Azure Configuration AppConfig AppConfiguration aspnetcore</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
@@ -10,7 +10,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Microsoft.Azure.AppConfiguration.AspNetCore</AssemblyName>
     <PackageReleaseNotes>https://aka.ms/MicrosoftAzureAppConfigurationAspNetCoreReleaseNotes</PackageReleaseNotes>
-    <PackageTags>Microsoft Azure Configuration AppConfig AppConfiguration aspnetcore</PackageTags>
+    <PackageTags>Microsoft Azure Configuration AppConfig AppConfiguration AzureAppConfiguration aspnetcore</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -10,6 +10,7 @@
     <AssemblyOriginatorKeyFile>..\..\build\AzureAppConfiguration.snk</AssemblyOriginatorKeyFile>
     <AssemblyName>Microsoft.Extensions.Configuration.AzureAppConfiguration</AssemblyName>
     <PackageReleaseNotes>https://aka.ms/MicrosoftExtensionsConfigurationAzureAppConfigurationReleaseNotes</PackageReleaseNotes>
+    <PackageTags>Microsoft Azure Configuration AppConfig AppConfiguration</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -10,7 +10,7 @@
     <AssemblyOriginatorKeyFile>..\..\build\AzureAppConfiguration.snk</AssemblyOriginatorKeyFile>
     <AssemblyName>Microsoft.Extensions.Configuration.AzureAppConfiguration</AssemblyName>
     <PackageReleaseNotes>https://aka.ms/MicrosoftExtensionsConfigurationAzureAppConfigurationReleaseNotes</PackageReleaseNotes>
-    <PackageTags>Microsoft Azure Configuration AppConfig AppConfiguration</PackageTags>
+    <PackageTags>Microsoft Azure Configuration AppConfig AppConfiguration AzureAppConfiguration</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request adds package tags to the Nuget packages for App Configuration. These will show up on `nuget.org` for future releases. https://github.com/Azure/AppConfiguration-DotnetProvider/issues/195