### PR TITLE
Support prefix filtering and prefix trimming from feature flags

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -14,7 +14,6 @@ using System.Linq;
 using System.Net;
 using System.Security;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -468,9 +467,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     if (changeWatcher.Key.EndsWith("*"))
                     {
                         // Get current application settings starting with changeWatcher.Key, excluding the last * character
+                        var keyPrefix = changeWatcher.Key.Substring(0, changeWatcher.Key.Length - 1);
                         currentKeyValues = _applicationSettings.Values.Where(kv =>
                         {
-                            return kv.Key.StartsWith(changeWatcher.Key.Substring(0, changeWatcher.Key.Length - 1)) && kv.Label == changeWatcher.Label.NormalizeNull();
+                            return kv.Key.StartsWith(keyPrefix) && kv.Label == changeWatcher.Label.NormalizeNull();
                         });
                     }
                     else

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -465,11 +465,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 {
                     IEnumerable<ConfigurationSetting> currentKeyValues;
 
-                    // Check if the user-provided feature flag filter ends with an unescaped * character:
-                    // (?<!\\)    Matches if the preceding character is not a backslash
-                    // (?:\\\\)*  Matches any number of occurrences of two backslashes
-                    // \*$        Matches if * is the last character
-                    if (Regex.IsMatch(changeWatcher.Key, @"(?<!\\)(?:\\\\)*\*$"))
+                    if (changeWatcher.Key.EndsWith("*"))
                     {
                         // Get current application settings starting with changeWatcher.Key, excluding the last * character
                         currentKeyValues = _applicationSettings.Values.Where(kv =>
@@ -487,7 +483,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
                     IEnumerable<KeyValueChange> keyValueChanges = await _client.GetKeyValueChangeCollection(currentKeyValues, new GetKeyValueChangeCollectionOptions
                     {
-                        Prefix = changeWatcher.Key,
+                        KeyFilter = changeWatcher.Key,
                         Label = changeWatcher.Label.NormalizeNull(),
                         RequestTracingEnabled = _requestTracingEnabled,
                         HostType = _hostType

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
@@ -77,19 +77,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                 options.Prefix = string.Empty;
             }
 
-            if (options.Prefix.Contains('*'))
-            {
-                throw new ArgumentException("The prefix cannot contain '*'", $"{nameof(options)}.{nameof(options.Prefix)}");
-            }
-
             if (keyValues.Any(k => string.IsNullOrEmpty(k.Key)))
             {
                 throw new ArgumentNullException($"{nameof(keyValues)}[].{nameof(ConfigurationSetting.Key)}");
-            }
-
-            if (!string.IsNullOrEmpty(options.Prefix) && keyValues.Any(k => !k.Key.StartsWith(options.Prefix)))
-            {
-                throw new ArgumentException("All key-values registered for refresh must start with the provided prefix.", $"{nameof(keyValues)}[].{nameof(ConfigurationSetting.Key)}");
             }
 
             if (keyValues.Any(k => !string.Equals(k.Label.NormalizeNull(), options.Label.NormalizeNull())))
@@ -105,7 +95,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
             var hasKeyValueCollectionChanged = false;
             var selector = new SettingSelector
             {
-                KeyFilter = options.Prefix + "*",
+                KeyFilter = options.Prefix,
                 LabelFilter = string.IsNullOrEmpty(options.Label) ? LabelFilter.Null : options.Label,
                 Fields = SettingFields.ETag | SettingFields.Key
             };
@@ -142,7 +132,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
             {
                 selector = new SettingSelector
                 {
-                    KeyFilter = options.Prefix + "*",
+                    KeyFilter = options.Prefix,
                     LabelFilter = string.IsNullOrEmpty(options.Label) ? LabelFilter.Null : options.Label
                 };
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
@@ -72,9 +72,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                 keyValues = Enumerable.Empty<ConfigurationSetting>();
             }
 
-            if (options.Prefix == null)
+            if (options.KeyFilter == null)
             {
-                options.Prefix = string.Empty;
+                options.KeyFilter = string.Empty;
             }
 
             if (keyValues.Any(k => string.IsNullOrEmpty(k.Key)))
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
             var hasKeyValueCollectionChanged = false;
             var selector = new SettingSelector
             {
-                KeyFilter = options.Prefix,
+                KeyFilter = options.KeyFilter,
                 LabelFilter = string.IsNullOrEmpty(options.Label) ? LabelFilter.Null : options.Label,
                 Fields = SettingFields.ETag | SettingFields.Key
             };
@@ -132,7 +132,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
             {
                 selector = new SettingSelector
                 {
-                    KeyFilter = options.Prefix,
+                    KeyFilter = options.KeyFilter,
                     LabelFilter = string.IsNullOrEmpty(options.Label) ? LabelFilter.Null : options.Label
                 };
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using Microsoft.Extensions.Configuration.AzureAppConfiguration.Models;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
@@ -10,10 +13,22 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
     /// </summary>
     public class FeatureFlagOptions
     {
+        private SortedSet<string> _featureFlagPrefixes = new SortedSet<string>(Comparer<string>.Create((k1, k2) => -string.Compare(k1, k2, StringComparison.OrdinalIgnoreCase)));
+
+        /// <summary>
+        /// A collection of key prefixes to be trimmed.
+        /// </summary>
+        internal IEnumerable<string> FeatureFlagPrefixes => _featureFlagPrefixes;
+
+        /// <summary>
+        /// A collection of <see cref="KeyValueSelector"/>.
+        /// </summary>
+        internal List<KeyValueSelector> FeatureFlagSelectors = new List<KeyValueSelector>();
+
         /// <summary>
         /// The label that feature flags will be selected from.
         /// </summary>
-        public string Label { get; set; } = LabelFilter.Null;
+        public string Label { get; set; }
 
         /// <summary>
         /// The time after which the cached values of the feature flags expire.  Must be greater than or equal to 1 second.
@@ -21,9 +36,67 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         public TimeSpan CacheExpirationInterval { get; set; } = AzureAppConfigurationOptions.DefaultFeatureFlagsCacheExpirationInterval;
 
         /// <summary>
-        /// Selectively load only those feature flags which begin with this prefix.
-        /// The characters asterisk (*), comma (,) and backslash (\) are reserved and must be escaped using a backslash (\).
+        /// Specify what feature flags to include in the configuration provider.
+        /// <see cref="Select"/> can be called multiple times to include multiple sets of feature flags.
         /// </summary>
-        public string Prefix { get; set; } = string.Empty;
+        /// <param name="featureFlagFilter">
+        /// The filter to apply to feature flag names when querying Azure App Configuration for feature flags.
+        /// For example, you can select all feature flags that begin with "MyApp" by setting the featureflagFilter to "MyApp*". 
+        /// The characters asterisk (*), comma (,) and backslash (\) are reserved and must be escaped using a backslash (\).
+        /// Built-in feature flag filter options: <see cref="KeyFilter"/>.
+        /// </param>
+        /// <param name="labelFilter">
+        /// The label filter to apply when querying Azure App Configuration for feature flags. By default the null label will be used. Built-in label filter options: <see cref="LabelFilter"/>
+        /// The characters asterisk (*) and comma (,) are not supported. Backslash (\) character is reserved and must be escaped using another backslash (\).
+        /// </param>
+        public FeatureFlagOptions Select(string featureFlagFilter, string labelFilter = LabelFilter.Null)
+        {
+            if (string.IsNullOrEmpty(featureFlagFilter))
+            {
+                throw new ArgumentNullException(nameof(featureFlagFilter));
+            }
+
+            if (labelFilter == null)
+            {
+                labelFilter = LabelFilter.Null;
+            }
+
+            // Do not support * and , for label filter for now.
+            if (labelFilter.Contains('*') || labelFilter.Contains(','))
+            {
+                throw new ArgumentException("The characters '*' and ',' are not supported in label filters.", nameof(labelFilter));
+            }
+
+            string featureFlagPrefix = FeatureManagementConstants.FeatureFlagMarker + featureFlagFilter;
+
+            if (!FeatureFlagSelectors.Any(s => s.KeyFilter.Equals(featureFlagPrefix) && s.LabelFilter.Equals(labelFilter)))
+            {
+                FeatureFlagSelectors.Add(new KeyValueSelector
+                {
+                    KeyFilter = featureFlagPrefix,
+                    LabelFilter = labelFilter
+                });
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Trims the provided prefix from the keys of all feature flags retrieved from Azure App Configuration.
+        /// </summary>
+        /// <remarks>
+        /// For example, you can trim the prefix "MyApp" from all feature flags by setting the prefix to "MyApp". 
+        /// </remarks>
+        /// <param name="prefix">The prefix to be trimmed.</param>
+        public FeatureFlagOptions TrimFeatureFlagPrefix(string prefix)
+        {
+            if (string.IsNullOrEmpty(prefix))
+            {
+                throw new ArgumentNullException(nameof(prefix));
+            }
+
+            _featureFlagPrefixes.Add(prefix);
+            return this;
+        }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
@@ -13,12 +13,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
     /// </summary>
     public class FeatureFlagOptions
     {
-        private SortedSet<string> _featureFlagPrefixes = new SortedSet<string>(Comparer<string>.Create((k1, k2) => -string.Compare(k1, k2, StringComparison.OrdinalIgnoreCase)));
-
         /// <summary>
         /// A collection of key prefixes to be trimmed.
         /// </summary>
-        internal IEnumerable<string> FeatureFlagPrefixes => _featureFlagPrefixes;
+        internal List<string> FeatureFlagPrefixes = new List<string>();
 
         /// <summary>
         /// A collection of <see cref="KeyValueSelector"/>.
@@ -54,6 +52,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
             if (string.IsNullOrEmpty(featureFlagFilter))
             {
                 throw new ArgumentNullException(nameof(featureFlagFilter));
+            }
+
+            if (featureFlagFilter.EndsWith(@"\*"))
+            {
+                throw new ArgumentException(@"Feature flag filter should not end with '\*'.", nameof(featureFlagFilter));
             }
 
             if (labelFilter == null)
@@ -95,7 +98,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                 throw new ArgumentNullException(nameof(prefix));
             }
 
-            _featureFlagPrefixes.Add(prefix);
+            FeatureFlagPrefixes.Add(prefix);
             return this;
         }
     }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
@@ -19,5 +19,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         /// The time after which the cached values of the feature flags expire.  Must be greater than or equal to 1 second.
         /// </summary>
         public TimeSpan CacheExpirationInterval { get; set; } = AzureAppConfigurationOptions.DefaultFeatureFlagsCacheExpirationInterval;
+
+        /// <summary>
+        /// Selectively load only those feature flags which begin with this prefix.
+        /// The characters asterisk (*), comma (,) and backslash (\) are reserved and must be escaped using a backslash (\).
+        /// </summary>
+        public string Prefix { get; set; } = string.Empty;
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/GetKeyValueChangeCollectionOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/GetKeyValueChangeCollectionOptions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     internal class GetKeyValueChangeCollectionOptions
     {
-        public string Prefix { get; set; }
+        public string KeyFilter { get; set; }
         public string Label { get; set; }
         public bool RequestTracingEnabled { get; set; }
         public HostType HostType { get; set; }

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -81,6 +81,101 @@ namespace Tests.AzureAppConfiguration
             contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
             eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
 
+        List<ConfigurationSetting> _featureFlagCollection = new List<ConfigurationSetting>
+        {
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "App1_Feature1",
+                value: @"
+                        {
+                          ""id"": ""App1_Feature1"",
+                          ""enabled"": true,
+                          ""conditions"": {
+                            ""client_filters"": []
+                          }
+                        }
+                        ",
+                label: "App1_Label",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "App1_Feature2",
+                value: @"
+                        {
+                          ""id"": ""App1_Feature2"",
+                          ""enabled"": false,
+                          ""conditions"": {
+                            ""client_filters"": []
+                          }
+                        }
+                        ",
+                label: "App1_Label",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "Feature1",
+                value: @"
+                        {
+                          ""id"": ""Feature1"",
+                          ""enabled"": false,
+                          ""conditions"": {
+                            ""client_filters"": []
+                          }
+                        }
+                        ",
+                label: "App1_Label",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "App2_Feature1",
+                value: @"
+                        {
+                          ""id"": ""App2_Feature1"",
+                          ""enabled"": false,
+                          ""conditions"": {
+                            ""client_filters"": []
+                          }
+                        }
+                        ",
+                label: "App2_Label",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "App2_Feature2",
+                value: @"
+                        {
+                          ""id"": ""App2_Feature2"",
+                          ""enabled"": true,
+                          ""conditions"": {
+                            ""client_filters"": []
+                          }
+                        }
+                        ",
+                label: "App2_Label",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "Feature1",
+                value: @"
+                        {
+                          ""id"": ""Feature1"",
+                          ""enabled"": true,
+                          ""conditions"": {
+                            ""client_filters"": []
+                          }
+                        }
+                        ",
+                label: "App2_Label",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+        };
+
+        ConfigurationSetting FirstFeatureFlag => _featureFlagCollection.First();
+
         [Fact]
         public void UsesFeatureFlags()
         {
@@ -331,6 +426,345 @@ namespace Tests.AzureAppConfiguration
 
             refresher.TryRefreshAsync().Wait();
             mockClient.Verify(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void PrefixFilterFeatureFlags()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, TestHelpers.CreateMockEndpointString());
+            var prefix = "App1";
+            var label = "App1_Label";
+            var cacheExpiration = TimeSpan.FromSeconds(1);
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(new MockAsyncPageable(_featureFlagCollection.Where(s => s.Key.StartsWith(FeatureManagementConstants.FeatureFlagMarker + prefix) && s.Label == label).ToList()));
+
+            var testClient = mockClient.Object;
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = testClient;
+                    options.UseFeatureFlags(ff =>
+                    {
+                        ff.CacheExpirationInterval = cacheExpiration;
+                        ff.Label = label;
+                        ff.Prefix = prefix;
+                    });
+                })
+                .Build();
+
+            Assert.Equal("True", config["FeatureManagement:App1_Feature1"]);
+            Assert.Equal("False", config["FeatureManagement:App1_Feature2"]);
+
+            // Verify that the feature flag that did not start with the specified prefix was not loaded
+            Assert.Null(config["FeatureManagement:Feature1"]);
+
+            // Verify that the feature flag that did not match the specified label was not loaded
+            Assert.Null(config["FeatureManagement:App2_Feature1"]);
+            Assert.Null(config["FeatureManagement:App2_Feature2"]);
+        }
+
+        [Fact]
+        public void MultipleCallsToUseFeatureFlags()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, TestHelpers.CreateMockEndpointString());
+            var prefix1 = "App1";
+            var prefix2 = "App2";
+            var label1 = "App1_Label";
+            var label2 = "App2_Label";
+            var cacheExpiration = TimeSpan.FromSeconds(1);
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    return new MockAsyncPageable(_featureFlagCollection.Where(s => 
+                        (s.Key.StartsWith(FeatureManagementConstants.FeatureFlagMarker + prefix1) && s.Label == label1) || 
+                        (s.Key.StartsWith(FeatureManagementConstants.FeatureFlagMarker + prefix2) && s.Label == label2)).ToList());
+                });
+
+            var testClient = mockClient.Object;
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = testClient;
+                    options.UseFeatureFlags(ff =>
+                    {
+                        ff.CacheExpirationInterval = cacheExpiration;
+                        ff.Label = label1;
+                        ff.Prefix = prefix1;
+                    });
+                    options.UseFeatureFlags(ff =>
+                    {
+                        ff.CacheExpirationInterval = cacheExpiration;
+                        ff.Label = label2;
+                        ff.Prefix = prefix2;
+                    });
+                })
+                .Build();
+
+            Assert.Equal("True", config["FeatureManagement:App1_Feature1"]);
+            Assert.Equal("False", config["FeatureManagement:App1_Feature2"]);
+            Assert.Equal("False", config["FeatureManagement:App2_Feature1"]);
+            Assert.Equal("True", config["FeatureManagement:App2_Feature2"]);
+
+            // Verify that the feature flag that did not start with the specified prefix was not loaded
+            Assert.Null(config["FeatureManagement:Feature1"]);
+        }
+
+        [Fact]
+        public void DifferentCacheExpirationsForMultipleFeatureFlagRegistrations()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, TestHelpers.CreateMockEndpointString());
+            var prefix1 = "App1";
+            var prefix2 = "App2";
+            var label1 = "App1_Label";
+            var label2 = "App2_Label";
+            var cacheExpiration1 = TimeSpan.FromSeconds(1);
+            var cacheExpiration2 = TimeSpan.FromSeconds(60);
+            IConfigurationRefresher refresher = null;
+            var featureFlagCollection = new List<ConfigurationSetting>(_featureFlagCollection);
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    return new MockAsyncPageable(featureFlagCollection.Where(s =>
+                        (s.Key.StartsWith(FeatureManagementConstants.FeatureFlagMarker + prefix1) && s.Label == label1) ||
+                        (s.Key.StartsWith(FeatureManagementConstants.FeatureFlagMarker + prefix2) && s.Label == label2 && s.Key != FeatureManagementConstants.FeatureFlagMarker + "App2_Feature3")).ToList());
+                });
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = mockClient.Object;
+                    options.UseFeatureFlags(ff =>
+                    {
+                        ff.CacheExpirationInterval = cacheExpiration1;
+                        ff.Label = label1;
+                        ff.Prefix = prefix1;
+                    });
+                    options.UseFeatureFlags(ff =>
+                    {
+                        ff.CacheExpirationInterval = cacheExpiration2;
+                        ff.Label = label2;
+                        ff.Prefix = prefix2;
+                    });
+
+                    refresher = options.GetRefresher();
+                })
+                .Build();
+
+            Assert.Equal("True", config["FeatureManagement:App1_Feature1"]);
+            Assert.Equal("False", config["FeatureManagement:App1_Feature2"]);
+            Assert.Equal("False", config["FeatureManagement:App2_Feature1"]);
+            Assert.Equal("True", config["FeatureManagement:App2_Feature2"]);
+
+            // update the value of App1_Feature1 feature flag with label1
+            featureFlagCollection[0] = ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "App1_Feature1",
+                value: @"
+                        {
+                          ""id"": ""App1_Feature1"",
+                          ""enabled"": true,
+                          ""conditions"": {
+                            ""client_filters"": [
+                              {
+                                ""name"": ""Browser"",
+                                ""parameters"": {
+                                  ""AllowedBrowsers"": [ ""Chrome"", ""Edge"" ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                        ",
+                label: "App1_Label",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1" + "f"));
+
+            // add new feature flag with label2
+            featureFlagCollection.Add(ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "App2_Feature3",
+                value: @"
+                        {
+                          ""id"": ""App2_Feature3"",
+                          ""enabled"": true,
+                          ""conditions"": {
+                            ""client_filters"": []
+                          }
+                        }
+                        ",
+                label: "App2_Label",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1" + "f")));
+
+            // Sleep to let the cache for feature flag with label1 expire
+            Thread.Sleep(cacheExpiration1);
+            refresher.RefreshAsync().Wait();
+
+            Assert.Equal("Browser", config["FeatureManagement:App1_Feature1:EnabledFor:0:Name"]);
+            Assert.Equal("Chrome", config["FeatureManagement:App1_Feature1:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Edge", config["FeatureManagement:App1_Feature1:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
+            Assert.Equal("False", config["FeatureManagement:App1_Feature2"]);
+            Assert.Equal("False", config["FeatureManagement:App2_Feature1"]);
+            Assert.Equal("True", config["FeatureManagement:App2_Feature2"]);
+
+            // even though App2_Feature3 feature flag has been added, its value should not be loaded in config because label2 cache has not expired
+            Assert.Null(config["FeatureManagement:App2_Feature3"]);
+        }
+
+        [Fact]
+        public void DifferentCacheExpirationsForSameFeatureFlagRegistrations()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, TestHelpers.CreateMockEndpointString());
+            var cacheExpiration1 = TimeSpan.FromSeconds(1);
+            var cacheExpiration2 = TimeSpan.FromSeconds(60);
+            IConfigurationRefresher refresher = null;
+            var featureFlagCollection = new List<ConfigurationSetting>(_featureFlagCollection);
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(new MockAsyncPageable(featureFlagCollection));
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = mockClient.Object;
+                    options.UseFeatureFlags(ff =>
+                    {
+                        ff.CacheExpirationInterval = cacheExpiration1;
+                    });
+                    options.UseFeatureFlags(ff =>
+                    {
+                        ff.CacheExpirationInterval = cacheExpiration2;
+                    });
+
+                    refresher = options.GetRefresher();
+                })
+                .Build();
+
+            Assert.Equal("True", config["FeatureManagement:App1_Feature1"]);
+            Assert.Equal("False", config["FeatureManagement:App1_Feature2"]);
+            Assert.Equal("False", config["FeatureManagement:App2_Feature1"]);
+            Assert.Equal("True", config["FeatureManagement:App2_Feature2"]);
+            Assert.Equal("True", config["FeatureManagement:Feature1"]);
+
+            // update the value of App1_Feature1 feature flag with label1
+            featureFlagCollection[0] = ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "App1_Feature1",
+                value: @"
+                        {
+                          ""id"": ""App1_Feature1"",
+                          ""enabled"": true,
+                          ""conditions"": {
+                            ""client_filters"": [
+                              {
+                                ""name"": ""Browser"",
+                                ""parameters"": {
+                                  ""AllowedBrowsers"": [ ""Chrome"", ""Edge"" ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                        ",
+                label: "App1_Label",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1" + "f"));
+
+            Thread.Sleep(cacheExpiration1);
+            refresher.RefreshAsync().Wait();
+
+            // The cache expiration time for feature flags was overwritten by second call to UseFeatureFlags.
+            // Sleeping for cacheExpiration1 time should not update feature flags.
+            Assert.Equal("True", config["FeatureManagement:App1_Feature1"]);
+            Assert.Equal("False", config["FeatureManagement:App1_Feature2"]);
+            Assert.Equal("False", config["FeatureManagement:App2_Feature1"]);
+            Assert.Equal("True", config["FeatureManagement:App2_Feature2"]);
+            Assert.Equal("True", config["FeatureManagement:Feature1"]);
+        }
+
+        [Fact]
+        public void TrimFeatureFlags()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, TestHelpers.CreateMockEndpointString());
+            var label1 = "App1_Label";
+            var cacheExpiration = TimeSpan.FromSeconds(1);
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(new MockAsyncPageable(_featureFlagCollection.Where(s => s.Label == label1).ToList()));
+
+            var testClient = mockClient.Object;
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = testClient;
+                    options.UseFeatureFlags(ff =>
+                    {
+                        ff.CacheExpirationInterval = cacheExpiration;
+                        ff.Label = label1;
+                    });
+                    options.TrimFeatureFlagPrefix("App1_");
+                })
+                .Build();
+
+            // Verify that prefix was trimmed from feature flag ID and in case of same ID after trimming, last feature flag value was present in config
+            Assert.Equal("False", config["FeatureManagement:Feature1"]);
+            Assert.Equal("False", config["FeatureManagement:Feature2"]);
+        }
+
+        [Fact]
+        public void MultipleTrimFeatureFlags()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, TestHelpers.CreateMockEndpointString());
+            var prefix1 = "App1";
+            var prefix2 = "App2";
+            var label1 = "App1_Label";
+            var label2 = "App2_Label";
+            var cacheExpiration = TimeSpan.FromSeconds(1);
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    return new MockAsyncPageable(_featureFlagCollection.Where(s =>
+                        (s.Key.StartsWith(FeatureManagementConstants.FeatureFlagMarker + prefix1) && s.Label == label1) ||
+                        (s.Key.StartsWith(FeatureManagementConstants.FeatureFlagMarker + prefix2) && s.Label == label2)).ToList());
+                });
+
+            var testClient = mockClient.Object;
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = testClient;
+                    options.UseFeatureFlags(ff =>
+                    {
+                        ff.CacheExpirationInterval = cacheExpiration;
+                        ff.Label = label1;
+                        ff.Prefix = prefix1;
+                    });
+                    options.UseFeatureFlags(ff =>
+                    {
+                        ff.CacheExpirationInterval = cacheExpiration;
+                        ff.Label = label2;
+                        ff.Prefix = prefix2;
+                    });
+                    options.TrimFeatureFlagPrefix("App1_");
+                    options.TrimFeatureFlagPrefix("App2_");
+
+                })
+                .Build();
+
+            // Verify that prefix was trimmed from feature flag ID and in case of same ID after trimming, last feature flag value was present in config
+            Assert.Equal("False", config["FeatureManagement:Feature1"]);
+            Assert.Equal("True", config["FeatureManagement:Feature2"]);
         }
     }
 }

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -522,6 +522,23 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
+        public void UseFeatureFlagsThrowsIfFeatureFlagFilterIsInvalid()
+        {
+            void action() => new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.UseFeatureFlags(ff =>
+                    {
+                        ff.Select(@"MyApp\*", "Label1");
+                        ff.Label = "Label1";
+                    });
+                })
+                .Build();
+
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
         public void MultipleCallsToUseFeatureFlags()
         {
             var mockResponse = new Mock<Response>();


### PR DESCRIPTION
In response to customer issue #163, this PR introduces two new APIs for using feature flags.

```cs 
1. FeatureFlagOptions Select(string featureFlagFilter, string labelFilter) 
```
Call this method to selectively load feature flags based on key and label filters. This method can be called multiple times within a `UseFeatureFlags` call. 

Usage example:

```
var configuration = new ConfigurationBuilder()
    .AddAzureAppConfiguration(options =>
    {
        options.Connect(connectionString);

        options.UseFeatureFlags(featureFlagOptions =>
        {
            featureFlagOptions.Select("MyFeature", "MyLabel");  // requests a single feature flag whose key is MyFeature and label is MyLabel 
            featureFlagOptions.Select("App1/*", "Label1");  // requests all feature flags whose key starts with App1/ and label is Label1 
            featureFlagOptions.CacheExpirationInterval = cacheExpirationTimeSpan;
        });
    })
    .Build();
```

```cs
2. FeatureFlagOptions TrimFeatureFlagPrefix(string prefix)
```

Trims the provided prefix from the keys of all feature flags retrieved from Azure App Configuration. Follows the same pattern as our existing [TrimKeyPrefix](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.configuration.azureappconfiguration.azureappconfigurationoptions.trimkeyprefix?view=azure-dotnet-preview) API.

Usage example:

```
var configuration = new ConfigurationBuilder()
    .AddAzureAppConfiguration(options =>
    {
        options.Connect(connectionString);

        // Load feature flags with a specific prefix and label 
        options.UseFeatureFlags(featureFlagOptions =>
        {
            featureFlagOptions.Select("App1/*", "Label1");  // requests all feature flags whose key starts with App1/ and label is Label1 
            featureFlagOptions.Select("*");   // requests all feature flags whose label is null

            featureFlagOptions.TrimFeatureFlagPrefix("App1/");   // Trim "App1/" prefix from all feature flags
            featureFlagOptions.TrimFeatureFlagPrefix("Common/");  // Trim "Common/" prefix from all feature flags
        });
    })
    .Build();
```





