### PR TITLE
Maintain nuget version for AspNetCore and base package separately

### DIFF
--- a/build/NugetProperties.props
+++ b/build/NugetProperties.props
@@ -10,6 +10,10 @@
     <PackageIconUrl>https://aka.ms/AzureAppConfigurationPackageIcon</PackageIconUrl>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'==''">
+    <Version>4.9.9999</Version>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'!='Official'">
     <!-- Note that CDP_PACKAGE_VERSION_NUMERIC uses format Major.Minor.MMddyyrrrr, which causes compile error CS7034 because .NET Core doesn't allow version numbers higher than 65534. -->
     <!-- CDP_PATCH_NUMBER is updated daily by the build system, the addition of a revision number makes the build number unique by the minute -->
@@ -22,5 +26,4 @@
     <Floored>$([System.Math]::Floor($(MinutesSinceMidnight)))</Floored>
     <Revision>$(Floored)</Revision>
   </PropertyGroup>
-
 </Project>

--- a/build/NugetProperties.props
+++ b/build/NugetProperties.props
@@ -9,4 +9,18 @@
     <PackageLicenseUrl>https://aka.ms/AzureAppConfigurationDotnetCorePublicPreviewEula</PackageLicenseUrl>
     <PackageIconUrl>https://aka.ms/AzureAppConfigurationPackageIcon</PackageIconUrl>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'!='Official'">
+    <!-- Note that CDP_PACKAGE_VERSION_NUMERIC uses format Major.Minor.MMddyyrrrr, which causes compile error CS7034 because .NET Core doesn't allow version numbers higher than 65534. -->
+    <!-- CDP_PATCH_NUMBER is updated daily by the build system, the addition of a revision number makes the build number unique by the minute -->
+    <!-- The revision number is the number of minutes since midnight [0, 1440) -->
+    <!-- Example build number, 1.0.573.1227 -->
+    <NowTicks>$([System.DateTime]::Now.Ticks)</NowTicks>
+    <TodayTicks>$([System.DateTime]::Today.Ticks)</TodayTicks>
+    <TicksSinceMidnight>$([MSBuild]::Subtract($(NowTicks), $(TodayTicks)))</TicksSinceMidnight>
+    <MinutesSinceMidnight>$([MSBuild]::Divide($(TicksSinceMidnight), 600000000))</MinutesSinceMidnight>
+    <Floored>$([System.Math]::Floor($(MinutesSinceMidnight)))</Floored>
+    <Revision>$(Floored)</Revision>
+  </PropertyGroup>
+
 </Project>

--- a/build/NugetProperties.props
+++ b/build/NugetProperties.props
@@ -9,26 +9,4 @@
     <PackageLicenseUrl>https://aka.ms/AzureAppConfigurationDotnetCorePublicPreviewEula</PackageLicenseUrl>
     <PackageIconUrl>https://aka.ms/AzureAppConfigurationPackageIcon</PackageIconUrl>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'==''">
-    <Version>4.9.9999</Version>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'=='Official'">
-    <Version>4.1.0</Version>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'!='Official'">
-    <!-- Note that CDP_PACKAGE_VERSION_NUMERIC uses format Major.Minor.MMddyyrrrr, which causes compile error CS7034 because .NET Core doesn't allow version numbers higher than 65534. -->
-    <!-- CDP_PATCH_NUMBER is updated daily by the build system, the addition of a revision number makes the build number unique by the minute -->
-    <!-- The revision number is the number of minutes since midnight [0, 1440) -->
-    <!-- Example build number, 1.0.573.1227 -->
-    <NowTicks>$([System.DateTime]::Now.Ticks)</NowTicks>
-    <TodayTicks>$([System.DateTime]::Today.Ticks)</TodayTicks>
-    <TicksSinceMidnight>$([MSBuild]::Subtract($(NowTicks), $(TodayTicks)))</TicksSinceMidnight>
-    <MinutesSinceMidnight>$([MSBuild]::Divide($(TicksSinceMidnight), 600000000))</MinutesSinceMidnight>
-    <Floored>$([System.Math]::Floor($(MinutesSinceMidnight)))</Floored>
-    <Revision>$(Floored)</Revision>
-    <Version>4.1.0-$(CDP_PATCH_NUMBER)-$(Revision)</Version>
-  </PropertyGroup>
 </Project>

