### PR TITLE
Add ILogger support for TryRefreshAsync in .NET Core package

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Extensions.Configuration
                 throw new ArgumentNullException(nameof(services));
             }
 
+            services.AddLogging();
             services.AddSingleton<IConfigurationRefresherProvider, AzureAppConfigurationRefresherProvider>();
             return services;
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -117,16 +117,16 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         internal bool IsOfflineCacheConfigured { get; private set; } = false;
 
         /// <summary>
-        /// The <see cref="ILoggerFactory"/> for creating a logger to log errors during refresh operation.
+        /// The <see cref="ILoggerFactory"/> for creating a logger to log errors.
         /// </summary>
         internal ILoggerFactory LoggerFactory { get; set; }
 
         /// <summary>
-        /// Register a logger factory to log errors during refresh operations.
+        /// Set a logger factory to log errors.
         /// </summary>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> for creating a logger.</param>
         /// <returns></returns>
-        public AzureAppConfigurationOptions RegisterLoggerFactory(ILoggerFactory loggerFactory)
+        public AzureAppConfigurationOptions SetLoggerFactory(ILoggerFactory loggerFactory)
         {
             LoggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             return this;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -117,22 +117,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         internal bool IsOfflineCacheConfigured { get; private set; } = false;
 
         /// <summary>
-        /// The <see cref="ILoggerFactory"/> for creating a logger to log errors.
-        /// </summary>
-        internal ILoggerFactory LoggerFactory { get; set; }
-
-        /// <summary>
-        /// Set a logger factory to log errors.
-        /// </summary>
-        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> for creating a logger.</param>
-        /// <returns></returns>
-        public AzureAppConfigurationOptions SetLoggerFactory(ILoggerFactory loggerFactory)
-        {
-            LoggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
-            return this;
-        }
-
-        /// <summary>
         /// Specify what key-values to include in the configuration provider.
         /// <see cref="Select"/> can be called multiple times to include multiple sets of key-values.
         /// </summary>

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.Models;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -114,6 +115,22 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// Flag to indicate whether Offline Cache has been configured.
         /// </summary>
         internal bool IsOfflineCacheConfigured { get; private set; } = false;
+
+        /// <summary>
+        /// The <see cref="ILoggerFactory"/> for creating a logger to log errors during refresh operation.
+        /// </summary>
+        internal ILoggerFactory LoggerFactory { get; set; }
+
+        /// <summary>
+        /// Register a logger factory to log errors during refresh operations.
+        /// </summary>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> for creating a logger.</param>
+        /// <returns></returns>
+        public AzureAppConfigurationOptions RegisterLoggerFactory(ILoggerFactory loggerFactory)
+        {
+            LoggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+            return this;
+        }
 
         /// <summary>
         /// Specify what key-values to include in the configuration provider.

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.Models;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -201,7 +201,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             {
                 if (e.Status == (int)HttpStatusCode.Unauthorized || e.Status == (int)HttpStatusCode.Forbidden)
                 {
-                    _logger?.LogError(e, "Refresh operation failed due to an authentication error.");
+                    _logger?.LogWarning(e, "Refresh operation failed due to an authentication error.");
+                }
+                else
+                {
+                    _logger?.LogWarning(e, "Refresh operation failed due to an error.");
                 }
 
                 return false;
@@ -211,14 +215,18 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 if (e.InnerExceptions.Any(exception => (exception is RequestFailedException ex) 
                                                         && (ex.Status == (int)HttpStatusCode.Unauthorized || ex.Status == (int)HttpStatusCode.Forbidden)))
                 {
-                    _logger?.LogError(e, "Refresh operation failed due to an authentication error.");
+                    _logger?.LogWarning(e, "Refresh operation failed due to an authentication error.");
+                }
+                else
+                {
+                    _logger?.LogWarning(e, "Refresh operation failed due to an error.");
                 }
 
                 return false;
             }
             catch (KeyVaultReferenceException e)
             {
-                _logger?.LogError(e, "Refresh operation failed while resolving a Key Vault reference.");
+                _logger?.LogWarning(e, "Refresh operation failed while resolving a Key Vault reference.");
                 return false;
             }
             catch (OperationCanceledException)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -231,6 +231,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
             catch (OperationCanceledException)
             {
+                _logger?.LogWarning("Refresh operation was canceled.");
                 return false;
             }
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -197,8 +197,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             {
                 await RefreshAsync().ConfigureAwait(false);
             }
-            catch (Exception ex) when (ex is RequestFailedException ||
-                                              ((ex as AggregateException)?.InnerExceptions?.All(e => e is RequestFailedException) ?? false))
+            catch (Exception ex) when (
+                ex is RequestFailedException ||
+                ((ex as AggregateException)?.InnerExceptions?.All(e => e is RequestFailedException) ?? false))
             {
                 if (IsAuthenticationError(ex))
                 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             set
             {
                 _loggerFactory = value;
-                _logger = _loggerFactory?.CreateLogger(LoggingConstants.AppConfigLogCategory);
+                _logger = _loggerFactory?.CreateLogger(LoggingConstants.AppConfigRefreshLogCategory);
             }
         }
 
@@ -89,7 +89,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _optional = optional;
             _loggerFactory = options.LoggerFactory;
-            _logger = _loggerFactory?.CreateLogger(LoggingConstants.AppConfigLogCategory);
+            _logger = _loggerFactory?.CreateLogger(LoggingConstants.AppConfigRefreshLogCategory);
 
             IEnumerable<KeyValueWatcher> watchers = options.ChangeWatchers.Union(options.MultiKeyWatchers);
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -88,8 +88,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _optional = optional;
-            _loggerFactory = options.LoggerFactory;
-            _logger = _loggerFactory?.CreateLogger(LoggingConstants.AppConfigRefreshLogCategory);
 
             IEnumerable<KeyValueWatcher> watchers = options.ChangeWatchers.Union(options.MultiKeyWatchers);
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -197,17 +197,28 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             {
                 await RefreshAsync().ConfigureAwait(false);
             }
-            catch (Exception ex) when (
-                ex is RequestFailedException ||
-                ((ex as AggregateException)?.InnerExceptions?.All(e => e is RequestFailedException) ?? false))
+            catch (RequestFailedException e)
             {
-                if (IsAuthenticationError(ex))
+                if (IsAuthenticationError(e))
                 {
-                    _logger?.LogWarning(ex, LoggingConstants.RefreshFailedDueToAuthenticationError);
+                    _logger?.LogWarning(e, LoggingConstants.RefreshFailedDueToAuthenticationError);
                 }
                 else
                 {
-                    _logger?.LogWarning(ex, LoggingConstants.RefreshFailedError);
+                    _logger?.LogWarning(e, LoggingConstants.RefreshFailedError);
+                }
+
+                return false;
+            }
+            catch (AggregateException e) when (e?.InnerExceptions?.All(e => e is RequestFailedException) ?? false)
+            {
+                if (IsAuthenticationError(e))
+                {
+                    _logger?.LogWarning(e, LoggingConstants.RefreshFailedDueToAuthenticationError);
+                }
+                else
+                {
+                    _logger?.LogWarning(e, LoggingConstants.RefreshFailedError);
                 }
 
                 return false;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
@@ -10,42 +10,60 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     internal class AzureAppConfigurationRefresher : IConfigurationRefresher
     {
         private AzureAppConfigurationProvider _provider = null;
+        private ILoggerFactory _loggerFactory;
 
         public Uri AppConfigurationEndpoint { get; private set; } = null;
+   
+        public ILoggerFactory LoggerFactory { 
+            get => _loggerFactory; 
+            set 
+            { 
+                ThrowIfNullProvider(nameof(LoggerFactory)); 
+                _loggerFactory = value;
+
+                // If IConfigurationRefresher.LoggerFactory is explicitly set, it should 
+                // overwrite the LoggerFactory set in AzureAppConfigurationProvider
+                _provider.LoggerFactory = _loggerFactory;
+            } 
+        }
 
         public void SetProvider(AzureAppConfigurationProvider provider)
         {
             _provider = provider ?? throw new ArgumentNullException(nameof(provider));
             AppConfigurationEndpoint = _provider.AppConfigurationEndpoint;
+
+            // Save a copy of AzureAppConfigurationProvider.LoggerFactory if it 
+            // was created during startup, so that it can be accessed later if needed
+            _loggerFactory = _provider.LoggerFactory;
         }
 
         public async Task RefreshAsync()
         {
-            ThrowIfNullProvider();
+            ThrowIfNullProvider(nameof(RefreshAsync));
             await _provider.RefreshAsync().ConfigureAwait(false);
         }
 
-        public async Task<bool> TryRefreshAsync(ILogger logger)
+        public async Task<bool> TryRefreshAsync()
         {
             if (_provider == null)
             {
                 return false;
             }
 
-            return await _provider.TryRefreshAsync(logger).ConfigureAwait(false);
+            return await _provider.TryRefreshAsync().ConfigureAwait(false);
         }
 
         public void SetDirty(TimeSpan? maxDelay)
         {
-            ThrowIfNullProvider();
+            ThrowIfNullProvider(nameof(SetDirty));
             _provider.SetDirty(maxDelay);
         }
 
-        private void ThrowIfNullProvider()
+        private void ThrowIfNullProvider(string operation)
         {
             if (_provider == null)
             {
-                throw new InvalidOperationException("ConfigurationBuilder.Build() must be called before this operation can be performed.");
+                throw new InvalidOperationException($"ConfigurationBuilder.Build() must be called before {operation} can be accessed.");
             }
         }
     }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
@@ -10,20 +10,19 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     internal class AzureAppConfigurationRefresher : IConfigurationRefresher
     {
         private AzureAppConfigurationProvider _provider = null;
-        private ILoggerFactory _loggerFactory;
 
         public Uri AppConfigurationEndpoint { get; private set; } = null;
    
         public ILoggerFactory LoggerFactory { 
-            get => _loggerFactory; 
+            get 
+            {
+                ThrowIfNullProvider(nameof(LoggerFactory));
+                return _provider.LoggerFactory;
+            }
             set 
             { 
                 ThrowIfNullProvider(nameof(LoggerFactory)); 
-                _loggerFactory = value;
-
-                // If IConfigurationRefresher.LoggerFactory is explicitly set, it should 
-                // overwrite the LoggerFactory set in AzureAppConfigurationProvider
-                _provider.LoggerFactory = _loggerFactory;
+                _provider.LoggerFactory = value;
             } 
         }
 
@@ -31,10 +30,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         {
             _provider = provider ?? throw new ArgumentNullException(nameof(provider));
             AppConfigurationEndpoint = _provider.AppConfigurationEndpoint;
-
-            // Save a copy of AzureAppConfigurationProvider.LoggerFactory if it 
-            // was created during startup, so that it can be accessed later if needed
-            _loggerFactory = _provider.LoggerFactory;
         }
 
         public async Task RefreshAsync()

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
@@ -24,14 +25,14 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             await _provider.RefreshAsync().ConfigureAwait(false);
         }
 
-        public async Task<bool> TryRefreshAsync()
+        public async Task<bool> TryRefreshAsync(ILogger logger)
         {
             if (_provider == null)
             {
                 return false;
             }
 
-            return await _provider.TryRefreshAsync().ConfigureAwait(false);
+            return await _provider.TryRefreshAsync(logger).ConfigureAwait(false);
         }
 
         public void SetDirty(TimeSpan? maxDelay)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresherProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresherProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +12,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     {
         public IEnumerable<IConfigurationRefresher> Refreshers { get; }
 
-        public AzureAppConfigurationRefresherProvider(IConfiguration configuration)
+        public AzureAppConfigurationRefresherProvider(IConfiguration configuration, ILoggerFactory _loggerFactory)
         {
             var configurationRoot = configuration as IConfigurationRoot;
             var refreshers = new List<IConfigurationRefresher>();
@@ -22,6 +23,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 {
                     if (provider is IConfigurationRefresher refresher)
                     {
+                        // Use _loggerFactory only if LoggerFactory hasn't been set in AzureAppConfigurationOptions
+                        if (refresher.LoggerFactory == null)
+                        {
+                            refresher.LoggerFactory = _loggerFactory;
+                        }
+
                         refreshers.Add(refresher);
                     }
                 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
@@ -5,6 +5,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     internal class LoggingConstants
     {
-        public const string AppConfigLogCategory = "Microsoft.Extensions.Configuration.AzureAppConfiguration";
+        public const string AppConfigRefreshLogCategory = "Microsoft.Extensions.Configuration.AzureAppConfiguration.Refresh";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+{
+    internal class LoggingConstants
+    {
+        public const string AppConfigLogCategory = "Microsoft.Extensions.Configuration.AzureAppConfiguration";
+    }
+}

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
@@ -5,6 +5,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     internal class LoggingConstants
     {
+        // Categories
         public const string AppConfigRefreshLogCategory = "Microsoft.Extensions.Configuration.AzureAppConfiguration.Refresh";
+
+        // Error messages
+        public const string RefreshFailedDueToAuthenticationError = "A refresh operation failed due to an authentication error.";
+        public const string RefreshFailedDueToKeyVaultError = "A refresh operation failed while resolving a Key Vault reference.";
+        public const string RefreshFailedError = "A refresh operation failed due to an error.";
+        public const string RefreshCanceledError = "A refresh operation was canceled.";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         // Error messages
         public const string RefreshFailedDueToAuthenticationError = "A refresh operation failed due to an authentication error.";
         public const string RefreshFailedDueToKeyVaultError = "A refresh operation failed while resolving a Key Vault reference.";
-        public const string RefreshFailedError = "A refresh operation failed due to an error.";
+        public const string RefreshFailedError = "A refresh operation failed.";
         public const string RefreshCanceledError = "A refresh operation was canceled.";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         Uri AppConfigurationEndpoint { get; }
 
         /// <summary>
+        /// An <see cref="ILoggerFactory"/> for creating logger to log errors during refresh operations.
+        /// </summary>
+        ILoggerFactory LoggerFactory { get; set; }
+
+        /// <summary>
         /// Refreshes the data from App Configuration asynchronously.
         /// </summary>
         /// <exception cref="KeyVaultReferenceException">An error occurred when resolving a reference to an Azure Key Vault resource.</exception>
@@ -32,8 +37,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// Refreshes the data from App Configuration asynchronously. A return value indicates whether the operation succeeded.
         /// </summary>
-        /// <param name="logger">A logger for errors that might occur during refresh operation.</param>
-        Task<bool> TryRefreshAsync(ILogger logger = default);
+        Task<bool> TryRefreshAsync();
 
         /// <summary>
         /// Sets the cached value for key-values registered for refresh as dirty.

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 //
 using Azure;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
@@ -31,7 +32,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// Refreshes the data from App Configuration asynchronously. A return value indicates whether the operation succeeded.
         /// </summary>
-        Task<bool> TryRefreshAsync();
+        /// <param name="logger">A logger for errors that might occur during refresh operation.</param>
+        Task<bool> TryRefreshAsync(ILogger logger = default);
 
         /// <summary>
         /// Sets the cached value for key-values registered for refresh as dirty.

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         Uri AppConfigurationEndpoint { get; }
 
         /// <summary>
-        /// An <see cref="ILoggerFactory"/> for creating logger to log errors during refresh operations.
+        /// An <see cref="ILoggerFactory"/> for creating a logger to log errors.
         /// </summary>
         ILoggerFactory LoggerFactory { get; set; }
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.18" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 

--- a/tests/Tests.AzureAppConfiguration/LoggingTests.cs
+++ b/tests/Tests.AzureAppConfiguration/LoggingTests.cs
@@ -92,8 +92,7 @@ namespace Tests.AzureAppConfiguration
                     {
                         refreshOptions.Register("TestKey1", "label")
                             .SetCacheExpiration(CacheExpirationTime);
-                    })
-                    .SetLoggerFactory(mockLoggerFactory.Object);
+                    });
 
                     refresher = options.GetRefresher();
                 })
@@ -103,6 +102,7 @@ namespace Tests.AzureAppConfiguration
             FirstKeyValue.Value = "newValue1";
             
             Thread.Sleep(CacheExpirationTime);
+            refresher.LoggerFactory = mockLoggerFactory.Object;
             refresher.TryRefreshAsync().Wait();
 
             Assert.NotEqual("newValue1", config["TestKey1"]);
@@ -153,8 +153,7 @@ namespace Tests.AzureAppConfiguration
                     {
                         refreshOptions.Register("SentinelKey", refreshAll: true)
                                       .SetCacheExpiration(CacheExpirationTime);
-                    })
-                    .SetLoggerFactory(mockLoggerFactory.Object);
+                    });
                     refresher = options.GetRefresher();
                 })
                 .Build();
