### PR TITLE
Update PackageLicenseUrl and upgrade base package patch version

### DIFF
--- a/build/NugetProperties.props
+++ b/build/NugetProperties.props
@@ -6,7 +6,7 @@
     <AssemblyOriginatorKeyFile>..\..\build\AzureAppConfiguration.snk</AssemblyOriginatorKeyFile>
     <RepositoryUrl>https://github.com/Azure/Azconfig-DotnetProvider</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Azure/AppConfiguration</PackageProjectUrl>
-    <PackageLicenseUrl>https://aka.ms/AzureAppConfigurationDotnetCorePublicPreviewEula</PackageLicenseUrl>
+    <PackageLicenseUrl>https://licenses.nuget.org/MIT</PackageLicenseUrl>
     <PackageIconUrl>https://aka.ms/AzureAppConfigurationPackageIcon</PackageIconUrl>
   </PropertyGroup>
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -32,7 +32,7 @@
   <!-- Nuget Package Version Settings -->
   
   <PropertyGroup>
-    <OfficialVersion>4.2.0</OfficialVersion>
+    <OfficialVersion>4.2.1</OfficialVersion>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'=='Official'">


### PR DESCRIPTION
Updated the nuget package license info and bumped up the patch version for `Microsoft.Extensions.Configuration.AzureAppConfiguration` package to 4.2.1