### PR TITLE
Update regular expression in user agent test

### DIFF
--- a/tests/Tests.AzureAppConfiguration/Tests.cs
+++ b/tests/Tests.AzureAppConfiguration/Tests.cs
@@ -191,7 +191,7 @@ namespace Tests.AzureAppConfiguration
             // 4. Contains the name and version of the App Configuration SDK package
             // 5. Contains the runtime information (target framework, OS description etc.) in the format set by the SDK
             // 6. Does not contain any additional components
-            string userAgentRegex = @"^Microsoft\.Extensions\.Configuration\.AzureAppConfiguration/\d+\.\d+\.\d+(-preview-\d+-\d+)?,azsdk-net-Data.AppConfiguration/[.+\w]+ \([.;\w\s]+\)$";
+            string userAgentRegex = @"^Microsoft\.Extensions\.Configuration\.AzureAppConfiguration/\d+\.\d+\.\d+(-preview)?(-\d+-\d+)?,azsdk-net-Data.AppConfiguration/[.+\w]+ \([.;\w\s]+\)$";
             
             var response = new MockResponse(200);
             response.SetContent(SerializationHelpers.Serialize(_kvCollectionPageOne.ToArray(), TestHelpers.SerializeBatch));


### PR DESCRIPTION
This pull request updates the unit test for user agent header to allow package versions such as `4.0.0-014180003-405` to be considered valid. This is needed to unblock test validation for non-official builds.