### PR TITLE
Add sentinel keys and filter keys support on feature flags

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 var serverData = new Dictionary<string, ConfigurationSetting>(StringComparer.OrdinalIgnoreCase);
 
                 // Use default query if there are no key-values specified for use other than the feature flags
-                bool useDefaultQuery = !_options.KeyValueSelectors.Any(selector => !selector.KeyFilter.StartsWith(FeatureManagementConstants.FeatureFlagMarker));
+                bool useDefaultQuery = !_options.KeyValueSelectors.Any(selector => selector.KeyFilter != FeatureManagementConstants.FeatureFlagMarker + "*");
 
                 if (useDefaultQuery)
                 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 //
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
@@ -10,6 +11,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
     /// </summary>
     public class FeatureFlagOptions
     {
+        internal List<string> FeatureFlagKeyFilters { get; } = new List<string>();
+        internal IList<string> RefreshRegistrationKeys = new List<string>();
+
         /// <summary>
         /// The label that feature flags will be selected from.
         /// </summary>
@@ -19,5 +23,32 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         /// The time after which the cached values of the feature flags expire.  Must be greater than or equal to 1 second.
         /// </summary>
         public TimeSpan CacheExpirationInterval { get; set; } = AzureAppConfigurationOptions.DefaultFeatureFlagsCacheExpirationInterval;
+
+        /// <summary>
+        /// Specify what feature flags to include in the configuration provider.
+        /// <see cref="Select"/> can be called multiple times to include multiple sets of key-values.
+        /// If <see cref="Select"/> is not called, all the feature flags found are included.
+        /// </summary>
+        /// <param name="featureFlagKeyFilter">
+        /// The key filter to apply when querying Azure App Configuration for key-values.
+        /// The characters asterisk (*), comma (,) and backslash (\) are reserved and must be escaped using a backslash (\).
+        /// Built-in key filter options: <see cref="KeyFilter"/>.
+        /// </param>
+        public FeatureFlagOptions Select(string featureFlagKeyFilter)
+        {
+            FeatureFlagKeyFilters.Add(featureFlagKeyFilter);
+            return this;
+        }
+
+        /// <summary>
+        /// Register the specified key that will refresh all feature flags being used by the configuration provider when the configuration provider's <see cref="IConfigurationRefresher"/> triggers a refresh.
+        /// The <see cref="IConfigurationRefresher"/> instance can be obtained by calling <see cref="AzureAppConfigurationOptions.GetRefresher()"/>.
+        /// </summary>
+        /// <param name="key">Key of the key-value.</param>
+        public FeatureFlagOptions RegisterRefreshKey(string key)
+        {
+            RefreshRegistrationKeys.Add(key);
+            return this;
+        }
     }
 }

--- a/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/MockResponse.cs
+++ b/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/MockResponse.cs
@@ -91,6 +91,8 @@ namespace Azure.Core.Testing
     class MockResponse<T> : Response<T>
     {
         private T _value;
+        private readonly Response _rawResponse;
+
         public override T Value => _value;
 
         public MockResponse(T value)
@@ -98,9 +100,15 @@ namespace Azure.Core.Testing
             _value = value;
         }
 
+        public MockResponse(T value, Response rawResponse)
+        {
+            _value = value;
+            _rawResponse = rawResponse;
+        }
+
         public override Response GetRawResponse()
         {
-            throw new NotImplementedException();
+            return _rawResponse ?? throw new NotImplementedException();
         }
     }
 }

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -12,7 +12,9 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Tests.AzureAppConfiguration
@@ -89,7 +91,9 @@ namespace Tests.AzureAppConfiguration
 
             var featureFlags = new List<ConfigurationSetting> { _kv };
 
-            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(
+                It.Is<SettingSelector>(settingsSelector => settingsSelector.KeyFilter == "*"),
+                It.IsAny<CancellationToken>()))
                 .Returns(new MockAsyncPageable(featureFlags));
 
             var testClient = mockClient.Object;
@@ -112,6 +116,41 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("TimeWindow", config["FeatureManagement:Beta:EnabledFor:3:Name"]);
             Assert.Equal("/Date(1578643200000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:Start"]);
             Assert.Equal("/Date(1578686400000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:End"]);
+        }
+
+        [Fact]
+        public void UsesOnlySelectedFeatureFlags()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, TestHelpers.CreateMockEndpointString());
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(
+                    It.Is<SettingSelector>(settingsSelector => settingsSelector.KeyFilter == ".appconfig.featureflag/Beta"),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new MockAsyncPageable(new List<ConfigurationSetting> { _kv }));
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(
+                    It.Is<SettingSelector>(settingsSelector => settingsSelector.KeyFilter == ".appconfig.featureflag/MyFeature2"),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new MockAsyncPageable(new List<ConfigurationSetting> { _kv2 }));
+
+            var testClient = mockClient.Object;
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = testClient;
+                    options.UseFeatureFlags(options =>
+                    {
+                        options.Select("Beta");
+                        options.Select("MyFeature2");
+                    });
+                })
+                .Build();
+
+            Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
+
+            Assert.Equal("SuperUsers", config["FeatureManagement:MyFeature2:EnabledFor:0:Name"]);
         }
 
         [Fact]