@@ -164,13 +163,14 @@ namespace Tests.AzureAppConfiguration
             // Update sentinel key-value to trigger refreshAll operation
             sentinelKv.Value = "UpdatedSentinelValue";
             Thread.Sleep(CacheExpirationTime);
+            refresher.LoggerFactory = mockLoggerFactory.Object;
             refresher.TryRefreshAsync().Wait();
 
             Assert.True(ValidateLoggedError(mockLogger, "Refresh operation failed while resolving a Key Vault reference."));
         }
 
         [Fact]
-        public void OverwriteLoggerFactoryWithIConfigurationRefresherInstance()
+        public void OverwriteLoggerFactory()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -193,8 +193,7 @@ namespace Tests.AzureAppConfiguration
                     {
                         refreshOptions.Register("TestKey1", "label")
                             .SetCacheExpiration(CacheExpirationTime);
-                    })
-                    .SetLoggerFactory(mockLoggerFactory1.Object);
+                    });
 
                     refresher = options.GetRefresher();
                 })
@@ -202,8 +201,11 @@ namespace Tests.AzureAppConfiguration
 
             Assert.Equal("TestValue1", config["TestKey1"]);
             FirstKeyValue.Value = "newValue1";
+            
+            // Set LoggerFactory
+            refresher.LoggerFactory = mockLoggerFactory1.Object;
 
