### PR TITLE
Support for Secret Client Options

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationKeyVaultOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationKeyVaultOptions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     public class AzureAppConfigurationKeyVaultOptions
     {
         internal TokenCredential Credential;
+        internal SecretClientOptions ClientOptions;
         internal List<SecretClient> SecretClients = new List<SecretClient>();
         internal Func<Uri, ValueTask<string>> SecretResolver;
         internal Dictionary<string, TimeSpan> SecretRefreshIntervals = new Dictionary<string, TimeSpan>();
@@ -28,6 +29,16 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public AzureAppConfigurationKeyVaultOptions SetCredential(TokenCredential credential)
         {
             Credential = credential;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the client options used when connecting to key vaults that have no registered <see cref="SecretClient"/>
+        /// </summary>
+        /// <param name="clientOptions">Default secret client options</param>
+        public AzureAppConfigurationKeyVaultOptions SetClientOptions(SecretClientOptions clientOptions)
+        {
+            ClientOptions = clientOptions;
             return this;
         }
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultSecretProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultSecretProvider.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
                 return null;
             }
 
-            client = new SecretClient(new Uri(secretUri.GetLeftPart(UriPartial.Authority)), _keyVaultOptions.Credential);
+            client = new SecretClient(new Uri(secretUri.GetLeftPart(UriPartial.Authority)), _keyVaultOptions.Credential,  _keyVaultOptions.ClientOptions);
             _secretClients.Add(keyVaultId, client);
             return client;
         }


### PR DESCRIPTION
Resolves #274 
Added the ability to set the SecretClientOptions similar to how the TokenCredential functions for use when creating and managing SecretClients internally.