### PR TITLE
Block concurrent network operations

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
@@ -33,11 +33,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
         /// </summary>
         public DateTimeOffset CacheExpires { get; set; }
 
-        /// <summary>
-        /// Semaphore that can be used to prevent simultaneous refresh of the key-value from multiple threads.
-        /// </summary>
-        public SemaphoreSlim Semaphore { get; } = new SemaphoreSlim(1);
-
         public override bool Equals(object obj)
         {
             if (obj is KeyValueWatcher kvWatcher)


### PR DESCRIPTION
This PR implements thread synchronization to ensure that multiple threads do not make network calls simultaneously. 
We have two [critical sections](https://en.wikipedia.org/wiki/Critical_section) where network calls are made: 
- App startup
- Refresh
 
Access to the critical sections will be controlled using [System.Threading.Interlocked.Exchange](https://docs.microsoft.com/en-us/dotnet/api/system.threading.interlocked.exchange?view=net-5.0) atomic operation.

As a result, we no longer need to maintain semaphores in `AzureAppConfigurationProvider` or `KeyValueWatcher`.  
`ConcurrentDictionary` can also be replaced by `Dictionary`.