-            // Overwrite logger factory
+            // Overwrite LoggerFactory
             refresher.LoggerFactory = mockLoggerFactory2.Object;
 
             Thread.Sleep(CacheExpirationTime);

--- a/tests/Tests.AzureAppConfiguration/LoggingTests.cs
+++ b/tests/Tests.AzureAppConfiguration/LoggingTests.cs
@@ -106,7 +106,7 @@ namespace Tests.AzureAppConfiguration
             refresher.TryRefreshAsync().Wait();
 
             Assert.NotEqual("newValue1", config["TestKey1"]);
-            Assert.True(ValidateLoggedError(mockLogger, "Refresh operation failed due to an error."));
+            Assert.True(ValidateLoggedError(mockLogger, LoggingConstants.RefreshFailedError));
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace Tests.AzureAppConfiguration
             refresher.TryRefreshAsync().Wait();
 
             Assert.NotEqual("newValue1", config["TestKey1"]);
-            Assert.True(ValidateLoggedError(mockLogger, "Refresh operation failed due to an authentication error."));
+            Assert.True(ValidateLoggedError(mockLogger, LoggingConstants.RefreshFailedDueToAuthenticationError));
         }
 
         [Fact]
@@ -203,7 +203,7 @@ namespace Tests.AzureAppConfiguration
             refresher.LoggerFactory = mockLoggerFactory.Object;
             refresher.TryRefreshAsync().Wait();
 
