### PR TITLE
Fix unit test failures

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -12,15 +12,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     internal static class TracingUtils
     {
-        static private HostType? _hostType = null;
-
         public static HostType GetHostType()
         {
-            if (_hostType.HasValue)
-            {
-                return _hostType.Value;
-            }
-
             HostType hostType = HostType.Unidentified;
 
             try
@@ -57,8 +50,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 }
             }
             catch (SecurityException) { }
-
-            _hostType = hostType;
 
             return hostType;
         }

--- a/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
@@ -296,7 +296,6 @@ namespace Tests.AzureAppConfiguration
             });
 
             Assert.NotNull(ex.InnerException);
-            Assert.IsType<AuthenticationFailedException>(ex.InnerException);
         }
 
         [Fact]


### PR DESCRIPTION
This pull request fixes issues with the following unit tests.

1. Tests.TestTurnOffRequestTracing
    This test currently fails when run alongside other tests.

2. KeyVaultReferenceTests.ServerRequestIsMadeWhenDefaultCredentialIsSet
    This test currently returns a different inner exception based on the user identity that invoked the test.