### PR TITLE
Remove Dev feed source from NuGet.config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <add key="AppConfig" value="https://msazure.pkgs.visualstudio.com/c7c910ac-8ab2-4064-960f-8ab3c6d2b227/_packaging/AppConfig/nuget/v3/index.json" />
-    <add key="Dev" value="https://msazure.pkgs.visualstudio.com/_packaging/Dev/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This pull request removes the `Dev` feed from the list of package sources in `NuGet.Config`. Based on response from the OneBranch team, it is not suggested to consume packages from this feed for production builds. We will continue to use the `AppConfig` feed for our future releases, similar to our latest `4.0.0` release. In the future, we will also replace the `nuget.org` feed with its internal mirror.