-            Assert.True(ValidateLoggedError(mockLogger, "Refresh operation failed while resolving a Key Vault reference."));
+            Assert.True(ValidateLoggedError(mockLogger, LoggingConstants.RefreshFailedDueToKeyVaultError));
         }
 
         [Fact]
@@ -249,7 +249,7 @@ namespace Tests.AzureAppConfiguration
             refresher.TryRefreshAsync().Wait();
 
             Assert.NotEqual("newValue1", config["TestKey1"]);
-            Assert.True(ValidateLoggedError(mockLogger2, "Refresh operation failed due to an authentication error."));
+            Assert.True(ValidateLoggedError(mockLogger2, LoggingConstants.RefreshFailedDueToAuthenticationError));
         }
 
         private bool ValidateLoggedError(Mock<ILogger> logger, string expectedMessage)

--- a/tests/Tests.AzureAppConfiguration/LoggingTests.cs
+++ b/tests/Tests.AzureAppConfiguration/LoggingTests.cs
@@ -1,0 +1,265 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Azure;
+using Azure.Core.Testing;
+using Azure.Data.AppConfiguration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+namespace Tests.AzureAppConfiguration
+{
+    public class LoggingTests
+    {
+        List<ConfigurationSetting> _kvCollection = new List<ConfigurationSetting>
+        {
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: "TestKey1",
+                label: "label",
+                value: "TestValue1",
+                eTag: new ETag("0a76e3d7-7ec1-4e37-883c-9ea6d0d89e63"),
+                contentType: "text"),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: "TestKey2",
+                label: "label",
+                value: "TestValue2",
+                eTag: new ETag("31c38369-831f-4bf1-b9ad-79db56c8b989"),
+                contentType: "text")
+        };
+
+        ConfigurationSetting FirstKeyValue => _kvCollection.First();
+        ConfigurationSetting sentinelKv = new ConfigurationSetting("SentinelKey", "SentinelValue");
+        ConfigurationSetting _kvr = ConfigurationModelFactory.ConfigurationSetting(
+                key: "TestKey1",
+                value: @"
+                        {
+                            ""uri"":""https://keyvault-theclassics.vault.azure.net/secrets/TheTrialSecret""
+                        }",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"),
+                contentType: KeyVaultConstants.ContentType + "; charset=utf-8");
+
+        TimeSpan CacheExpirationTime = TimeSpan.FromSeconds(1);
+
+        [Fact]
+        public void ThrowsIfLoggerFactorySetWithIConfigurationRefresherBeforeBuild()
+        {
+            IConfigurationRefresher refresher = null;
+
+            void action() => new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.Register("TestKey1", "label")
+                            .SetCacheExpiration(CacheExpirationTime);
+                    });
+
+                    refresher = options.GetRefresher();
+                    refresher.LoggerFactory = NullLoggerFactory.Instance; // Throws
+                })
+                .Build();
+
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
+        public void ValidateUnauthorizedExceptionLoggedDuringRefresh()
+        {
+            IConfigurationRefresher refresher = null;
+            var mockClient = GetMockConfigurationClient();
+            mockClient.Setup(c => c.GetConfigurationSettingAsync(It.IsAny<ConfigurationSetting>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+               .Throws(new RequestFailedException(401, "Unauthorized"));
+
+            var mockLogger = new Mock<ILogger>();
+            var mockLoggerFactory = new Mock<ILoggerFactory>();
+            mockLoggerFactory.Setup(mlf => mlf.CreateLogger(LoggingConstants.AppConfigLogCategory)).Returns(mockLogger.Object);
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = mockClient.Object;
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.Register("TestKey1", "label")
+                            .SetCacheExpiration(CacheExpirationTime);
+                    })
+                    .RegisterLoggerFactory(mockLoggerFactory.Object);
+
+                    refresher = options.GetRefresher();
+                })
+                .Build();
+
+            Assert.Equal("TestValue1", config["TestKey1"]);
+            FirstKeyValue.Value = "newValue1";
+            
+            Thread.Sleep(CacheExpirationTime);
+            refresher.TryRefreshAsync().Wait();
+
+            Assert.NotEqual("newValue1", config["TestKey1"]);
+            Assert.True(ValidateLoggedError(mockLogger, "Refresh operation failed due to an authentication error."));
+        }
+
+        [Fact]
+        public void ValidateKeyVaultExceptionLoggedDuringRefresh()
+        {
+            IConfigurationRefresher refresher = null;
+            TimeSpan cacheExpirationTime = TimeSpan.FromSeconds(1);
+
+            // Mock ConfigurationClient
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, TestHelpers.CreateMockEndpointString());
+
+            Response<ConfigurationSetting> GetTestKey(string key, string label, CancellationToken cancellationToken)
+            {
+                return Response.FromValue(TestHelpers.CloneSetting(sentinelKv), mockResponse.Object);
+            }
+
+            Response<ConfigurationSetting> GetIfChanged(ConfigurationSetting setting, bool onlyIfChanged, CancellationToken cancellationToken)
+            {
+                var unchanged = sentinelKv.Key == setting.Key && sentinelKv.Label == setting.Label && sentinelKv.Value == setting.Value;
+                var response = new MockResponse(unchanged ? 304 : 200);
+                return Response.FromValue(sentinelKv, response);
+            }
+
+            // No KVR during startup; return KVR during refresh operation to see error because ConfigureKeyVault is missing
+            mockClient.SetupSequence(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(new MockAsyncPageable(_kvCollection.Select(setting => TestHelpers.CloneSetting(setting)).ToList()))
+                .Returns(new MockAsyncPageable(new List<ConfigurationSetting> { _kvr }));
+            mockClient.Setup(c => c.GetConfigurationSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Func<string, string, CancellationToken, Response<ConfigurationSetting>>)GetTestKey);
+            mockClient.Setup(c => c.GetConfigurationSettingAsync(It.IsAny<ConfigurationSetting>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Func<ConfigurationSetting, bool, CancellationToken, Response<ConfigurationSetting>>)GetIfChanged);
+
+            // Mock ILogger and ILoggerFactory
+            var mockLogger = new Mock<ILogger>();
+            var mockLoggerFactory = new Mock<ILoggerFactory>();
+            mockLoggerFactory.Setup(mlf => mlf.CreateLogger(LoggingConstants.AppConfigLogCategory)).Returns(mockLogger.Object);
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = mockClient.Object;
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.Register("SentinelKey", refreshAll: true)
+                                      .SetCacheExpiration(CacheExpirationTime);
+                    })
+                    .RegisterLoggerFactory(mockLoggerFactory.Object);
+                    refresher = options.GetRefresher();
+                })
+                .Build();
+
+            Assert.Equal("SentinelValue", config["SentinelKey"]);
+
+            // Update sentinel key-value to trigger refreshAll operation
+            sentinelKv.Value = "UpdatedSentinelValue";
+            Thread.Sleep(CacheExpirationTime);
+            refresher.TryRefreshAsync().Wait();
+
+            Assert.True(ValidateLoggedError(mockLogger, "Refresh operation failed while resolving a Key Vault reference."));
+        }
+
+        [Fact]
+        public void OverwriteLoggerFactoryWithIConfigurationRefresherInstance()
+        {
+            IConfigurationRefresher refresher = null;
+            var mockClient = GetMockConfigurationClient();
+            mockClient.Setup(c => c.GetConfigurationSettingAsync(It.IsAny<ConfigurationSetting>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+               .Throws(new RequestFailedException(403, "Forbidden"));
+
+            var mockLogger1 = new Mock<ILogger>();
+            var mockLoggerFactory1 = new Mock<ILoggerFactory>();
+            mockLoggerFactory1.Setup(mlf => mlf.CreateLogger(LoggingConstants.AppConfigLogCategory)).Returns(mockLogger1.Object);
+
+            var mockLogger2 = new Mock<ILogger>();
+            var mockLoggerFactory2 = new Mock<ILoggerFactory>();
+            mockLoggerFactory2.Setup(mlf => mlf.CreateLogger(LoggingConstants.AppConfigLogCategory)).Returns(mockLogger2.Object);
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = mockClient.Object;
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.Register("TestKey1", "label")
+                            .SetCacheExpiration(CacheExpirationTime);
+                    })
+                    .RegisterLoggerFactory(mockLoggerFactory1.Object);
+
+                    refresher = options.GetRefresher();
+                })
+                .Build();
+
+            Assert.Equal("TestValue1", config["TestKey1"]);
+            FirstKeyValue.Value = "newValue1";
+
+            // Overwrite logger factory
+            refresher.LoggerFactory = mockLoggerFactory2.Object;
+
+            Thread.Sleep(CacheExpirationTime);
+            refresher.TryRefreshAsync().Wait();
+
+            Assert.NotEqual("newValue1", config["TestKey1"]);
+            Assert.True(ValidateLoggedError(mockLogger2, "Refresh operation failed due to an authentication error."));
+        }
+
+        private bool ValidateLoggedError(Mock<ILogger> logger, string expectedMessage)
+        {
+            Func<object, Type, bool> state = (v, t) => v.ToString().StartsWith(expectedMessage);
+
+            logger.Verify(
+                x => x.Log(
+                    It.Is<LogLevel>(l => l == LogLevel.Error),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => state(v, t)),
+                    It.IsAny<Exception>(),
+                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)));
+
+            return true;
+        }
+
+        private Mock<ConfigurationClient> GetMockConfigurationClient()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict, TestHelpers.CreateMockEndpointString());
+
+            Response<ConfigurationSetting> GetTestKey(string key, string label, CancellationToken cancellationToken)
+            {
+                return Response.FromValue(TestHelpers.CloneSetting(_kvCollection.FirstOrDefault(s => s.Key == key && s.Label == label)), mockResponse.Object);
+            }
+
+            Response<ConfigurationSetting> GetIfChanged(ConfigurationSetting setting, bool onlyIfChanged, CancellationToken cancellationToken)
+            {
+                var newSetting = _kvCollection.FirstOrDefault(s => (s.Key == setting.Key && s.Label == setting.Label));
+                var unchanged = (newSetting.Key == setting.Key && newSetting.Label == setting.Label && newSetting.Value == setting.Value);
+                var response = new MockResponse(unchanged ? 304 : 200);
+                return Response.FromValue(newSetting, response);
+            }
+
+            // We don't actually select KV based on SettingSelector, we just return a deep copy of _kvCollection
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    return new MockAsyncPageable(_kvCollection.Select(setting => TestHelpers.CloneSetting(setting)).ToList());
+                });
+
+            mockClient.Setup(c => c.GetConfigurationSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Func<string, string, CancellationToken, Response<ConfigurationSetting>>)GetTestKey);
+
+            mockClient.Setup(c => c.GetConfigurationSettingAsync(It.IsAny<ConfigurationSetting>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Func<ConfigurationSetting, bool, CancellationToken, Response<ConfigurationSetting>>)GetIfChanged);
+
+            return mockClient;
+        }
+    }
+}

