### PR TITLE
Add user telemetry to correlation context header

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -100,6 +100,16 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         internal ConfigurationClientOptions ClientOptions { get; } = GetDefaultClientOptions();
 
         /// <summary>
+        /// Flag to indicate whether Key Vault options have been configured.
+        /// </summary>
+        internal bool IsKeyVaultConfigured { get; private set; } = false;
+
+        /// <summary>
+        /// Flag to indicate whether Offline Cache has been configured.
+        /// </summary>
+        internal bool IsOfflineCacheConfigured { get; private set; } = false;
+
+        /// <summary>
         /// Specify what key-values to include in the configuration provider.
         /// <see cref="Select"/> can be called multiple times to include multiple sets of key-values.
         /// </summary>
@@ -215,6 +225,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public AzureAppConfigurationOptions SetOfflineCache(IOfflineCache offlineCache)
         {
             OfflineCache = offlineCache ?? throw new ArgumentNullException(nameof(offlineCache));
+            IsOfflineCacheConfigured = true;
 
             return this;
         }
@@ -335,6 +346,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             _adapters.RemoveAll(a => a is AzureKeyVaultKeyValueAdapter);
             _adapters.Add(new AzureKeyVaultKeyValueAdapter(new AzureKeyVaultSecretProvider(keyVaultOptions)));
 
+            IsKeyVaultConfigured = true;
             return this;
         }
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -619,11 +619,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         private void SetRequestTracingOptions()
         {
-            _requestTracingOptions = new RequestTracingOptions();
-            _requestTracingOptions.HostType = TracingUtils.GetHostType();
-            _requestTracingOptions.IsDevEnvironment = TracingUtils.IsDevEnvironment();
-            _requestTracingOptions.IsKeyVaultConfigured = _options.IsKeyVaultConfigured;
-            _requestTracingOptions.IsOfflineCacheConfigured = _options.IsOfflineCacheConfigured;
+            _requestTracingOptions = new RequestTracingOptions
+            {
+                HostType = TracingUtils.GetHostType(),
+                IsDevEnvironment = TracingUtils.IsDevEnvironment(),
+                IsKeyVaultConfigured = _options.IsKeyVaultConfigured,
+                IsOfflineCacheConfigured = _options.IsOfflineCacheConfigured
+            };
         }
 
         private DateTimeOffset AddRandomDelay(DateTimeOffset dt, TimeSpan maxDelay)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         public const string RequestTypeKey = "RequestType";
         public const string HostTypeKey = "Host";
-        public const string DevEnvironmentTag = "DevEnvironment";
+        public const string EnvironmentKey = "Environment";
         public const string KeyVaultConfiguredTag = "KeyVaultConfigured";
         public const string OfflineCacheConfiguredTag = "OfflineCacheConfigured";
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public const string RequestTypeKey = "RequestType";
         public const string HostTypeKey = "Host";
         public const string DevEnvironmentTag = "DevEnvironment";
-        public const string KvrConfiguredTag = "KeyVaultConfigured";
+        public const string KeyVaultConfiguredTag = "KeyVaultConfigured";
         public const string OfflineCacheConfiguredTag = "OfflineCacheConfigured";
 
         public const string DiagnosticHeaderActivityName = "Azure.CustomDiagnosticHeaders";

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
@@ -9,6 +9,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public const string AzureFunctionEnvironmentVariable = "FUNCTIONS_EXTENSION_VERSION";
         public const string AzureWebAppEnvironmentVariable = "WEBSITE_SITE_NAME";
         public const string KubernetesEnvironmentVariable = "KUBERNETES_PORT";
+        
+        public const string AspNetCoreEnvironmentVariable = "ASPNETCORE_ENVIRONMENT";
+        public const string DotNetCoreEnvironmentVariable = "DOTNET_ENVIRONMENT";
+        public const string DevelopmentEnvironmentName = "Development";
 
         // Documentation : https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-environment-variables-reference
         public const string ServiceFabricEnvironmentVariable = "Fabric_NodeName";
@@ -17,6 +21,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         public const string RequestTypeKey = "RequestType";
         public const string HostTypeKey = "Host";
+        public const string DevEnvironmentTag = "DevEnvironment";
+        public const string KvrConfiguredTag = "KeyVaultConfigured";
+        public const string OfflineCacheConfiguredTag = "OfflineCacheConfigured";
 
         public const string DiagnosticHeaderActivityName = "Azure.CustomDiagnosticHeaders";
         public const string CorrelationContextHeader = "Correlation-Context";

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
             var eTagMap = keyValues.ToDictionary(kv => kv.Key, kv => kv.ETag);
 
             // Fetch e-tags for prefixed key-values that can be used to detect changes
