### PR TITLE
ConfigureRefresh() throws in case of no refresh registration

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
             if (!refreshOptions.RefreshRegistrations.Any())
             {
-                throw new ArgumentException("ConfigureRefresh() must have at least one key-value registered for refresh.");
+                throw new ArgumentException($"{nameof(ConfigureRefresh)}() must have at least one key-value registered for refresh.");
             }
 
             foreach (var item in refreshOptions.RefreshRegistrations)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -264,6 +264,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             var refreshOptions = new AzureAppConfigurationRefreshOptions();
             configure?.Invoke(refreshOptions);
 
+            if (!refreshOptions.RefreshRegistrations.Any())
+            {
+                throw new ArgumentException("ConfigureRefresh() must have at least one key-value registered for refresh.");
+            }
+
             foreach (var item in refreshOptions.RefreshRegistrations)
             {
                 item.Value.CacheExpirationInterval = refreshOptions.CacheExpirationInterval;

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -904,6 +904,22 @@ namespace Tests.AzureAppConfiguration
             Assert.Throws<InvalidOperationException>(action);
         }
 
+        [Fact]
+        public void RefreshTests_ConfigureRefreshThrowsOnNoRegistration()
+        {
+            void action() => new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.SetCacheExpiration(TimeSpan.FromSeconds(1));
+                    });
+                })
+                .Build();
+
+            Assert.Throws<ArgumentException>(action);
+        }
+
         private void WaitAndRefresh(IConfigurationRefresher refresher, int millisecondsDelay)
         {
             Task.Delay(millisecondsDelay).Wait();


### PR DESCRIPTION
This pull request updates the configuration provider to throw when `ConfigureRefresh` is invoked with a callback that does not register any key-value for refresh https://github.com/Azure/AppConfiguration-DotnetProvider/issues/162