--- a/tests/Tests.AzureAppConfiguration/LoggingTests.cs
+++ b/tests/Tests.AzureAppConfiguration/LoggingTests.cs
@@ -82,7 +82,7 @@ namespace Tests.AzureAppConfiguration
 
             var mockLogger = new Mock<ILogger>();
             var mockLoggerFactory = new Mock<ILoggerFactory>();
-            mockLoggerFactory.Setup(mlf => mlf.CreateLogger(LoggingConstants.AppConfigLogCategory)).Returns(mockLogger.Object);
+            mockLoggerFactory.Setup(mlf => mlf.CreateLogger(LoggingConstants.AppConfigRefreshLogCategory)).Returns(mockLogger.Object);
 
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
@@ -93,7 +93,7 @@ namespace Tests.AzureAppConfiguration
                         refreshOptions.Register("TestKey1", "label")
                             .SetCacheExpiration(CacheExpirationTime);
                     })
-                    .RegisterLoggerFactory(mockLoggerFactory.Object);
+                    .SetLoggerFactory(mockLoggerFactory.Object);
 
                     refresher = options.GetRefresher();
                 })
@@ -143,7 +143,7 @@ namespace Tests.AzureAppConfiguration
             // Mock ILogger and ILoggerFactory
             var mockLogger = new Mock<ILogger>();
             var mockLoggerFactory = new Mock<ILoggerFactory>();
