### PR TITLE
Upgrading Microsoft.Extensions packages from 2.1.1 to 3.1.18

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -16,8 +16,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.18" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 


### PR DESCRIPTION
As the official support for 2.1.x packages is [ending on Aug 21, 2021](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle), this PR updates the following packages to the latest 3.1.18 versions:
- `Microsoft.Extensions.Configuration`
- `Microsoft.Extensions.DependencyInjection.Abstractions`