### PR TITLE
Allow refresh for key-values with same key but different labels

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         private const int MaxRetries = 2;
         private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(1);
 
-        private Dictionary<string, KeyValueWatcher> _changeWatchers = new Dictionary<string, KeyValueWatcher>();
+        private List<KeyValueWatcher> _changeWatchers = new List<KeyValueWatcher>();
         private List<KeyValueWatcher> _multiKeyWatchers = new List<KeyValueWatcher>();
         private List<IKeyValueAdapter> _adapters = new List<IKeyValueAdapter>() 
         { 
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// A collection of <see cref="KeyValueWatcher"/>.
         /// </summary>
-        internal IEnumerable<KeyValueWatcher> ChangeWatchers => _changeWatchers.Values;
+        internal IEnumerable<KeyValueWatcher> ChangeWatchers => _changeWatchers;
 
         /// <summary>
         /// A collection of <see cref="KeyValueWatcher"/>.
@@ -266,8 +266,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
             foreach (var item in refreshOptions.RefreshRegistrations)
             {
-                item.Value.CacheExpirationInterval = refreshOptions.CacheExpirationInterval;
-                _changeWatchers[item.Key] = item.Value;
+                item.CacheExpirationInterval = refreshOptions.CacheExpirationInterval;
+                _changeWatchers.Add(item);
             }
 
             return this;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefreshOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefreshOptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         internal static readonly TimeSpan MinimumCacheExpirationInterval = TimeSpan.FromMilliseconds(1000);
 
         internal TimeSpan CacheExpirationInterval { get; private set; } = DefaultCacheExpirationInterval;
-        internal IDictionary<string, KeyValueWatcher> RefreshRegistrations = new Dictionary<string, KeyValueWatcher>();
+        internal ISet<KeyValueWatcher> RefreshRegistrations = new HashSet<KeyValueWatcher>();
 
         /// <summary>
         /// Register the specified key-value to be refreshed when the configuration provider's <see cref="IConfigurationRefresher"/> triggers a refresh.
@@ -38,12 +38,17 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <param name="refreshAll">If true, a change in the value of this key refreshes all key-values being used by the configuration provider.</param>
         public AzureAppConfigurationRefreshOptions Register(string key, string label = LabelFilter.Null, bool refreshAll = false)
         {
-            RefreshRegistrations[key] = new KeyValueWatcher
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            RefreshRegistrations.Add(new KeyValueWatcher
             {
                 Key = key,
                 Label = label,
                 RefreshAll = refreshAll
-            };
+            });
 
             return this;
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
@@ -37,5 +37,26 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
         /// Semaphore that can be used to prevent simultaneous refresh of the key-value from multiple threads.
         /// </summary>
         public SemaphoreSlim Semaphore { get; } = new SemaphoreSlim(1);
+
+        public override int GetHashCode()
+        {
+            if (Label == null)
+            {
+                return Key.GetHashCode();
+            }
+
+            return Key.GetHashCode() ^ Label.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is KeyValueWatcher keyLabel)
+            {
+                return string.Equals(Key, keyLabel.Key, StringComparison.Ordinal)
+                    && string.Equals(Label, keyLabel.Label, StringComparison.Ordinal);
+            }
+
+            return false;
+        }
     }
 }

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -904,6 +904,19 @@ namespace Tests.AzureAppConfiguration
             Assert.Throws<InvalidOperationException>(action);
         }
 
+        [Fact]
+        public void RefreshTests_MultipleRefreshRegistrationsForSameKeyAndDifferentLabel()
+        {
+            var refreshOptions = new AzureAppConfigurationRefreshOptions()
+                .Register("TestKey")
+                .Register("TestKey", "Label 1")
+                .Register("TestKey", "Label 2")
+                .Register("TestKey", "Label 1")     // Duplicate registration
+                .Register("TestKey", "Label 2");    // Duplicate registration
+
+            Assert.Equal(3, refreshOptions.RefreshRegistrations.Count);
+        }
+
         private void WaitAndRefresh(IConfigurationRefresher refresher, int millisecondsDelay)
         {
             Task.Delay(millisecondsDelay).Wait();


### PR DESCRIPTION
This pull request contains changes to address issues https://github.com/Azure/AppConfiguration-DotnetProvider/issues/156 and https://github.com/Azure/AppConfiguration-DotnetProvider/issues/171.