-            mockLoggerFactory.Setup(mlf => mlf.CreateLogger(LoggingConstants.AppConfigLogCategory)).Returns(mockLogger.Object);
+            mockLoggerFactory.Setup(mlf => mlf.CreateLogger(LoggingConstants.AppConfigRefreshLogCategory)).Returns(mockLogger.Object);
 
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
@@ -154,7 +154,7 @@ namespace Tests.AzureAppConfiguration
                         refreshOptions.Register("SentinelKey", refreshAll: true)
                                       .SetCacheExpiration(CacheExpirationTime);
                     })
-                    .RegisterLoggerFactory(mockLoggerFactory.Object);
+                    .SetLoggerFactory(mockLoggerFactory.Object);
                     refresher = options.GetRefresher();
                 })
                 .Build();
@@ -179,11 +179,11 @@ namespace Tests.AzureAppConfiguration
 
             var mockLogger1 = new Mock<ILogger>();
             var mockLoggerFactory1 = new Mock<ILoggerFactory>();
-            mockLoggerFactory1.Setup(mlf => mlf.CreateLogger(LoggingConstants.AppConfigLogCategory)).Returns(mockLogger1.Object);
+            mockLoggerFactory1.Setup(mlf => mlf.CreateLogger(LoggingConstants.AppConfigRefreshLogCategory)).Returns(mockLogger1.Object);
 
             var mockLogger2 = new Mock<ILogger>();
             var mockLoggerFactory2 = new Mock<ILoggerFactory>();
