### PR TITLE
allow user defined keyvalueadapters to be added to the pipeline

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// A collection of <see cref="IKeyValueAdapter"/>.
         /// </summary>
-        internal IEnumerable<IKeyValueAdapter> Adapters
+        public IEnumerable<IKeyValueAdapter> Adapters
         {
             get => _adapters;
             set => _adapters = value?.ToList();

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
-    internal interface IKeyValueAdapter
+    public interface IKeyValueAdapter
     {
         Task<IEnumerable<KeyValuePair<string, string>>> ProcessKeyValue(ConfigurationSetting setting, CancellationToken cancellationToken);
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
@@ -8,10 +8,24 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
+    /// <summary>
+    /// Defines the necessary interface to process configuration settings into key value pairs
+    /// </summary>
     public interface IKeyValueAdapter
     {
+        /// <summary>
+        /// Processed settings into key value pairs
+        /// </summary>
+        /// <param name="setting">The <see cref="ConfigurationSetting"/> to be processed</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The processed settings</returns>
         Task<IEnumerable<KeyValuePair<string, string>>> ProcessKeyValue(ConfigurationSetting setting, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Whether the setting can be processed by the adapter
+        /// </summary>
+        /// <param name="setting">The <see cref="ConfigurationSetting"/> in question</param>
+        /// <returns>A flag</returns>
         bool CanProcess(ConfigurationSetting setting);
     }
 }


### PR DESCRIPTION
This pr allows users create and add IKeyValueAdapters to the configuration pipeline.

I created this pr after an issue I had with a .Net 5 app that uses an existing configuration container.  The values in this container are used by both standard .Net framework apps and .Net 5 apps.  I found that any value in a configuration section wouldn't be overridden due to a mismatch in keys.  This mismatch is simply caused by the different way the frameworks handle configuration values.  Instead of having to duplicate hundreds of keys, I was able to write a keyvalueadapter to handle this scenario with this pr.