--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
@@ -27,16 +27,16 @@
 
   <!-- Nuget Package Version Settings -->
 
-  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'==''">
-    <Version>4.9.9999</Version>
+  <PropertyGroup>
+    <OfficialVersion>4.1.0</OfficialVersion>
   </PropertyGroup>
-
+  
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'=='Official'">
-    <Version>4.1.0</Version>
+    <Version>$(OfficialVersion)</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'!='Official'">
-    <Version>4.1.0-$(CDP_PATCH_NUMBER)-$(Revision)</Version>
+    <Version>$(OfficialVersion)-$(CDP_PATCH_NUMBER)-$(Revision)</Version>
   </PropertyGroup>
   
 </Project>

--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
@@ -36,16 +36,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'!='Official'">
-    <!-- Note that CDP_PACKAGE_VERSION_NUMERIC uses format Major.Minor.MMddyyrrrr, which causes compile error CS7034 because .NET Core doesn't allow version numbers higher than 65534. -->
-    <!-- CDP_PATCH_NUMBER is updated daily by the build system, the addition of a revision number makes the build number unique by the minute -->
-    <!-- The revision number is the number of minutes since midnight [0, 1440) -->
-    <!-- Example build number, 1.0.573.1227 -->
-    <NowTicks>$([System.DateTime]::Now.Ticks)</NowTicks>
-    <TodayTicks>$([System.DateTime]::Today.Ticks)</TodayTicks>
-    <TicksSinceMidnight>$([MSBuild]::Subtract($(NowTicks), $(TodayTicks)))</TicksSinceMidnight>
-    <MinutesSinceMidnight>$([MSBuild]::Divide($(TicksSinceMidnight), 600000000))</MinutesSinceMidnight>
-    <Floored>$([System.Math]::Floor($(MinutesSinceMidnight)))</Floored>
-    <Revision>$(Floored)</Revision>
     <Version>4.1.0-$(CDP_PATCH_NUMBER)-$(Revision)</Version>
   </PropertyGroup>
   

--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
@@ -24,4 +24,29 @@
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
+
+  <!-- Nuget Package Version Settings -->
+
+  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'==''">
+    <Version>4.9.9999</Version>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'=='Official'">
+    <Version>4.1.0</Version>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'!='Official'">
+    <!-- Note that CDP_PACKAGE_VERSION_NUMERIC uses format Major.Minor.MMddyyrrrr, which causes compile error CS7034 because .NET Core doesn't allow version numbers higher than 65534. -->
+    <!-- CDP_PATCH_NUMBER is updated daily by the build system, the addition of a revision number makes the build number unique by the minute -->
+    <!-- The revision number is the number of minutes since midnight [0, 1440) -->
+    <!-- Example build number, 1.0.573.1227 -->
+    <NowTicks>$([System.DateTime]::Now.Ticks)</NowTicks>
+    <TodayTicks>$([System.DateTime]::Today.Ticks)</TodayTicks>
+    <TicksSinceMidnight>$([MSBuild]::Subtract($(NowTicks), $(TodayTicks)))</TicksSinceMidnight>
+    <MinutesSinceMidnight>$([MSBuild]::Divide($(TicksSinceMidnight), 600000000))</MinutesSinceMidnight>
+    <Floored>$([System.Math]::Floor($(MinutesSinceMidnight)))</Floored>
+    <Revision>$(Floored)</Revision>
+    <Version>4.1.0-$(CDP_PATCH_NUMBER)-$(Revision)</Version>
+  </PropertyGroup>
+  
 </Project>

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -31,16 +31,16 @@
   
   <!-- Nuget Package Version Settings -->
   