-            mockLoggerFactory2.Setup(mlf => mlf.CreateLogger(LoggingConstants.AppConfigLogCategory)).Returns(mockLogger2.Object);
+            mockLoggerFactory2.Setup(mlf => mlf.CreateLogger(LoggingConstants.AppConfigRefreshLogCategory)).Returns(mockLogger2.Object);
 
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
@@ -194,7 +194,7 @@ namespace Tests.AzureAppConfiguration
                         refreshOptions.Register("TestKey1", "label")
                             .SetCacheExpiration(CacheExpirationTime);
                     })
-                    .RegisterLoggerFactory(mockLoggerFactory1.Object);
+                    .SetLoggerFactory(mockLoggerFactory1.Object);
 
                     refresher = options.GetRefresher();
                 })

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -7,6 +7,7 @@ using Azure.Data.AppConfiguration;
 using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
 using System.Collections.Generic;
@@ -1103,7 +1104,7 @@ namespace Tests.AzureAppConfiguration
                 .AddAzureAppConfiguration(optionsInitializer, optional: true)
                 .Build();
 
-            IConfigurationRefresherProvider refresherProvider = new AzureAppConfigurationRefresherProvider(configuration);
+            IConfigurationRefresherProvider refresherProvider = new AzureAppConfigurationRefresherProvider(configuration, NullLoggerFactory.Instance);
             Assert.Equal(2, refresherProvider.Refreshers.Count());
         }
 
