### PR TITLE
Add telemetry when Key Vault refresh is configured

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationKeyVaultOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationKeyVaultOptions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         internal Func<Uri, ValueTask<string>> SecretResolver;
         internal Dictionary<string, TimeSpan> SecretRefreshIntervals = new Dictionary<string, TimeSpan>();
         internal TimeSpan? DefaultSecretRefreshInterval = null;
+        internal bool IsKeyVaultRefreshConfigured = false;
 
         /// <summary>
         /// Sets the credentials used to authenticate to key vaults that have no registered <see cref="SecretClient"/>.
@@ -69,6 +70,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
 
             SecretRefreshIntervals[secretReferenceKey] = refreshInterval;
+            IsKeyVaultRefreshConfigured = true;
             return this;
         }
 
@@ -80,6 +82,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public AzureAppConfigurationKeyVaultOptions SetSecretRefreshInterval(TimeSpan refreshInterval)
         {
             DefaultSecretRefreshInterval = refreshInterval;
+            IsKeyVaultRefreshConfigured = true;
             return this;
         }
     }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -106,6 +106,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         internal bool IsKeyVaultConfigured { get; private set; } = false;
 
         /// <summary>
+        /// Flag to indicate whether Key Vault secret values will be refreshed automatically.
+        /// </summary>
+        internal bool IsKeyVaultRefreshConfigured { get; private set; } = false;
+
+        /// <summary>
         /// Flag to indicate whether Offline Cache has been configured.
         /// </summary>
         internal bool IsOfflineCacheConfigured { get; private set; } = false;
@@ -348,6 +353,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             _adapters.RemoveAll(a => a is AzureKeyVaultKeyValueAdapter);
             _adapters.Add(new AzureKeyVaultKeyValueAdapter(new AzureKeyVaultSecretProvider(keyVaultOptions)));
 
+            IsKeyVaultRefreshConfigured = keyVaultOptions.IsKeyVaultRefreshConfigured;
             IsKeyVaultConfigured = true;
             return this;
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -624,6 +624,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 HostType = TracingUtils.GetHostType(),
                 IsDevEnvironment = TracingUtils.IsDevEnvironment(),
                 IsKeyVaultConfigured = _options.IsKeyVaultConfigured,
+                IsKeyVaultRefreshConfigured = _options.IsKeyVaultRefreshConfigured,
                 IsOfflineCacheConfigured = _options.IsOfflineCacheConfigured
             };
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public const string HostTypeKey = "Host";
         public const string EnvironmentKey = "Environment";
         public const string KeyVaultConfiguredTag = "KeyVaultConfigured";
+        public const string KeyVaultRefreshConfiguredTag = "KeyVaultRefreshConfigured";
         public const string OfflineCacheConfiguredTag = "OfflineCacheConfigured";
 
         public const string DiagnosticHeaderActivityName = "Azure.CustomDiagnosticHeaders";

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public const string HostTypeKey = "Host";
         public const string EnvironmentKey = "Env";
         public const string DevEnvironmentValue = "Dev";
-        public const string KeyVaultConfiguredTag = "HasKeyVault";
+        public const string KeyVaultConfiguredTag = "UsesKeyVault";
         public const string KeyVaultRefreshConfiguredTag = "RefreshesKeyVault";
-        public const string OfflineCacheConfiguredTag = "HasOfflineCache";
+        public const string OfflineCacheConfiguredTag = "UsesOfflineCache";
 
         public const string DiagnosticHeaderActivityName = "Azure.CustomDiagnosticHeaders";
         public const string CorrelationContextHeader = "Correlation-Context";

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
@@ -21,10 +21,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         public const string RequestTypeKey = "RequestType";
         public const string HostTypeKey = "Host";
-        public const string EnvironmentKey = "Environment";
-        public const string KeyVaultConfiguredTag = "KeyVaultConfigured";
-        public const string KeyVaultRefreshConfiguredTag = "KeyVaultRefreshConfigured";
-        public const string OfflineCacheConfiguredTag = "OfflineCacheConfigured";
+        public const string EnvironmentKey = "Env";
+        public const string DevEnvironmentValue = "Dev";
+        public const string KeyVaultConfiguredTag = "HasKeyVault";
+        public const string KeyVaultRefreshConfiguredTag = "RefreshesKeyVault";
+        public const string OfflineCacheConfiguredTag = "HasOfflineCache";
 
         public const string DiagnosticHeaderActivityName = "Azure.CustomDiagnosticHeaders";
         public const string CorrelationContextHeader = "Correlation-Context";

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/RequestTracingOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/RequestTracingOptions.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public bool IsKeyVaultConfigured { get; set; } = false;
 
         /// <summary>
+        /// Flag to indicate whether Key Vault secret values will be refreshed automatically.
+        /// </summary>
+        public bool IsKeyVaultRefreshConfigured { get; set; } = false;
+
+        /// <summary>
         /// Flag to indicate whether Offline Cache has been configured.
         /// </summary>
         public bool IsOfflineCacheConfigured { get; set; } = false;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
             if (requestTracingOptions.IsKeyVaultConfigured)
             {
-                correlationContextTags.Add(RequestTracingConstants.KeyVaultConfiguredTag);
+                correlationContextTags.Add(requestTracingOptions.IsKeyVaultRefreshConfigured ? RequestTracingConstants.KeyVaultRefreshConfiguredTag : RequestTracingConstants.KeyVaultConfiguredTag);
             }
 
             if (requestTracingOptions.IsOfflineCacheConfigured)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -120,12 +120,17 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
             if (requestTracingOptions.IsDevEnvironment)
             {
-                correlationContextKeyValues.Add(new KeyValuePair<string, string>(RequestTracingConstants.EnvironmentKey, RequestTracingConstants.DevelopmentEnvironmentName));
+                correlationContextKeyValues.Add(new KeyValuePair<string, string>(RequestTracingConstants.EnvironmentKey, RequestTracingConstants.DevEnvironmentValue));
             }
 
             if (requestTracingOptions.IsKeyVaultConfigured)
             {
-                correlationContextTags.Add(requestTracingOptions.IsKeyVaultRefreshConfigured ? RequestTracingConstants.KeyVaultRefreshConfiguredTag : RequestTracingConstants.KeyVaultConfiguredTag);
+                correlationContextTags.Add(RequestTracingConstants.KeyVaultConfiguredTag);
+            }
+
+            if (requestTracingOptions.IsKeyVaultRefreshConfigured)
+            {
+                correlationContextTags.Add(RequestTracingConstants.KeyVaultRefreshConfiguredTag);
             }
 
             if (requestTracingOptions.IsOfflineCacheConfigured)


### PR DESCRIPTION
Continuation of telemetry collection work done in #265

This PR adds a new telemetry tag to correlation context header if auto-refresh of Key Vault secrets is configured. 
The names of other telemetry options have also been changed:

1. **Env=Dev** - added if request is made from a dev machine.
2. **UsesKeyVault** - added if application has invoked `ConfigureKeyVault` API.
3. **RefreshesKeyVault** - added if application has invoked `SetSecretRefreshInterval` API.
4. **UsesOfflineCache** - added if application has invoked `SetOfflineCache` API.

Sample header values:

- `RequestType=Startup,Env=Dev,UsesKeyVault,UsesOfflineCache`
- `RequestType=Startup,HostType=AzureWebApp,UsesKeyVault,RefreshesKeyVault`
- `RequestType=Watch,HostType=IISExpress,Env=Dev,UsesKeyVault,RefreshesKeyVault,UsesOfflineCache`