-  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'==''">
-    <Version>4.9.9999</Version>
+  <PropertyGroup>
+    <OfficialVersion>4.1.0</OfficialVersion>
   </PropertyGroup>
-
+  
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'=='Official'">
-    <Version>4.1.0</Version>
+    <Version>$(OfficialVersion)</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'!='Official'">
-    <Version>4.1.0-$(CDP_PATCH_NUMBER)-$(Revision)</Version>
+    <Version>$(OfficialVersion)-$(CDP_PATCH_NUMBER)-$(Revision)</Version>
   </PropertyGroup>
-
+  
 </Project>

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -40,16 +40,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'!='Official'">
-    <!-- Note that CDP_PACKAGE_VERSION_NUMERIC uses format Major.Minor.MMddyyrrrr, which causes compile error CS7034 because .NET Core doesn't allow version numbers higher than 65534. -->
-    <!-- CDP_PATCH_NUMBER is updated daily by the build system, the addition of a revision number makes the build number unique by the minute -->
-    <!-- The revision number is the number of minutes since midnight [0, 1440) -->
-    <!-- Example build number, 1.0.573.1227 -->
-    <NowTicks>$([System.DateTime]::Now.Ticks)</NowTicks>
-    <TodayTicks>$([System.DateTime]::Today.Ticks)</TodayTicks>
-    <TicksSinceMidnight>$([MSBuild]::Subtract($(NowTicks), $(TodayTicks)))</TicksSinceMidnight>
-    <MinutesSinceMidnight>$([MSBuild]::Divide($(TicksSinceMidnight), 600000000))</MinutesSinceMidnight>
-    <Floored>$([System.Math]::Floor($(MinutesSinceMidnight)))</Floored>
-    <Revision>$(Floored)</Revision>
     <Version>4.1.0-$(CDP_PATCH_NUMBER)-$(Revision)</Version>
   </PropertyGroup>
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -28,5 +28,29 @@
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
     <Copy SourceFiles="$(DocumentationFile)" DestinationFolder="$(OutDir)\XMLComments" SkipUnchangedFiles="false" />
   </Target>
+  
+  <!-- Nuget Package Version Settings -->
+  
+  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'==''">
+    <Version>4.9.9999</Version>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'=='Official'">
+    <Version>4.1.0</Version>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'!='Official'">
+    <!-- Note that CDP_PACKAGE_VERSION_NUMERIC uses format Major.Minor.MMddyyrrrr, which causes compile error CS7034 because .NET Core doesn't allow version numbers higher than 65534. -->
+    <!-- CDP_PATCH_NUMBER is updated daily by the build system, the addition of a revision number makes the build number unique by the minute -->
+    <!-- The revision number is the number of minutes since midnight [0, 1440) -->
+    <!-- Example build number, 1.0.573.1227 -->
+    <NowTicks>$([System.DateTime]::Now.Ticks)</NowTicks>
+    <TodayTicks>$([System.DateTime]::Today.Ticks)</TodayTicks>
+    <TicksSinceMidnight>$([MSBuild]::Subtract($(NowTicks), $(TodayTicks)))</TicksSinceMidnight>
+    <MinutesSinceMidnight>$([MSBuild]::Divide($(TicksSinceMidnight), 600000000))</MinutesSinceMidnight>
+    <Floored>$([System.Math]::Floor($(MinutesSinceMidnight)))</Floored>
+    <Revision>$(Floored)</Revision>
+    <Version>4.1.0-$(CDP_PATCH_NUMBER)-$(Revision)</Version>
+  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Instead of having a common nuget package version for both `Microsoft.Extensions.Configuration.AzureAppConfiguration` and `Microsoft.Azure.AppConfiguration.AspNetCore` packages, we can maintain the version separately for both projects. This would prevent accidentally publishing a new package of AspNetCore without changing the base package version reference.