### PR TITLE
Making offline cache obsolete

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// An offline cache provider which can be used to enable offline data retrieval and storage.
         /// </summary>
+        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
         public IOfflineCache OfflineCache { get; private set; }
 
         /// <summary>
@@ -222,6 +223,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// Use an offline file cache to store Azure App Configuration data or retrieve previously stored data during offline periods.
         /// </summary>
         /// <param name="offlineCache">The offline file cache to use for storing/retrieving Azure App Configuration data.</param>
+        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
         public AzureAppConfigurationOptions SetOfflineCache(IOfflineCache offlineCache)
         {
             OfflineCache = offlineCache ?? throw new ArgumentNullException(nameof(offlineCache));

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// An offline cache provider which can be used to enable offline data retrieval and storage.
         /// </summary>
-        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
+        [Obsolete("OfflineCache will be deprecated in a future release.")]
         public IOfflineCache OfflineCache { get; private set; }
 
         /// <summary>
@@ -223,7 +223,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// Use an offline file cache to store Azure App Configuration data or retrieve previously stored data during offline periods.
         /// </summary>
         /// <param name="offlineCache">The offline file cache to use for storing/retrieving Azure App Configuration data.</param>
-        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
+        [Obsolete("SetOfflineCache will be deprecated in a future release.")]
         public AzureAppConfigurationOptions SetOfflineCache(IOfflineCache offlineCache)
         {
             OfflineCache = offlineCache ?? throw new ArgumentNullException(nameof(offlineCache));

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IOfflineCache.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IOfflineCache.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using System;
+
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     /// <summary>
     /// Defines the necessary interface to perform offline caching of Azure App Configuration data.
     /// </summary>
+    [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
     public interface IOfflineCache
     {
         /// <summary>
@@ -13,6 +16,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// </summary>
         /// <param name="options">Options describing what data is being requested.</param>
         /// <returns>Cached Azure App Configuration data.</returns>
+        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
         string Import(AzureAppConfigurationOptions options);
 
         /// <summary>
@@ -20,6 +24,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// </summary>
         /// <param name="options">The options that were used to retrieve the Azure App Configuration data.</param>
         /// <param name="data">The data to cache for later usage.</param>
+        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
         void Export(AzureAppConfigurationOptions options, string data);
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IOfflineCache.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IOfflineCache.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     /// <summary>
     /// Defines the necessary interface to perform offline caching of Azure App Configuration data.
     /// </summary>
-    [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
+    [Obsolete("IOfflineCache will be deprecated in a future release.")]
     public interface IOfflineCache
     {
         /// <summary>
@@ -16,7 +16,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// </summary>
         /// <param name="options">Options describing what data is being requested.</param>
         /// <returns>Cached Azure App Configuration data.</returns>
-        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
         string Import(AzureAppConfigurationOptions options);
 
         /// <summary>
@@ -24,7 +23,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// </summary>
         /// <param name="options">The options that were used to retrieve the Azure App Configuration data.</param>
         /// <param name="data">The data to cache for later usage.</param>
-        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
         void Export(AzureAppConfigurationOptions options, string data);
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/OfflineFileCache.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/OfflineFileCache.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     /// <summary>
     /// An offline cache provider for Azure App Configuration that uses the file system to store data.
     /// </summary>
-    [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
+    [Obsolete("OfflineFileCache will be deprecated in a future release.")]
     public class OfflineFileCache : IOfflineCache
     {
         private string _localCachePath = null;
@@ -57,7 +57,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// If the options are null or the encryption keys are omitted, they will be derived from the store's connection string.
         /// <see cref="OfflineFileCacheOptions.Path"/> is required unless the application is running inside of an Azure App Service instance, in which case it can be populated automatically.
         /// </param>
-        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
         public OfflineFileCache(OfflineFileCacheOptions options = null)
         {
             OfflineFileCacheOptions opts = options ?? new OfflineFileCacheOptions();
@@ -109,7 +108,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// An implementation of <see cref="IOfflineCache.Import(AzureAppConfigurationOptions)"/> that retrieves the cached data from the file system.
         /// </summary>
-        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
         public string Import(AzureAppConfigurationOptions options)
         {
             EnsureOptions(options);
@@ -173,7 +171,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// An implementation of <see cref="IOfflineCache.Export(AzureAppConfigurationOptions, string)"/> that caches the data in the file system.
         /// </summary>
-        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
         public void Export(AzureAppConfigurationOptions options, string data)
         {
             EnsureOptions(options);

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/OfflineFileCache.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/OfflineFileCache.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     /// <summary>
     /// An offline cache provider for Azure App Configuration that uses the file system to store data.
     /// </summary>
+    [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
     public class OfflineFileCache : IOfflineCache
     {
         private string _localCachePath = null;
@@ -56,6 +57,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// If the options are null or the encryption keys are omitted, they will be derived from the store's connection string.
         /// <see cref="OfflineFileCacheOptions.Path"/> is required unless the application is running inside of an Azure App Service instance, in which case it can be populated automatically.
         /// </param>
+        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
         public OfflineFileCache(OfflineFileCacheOptions options = null)
         {
             OfflineFileCacheOptions opts = options ?? new OfflineFileCacheOptions();
@@ -107,6 +109,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// An implementation of <see cref="IOfflineCache.Import(AzureAppConfigurationOptions)"/> that retrieves the cached data from the file system.
         /// </summary>
+        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
         public string Import(AzureAppConfigurationOptions options)
         {
             EnsureOptions(options);
@@ -170,6 +173,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// An implementation of <see cref="IOfflineCache.Export(AzureAppConfigurationOptions, string)"/> that caches the data in the file system.
         /// </summary>
+        [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
         public void Export(AzureAppConfigurationOptions options, string data)
         {
             EnsureOptions(options);

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/OfflineFileCacheOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/OfflineFileCacheOptions.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using System;
+
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     /// <summary>
     /// Options for controlling the behavior of an <see cref="OfflineFileCache"/>.
     /// </summary>
+    [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
     public class OfflineFileCacheOptions
     {
         /// <summary>

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/OfflineFileCacheOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/OfflineFileCacheOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     /// <summary>
     /// Options for controlling the behavior of an <see cref="OfflineFileCache"/>.
     /// </summary>
-    [Obsolete("Offline caching capabilities are being deprecated to reduce security vulnerabilities.")]
+    [Obsolete("OfflineFileCacheOptions will be deprecated in a future release.")]
     public class OfflineFileCacheOptions
     {
         /// <summary>


### PR DESCRIPTION
This PR marks all public methods and `IOfflineCache` interface as obsolete as we are planning to remove these APIs in the next major release.