@@ -1111,7 +1112,7 @@ namespace Tests.AzureAppConfiguration
         public void RefreshTests_AzureAppConfigurationRefresherProviderThrowsIfNoRefresher()
         {
             IConfiguration configuration = new ConfigurationBuilder().Build();
-            void action() => new AzureAppConfigurationRefresherProvider(configuration);
+            void action() => new AzureAppConfigurationRefresherProvider(configuration, NullLoggerFactory.Instance);
             Assert.Throws<InvalidOperationException>(action);
         }
 


### PR DESCRIPTION
This PR adds a new public property to the `IConfigurationRefresher` interface to support logging any exceptions that occur during refresh operations:
`ILoggerFactory IConfigurationRefresher.LoggerFactory { get; set; }`


**Using ILoggerFactory with Dependency Injection**

If you want to get your `ILoggerFactory` through dependency injection, the default `ILoggerFactory` will be added automatically when `services.AddAzureAppConfiguration()` is invoked in your `ConfigureServices` method. No code changes are needed.


**Using ILoggerFactory without Dependency Injection**

If you don't use dependency injection, you can set your own instance of `ILoggerFactory` on the `IConfigurationRefresher` instance.

```cs
IConfigurationRefresher refresher = null;
var config = new ConfigurationBuilder()
            .AddAzureAppConfiguration(options =>
            {
                options.ConfigureRefresh(refreshOptions =>
                {
                    refreshOptions.Register("Sentinel", true)
                        .SetCacheExpiration(TimeSpan.FromSeconds(30));
                })

                refresher = options.GetRefresher();
            })
            .Build();

refresher.LoggerFactory = _loggerFactory;
bool success = await refresher.TryRefreshAsync();

```


**Logging Category**
The category of refresh logs will be: `Microsoft.Extensions.Configuration.AzureAppConfiguration.Refresh`


**Breaking Change**
This is a breaking change because we added a new dependency on `Microsoft.Extensions.Logging` package and the public interface has changed. 

The AspNetCore middleware doesn't need any special changes to support ILogger.