@@ -250,6 +289,100 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("Firefox", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
             Assert.Equal("Safari", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
             Assert.Null(config["FeatureManagement:MyFeature2:EnabledFor:0:Name"]);
+        }
+
+        [Fact]
+        public void WatchesFeatureFlagsUsingRefreshKeys()
+        {
+            var featureFlags = new List<ConfigurationSetting> { _kv };
+
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, TestHelpers.CreateMockEndpointString());
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(new MockAsyncPageable(featureFlags));
+
+            var refreshKeyConfigurationSetting = new ConfigurationSetting("MyRefreshKey", "1");
+
+            mockClient.Setup(c => c.GetConfigurationSettingAsync("MyRefreshKey", LabelFilter.Null, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<Response<ConfigurationSetting>>(new MockResponse<ConfigurationSetting>(refreshKeyConfigurationSetting)));
+
+            IConfigurationRefresher refresher = null;
+            var cacheExpirationTimeSpan = TimeSpan.FromSeconds(1);
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = mockClient.Object; ;
+                    options.UseFeatureFlags(o =>
+                    {
+                        o.CacheExpirationInterval = cacheExpirationTimeSpan;
+                        o.RegisterRefreshKey("MyRefreshKey");
+                    });
+
+                    refresher = options.GetRefresher();
+                })
+                .Build();
+
+            Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
+            Assert.Equal("Firefox", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Safari", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
+            Assert.Equal("RollOut", config["FeatureManagement:Beta:EnabledFor:1:Name"]);
+            Assert.Equal("20", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Percentage"]);
+            Assert.Equal("US", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Region"]);
+            Assert.Equal("SuperUsers", config["FeatureManagement:Beta:EnabledFor:2:Name"]);
+            Assert.Equal("TimeWindow", config["FeatureManagement:Beta:EnabledFor:3:Name"]);
+            Assert.Equal("/Date(1578643200000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:Start"]);
+            Assert.Equal("/Date(1578686400000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:End"]);
+
+            featureFlags[0] = ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "myFeature",
+                value: @"
+                        {
+                          ""id"": ""Beta"",
+                          ""description"": ""The new beta version of our web site."",
+                          ""display_name"": ""Beta Feature"",
+                          ""enabled"": true,
+                          ""conditions"": {
+                            ""client_filters"": [
+                              {
+                                ""name"": ""Browser"",
+                                ""parameters"": {
+                                  ""AllowedBrowsers"": [ ""Chrome"", ""Edge"" ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                        ",
+                label: default,
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1" + "f"));
+
+            featureFlags.Add(_kv2);
+
+            // Wait for the cache to expire
+            Thread.Sleep(cacheExpirationTimeSpan);
+
+            mockClient.Setup(c => c.GetConfigurationSettingAsync(refreshKeyConfigurationSetting, true, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<Response<ConfigurationSetting>>(new MockResponse<ConfigurationSetting>(refreshKeyConfigurationSetting, new MockResponse((int)HttpStatusCode.NoContent))));
+            refresher.RefreshAsync().Wait();
+
+            // Values should not have changed as the returned status code is not 200 OK
+            Assert.Equal("Firefox", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Safari", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
+
+            // Wait for the cache to expire
+            Thread.Sleep(cacheExpirationTimeSpan);
+
+            mockClient.Setup(c => c.GetConfigurationSettingAsync(refreshKeyConfigurationSetting, true, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<Response<ConfigurationSetting>>(new MockResponse<ConfigurationSetting>(refreshKeyConfigurationSetting, new MockResponse((int)HttpStatusCode.OK))));
+            refresher.RefreshAsync().Wait();
+
+            // Values should have changed as the returned status code is 200 OK
+            Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
+            Assert.Equal("Chrome", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Edge", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
+            Assert.Equal("SuperUsers", config["FeatureManagement:MyFeature2:EnabledFor:0:Name"]);
         }
 
         [Fact]


### PR DESCRIPTION
Hello !

This pull request aims to implement both sentinel and filter keys for feature flags.

The purpose has been explained in this issue: #163 

Developers should be able to opt-in independently to filter keys and refresh keys by calling respectively `Select` and `RegisterRefreshKey`. When enabled, it disables the "global" selection and "global" refresh.

Thank you for your consideration.