### PR TITLE
Add AppConfig package source to NuGet.config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <add key="AppConfig" value="https://msazure.pkgs.visualstudio.com/c7c910ac-8ab2-4064-960f-8ab3c6d2b227/_packaging/AppConfig/nuget/v3/index.json" />
     <add key="Dev" value="https://msazure.pkgs.visualstudio.com/_packaging/Dev/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
This pull request adds an additional package source to `NuGet.config` to bypass the issue with conflicting package version `4.0.0` in the `Dev` feed. The new feed has been granted appropriate permissions to be accessed by our build pipeline.