-            await TracingUtils.CallWithRequestTracing(options.RequestTracingEnabled, RequestType.Watch, options.HostType,
+            await TracingUtils.CallWithRequestTracing(options.RequestTracingEnabled, RequestType.Watch, options.RequestTracingOptions,
                 async () =>
                 {
                     await foreach(ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector).ConfigureAwait(false))
@@ -137,7 +137,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                 };
 
                 eTagMap = keyValues.ToDictionary(kv => kv.Key, kv => kv.ETag);
-                await TracingUtils.CallWithRequestTracing(options.RequestTracingEnabled, RequestType.Watch, options.HostType,
+                await TracingUtils.CallWithRequestTracing(options.RequestTracingEnabled, RequestType.Watch, options.RequestTracingOptions,
                     async () =>
                     {
                         await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector).ConfigureAwait(false))

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/GetKeyValueChangeCollectionOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/GetKeyValueChangeCollectionOptions.cs
@@ -8,6 +8,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public string KeyFilter { get; set; }
         public string Label { get; set; }
         public bool RequestTracingEnabled { get; set; }
-        public HostType HostType { get; set; }
+        public RequestTracingOptions RequestTracingOptions { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/RequestTracingOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/RequestTracingOptions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+{
+    internal class RequestTracingOptions
+    {
+        /// <summary>
+        /// Type of host.
+        /// </summary>
+        public HostType HostType { get; set; }
+
+        /// <summary>
+        /// Flag to indicate whether Key Vault options have been configured.
+        /// </summary>
+        public bool IsKeyVaultConfigured { get; set; } = false;
+
+        /// <summary>
+        /// Flag to indicate whether Offline Cache has been configured.
+        /// </summary>
+        public bool IsOfflineCacheConfigured { get; set; } = false;
+
+        /// <summary>
+        /// Flag to indicate whether the request is from a development environment.
+        /// </summary>
+        public bool IsDevEnvironment { get; set; } = false;
+    }
+}

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         {
             string correlationContextHeader = "";
 
-            if (tracingEnabled)
+            if (tracingEnabled && requestTracingOptions != null)
             {
                 correlationContextHeader = CreateCorrelationContextHeader(requestType, requestTracingOptions);
             }
@@ -111,11 +111,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             IList<KeyValuePair<string, string>> correlationContextKeyValues = new List<KeyValuePair<string, string>>();
             IList<string> correlationContextTags = new List<string>();
             
-            AddRequestType(correlationContextKeyValues, requestType);
+            correlationContextKeyValues.Add(new KeyValuePair<string, string>(RequestTracingConstants.RequestTypeKey, Enum.GetName(typeof(RequestType), requestType)));
 
             if (requestTracingOptions.HostType != HostType.Unidentified)
             {
-                AddHostType(correlationContextKeyValues, requestTracingOptions.HostType);
+                correlationContextKeyValues.Add(new KeyValuePair<string, string>(RequestTracingConstants.HostTypeKey, Enum.GetName(typeof(HostType), requestTracingOptions.HostType)));
             }
 
             if (requestTracingOptions.IsDevEnvironment)
@@ -125,7 +125,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
             if (requestTracingOptions.IsKeyVaultConfigured)
             {
-                correlationContextTags.Add(RequestTracingConstants.KvrConfiguredTag);
+                correlationContextTags.Add(RequestTracingConstants.KeyVaultConfiguredTag);
             }
 
             if (requestTracingOptions.IsOfflineCacheConfigured)
@@ -157,18 +157,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
 
             return fullHeader;
-        }
-
-        private static void AddRequestType(IList<KeyValuePair<string, string>> correlationContext, RequestType requestType)
-        {
-            string requestTypeValue = Enum.GetName(typeof(RequestType), requestType);
-            correlationContext.Add(new KeyValuePair<string, string>(RequestTracingConstants.RequestTypeKey, requestTypeValue));
-        }
-
-        private static void AddHostType(IList<KeyValuePair<string, string>> correlationContext, HostType hostType)
-        {
-            string hostTypeValue = Enum.GetName(typeof(HostType), hostType);
-            correlationContext.Add(new KeyValuePair<string, string>(RequestTracingConstants.HostTypeKey, hostTypeValue));
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Security;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
@@ -120,7 +120,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
             if (requestTracingOptions.IsDevEnvironment)
             {
-                correlationContextTags.Add(RequestTracingConstants.DevEnvironmentTag);
+                correlationContextKeyValues.Add(new KeyValuePair<string, string>(RequestTracingConstants.EnvironmentKey, RequestTracingConstants.DevelopmentEnvironmentName));
             }
 
             if (requestTracingOptions.IsKeyVaultConfigured)
@@ -133,30 +133,29 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 correlationContextTags.Add(RequestTracingConstants.OfflineCacheConfiguredTag);
             }
 
-            string headerKeyValues = "";
-            string headerTags = "";
-            string fullHeader = "";
+            var sb = new StringBuilder();
 
-            if (correlationContextKeyValues.Count > 0)
+            foreach (KeyValuePair<string,string> kvp in correlationContextKeyValues)
             {
-                headerKeyValues = string.Join(",", correlationContextKeyValues.Select(kvp => $"{kvp.Key}={kvp.Value}"));
-            }
-                
-            if (correlationContextTags.Count > 0)
-            {
-                headerTags = string.Join(",", correlationContextTags);
+                if (sb.Length > 0)
+                {
+                    sb.Append(",");
+                }
+
+                sb.Append($"{kvp.Key}={kvp.Value}");
             }
 
-            if (!string.IsNullOrWhiteSpace(headerKeyValues) && !string.IsNullOrWhiteSpace(headerTags))
+            foreach (string tag in correlationContextTags)
             {
-                fullHeader = string.Join(",", headerKeyValues, headerTags);
-            }
-            else
-            {
-                fullHeader = !string.IsNullOrWhiteSpace(headerKeyValues) ? headerKeyValues : headerTags;
+                if (sb.Length > 0)
+                {
+                    sb.Append(",");
+                }
+
+                sb.Append($"{tag}");
             }
 
-            return fullHeader;
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
This change adds the following keywords to the `correlation-context` header:
1. **DevEnvironment** - added if request is made from a dev machine.
2. **KeyVaultConfigured** - added if application has invoked `ConfigureKeyVault` API.
3. **OfflineCacheConfigured** - added if application has invoked `SetOfflineCache` API.

Sample header values:

- `RequestType=Startup,DevEnvironment,KeyVaultConfigured,OfflineCacheConfigured`
- `RequestType=Startup,HostType=AzureWebApp,KeyVaultConfigured`