### PR TITLE
Add support for CancellationToken during refresh operations

### DIFF
--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/AzureAppConfigurationRefreshMiddleware.cs
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/AzureAppConfigurationRefreshMiddleware.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.AppConfiguration.AspNetCore
         {
             foreach (var refresher in Refreshers)
             {
-                _ = refresher.TryRefreshAsync(context.RequestAborted);
+                _ = refresher.TryRefreshAsync();
             }
 
             // Call the next delegate/middleware in the pipeline

--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/AzureAppConfigurationRefreshMiddleware.cs
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/AzureAppConfigurationRefreshMiddleware.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.AppConfiguration.AspNetCore
         {
             foreach (var refresher in Refreshers)
             {
-                _ = refresher.TryRefreshAsync();
+                _ = refresher.TryRefreshAsync(context.RequestAborted);
             }
 
             // Call the next delegate/middleware in the pipeline

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -504,12 +504,14 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
         }
 
-        private async Task RefreshKeyValueAdapters(CancellationToken cancellationToken)
+        private Task RefreshKeyValueAdapters(CancellationToken cancellationToken)
         {
             if (_options.Adapters.Any(adapter => adapter.NeedsRefresh()))
             {
-                SetData(_applicationSettings, false, cancellationToken);
+                return SetData(_applicationSettings, false, cancellationToken);
             }
+
+            return Task.CompletedTask;
         }
 
         private async Task RefreshKeyValueCollections(CancellationToken cancellationToken)
@@ -657,10 +659,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
         }
 
-        private async Task CallWithRequestTracing(Func<Task> clientCall)
+        private Task CallWithRequestTracing(Func<Task> clientCall)
         {
             var requestType = _isInitialLoadComplete ? RequestType.Watch : RequestType.Startup;
-            TracingUtils.CallWithRequestTracing(_requestTracingEnabled, requestType, _requestTracingOptions, clientCall);
+            return TracingUtils.CallWithRequestTracing(_requestTracingEnabled, requestType, _requestTracingOptions, clientCall);
         }
 
         private void SetRequestTracingOptions()

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             {
                 // Load() is invoked only once during application startup. We don't need to check for concurrent network
                 // operations here because there can't be any other startup or refresh operation in progress at this time.
-                LoadAll(_optional).ConfigureAwait(false).GetAwaiter().GetResult();
+                LoadAll(_optional, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
             }
             catch (ArgumentException)
             {
@@ -252,7 +252,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
         }
 
-        private async Task LoadAll(bool ignoreFailures, CancellationToken cancellationToken = default)
+        private async Task LoadAll(bool ignoreFailures, CancellationToken cancellationToken)
         {
             IDictionary<string, ConfigurationSetting> data = null;
             string cachedData = null;
@@ -404,7 +404,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
         }
 
-        private async Task RefreshIndividualKeyValues(CancellationToken cancellationToken = default)
+        private async Task RefreshIndividualKeyValues(CancellationToken cancellationToken)
         {
             bool shouldRefreshAll = false;
 
@@ -504,7 +504,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
         }
 
-        private async Task RefreshKeyValueAdapters(CancellationToken cancellationToken = default)
+        private async Task RefreshKeyValueAdapters(CancellationToken cancellationToken)
         {
             if (_options.Adapters.Any(adapter => adapter.NeedsRefresh()))
             {
@@ -512,7 +512,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
         }
 
-        private async Task RefreshKeyValueCollections(CancellationToken cancellationToken = default)
+        private async Task RefreshKeyValueCollections(CancellationToken cancellationToken)
         {
             foreach (KeyValueWatcher changeWatcher in _options.MultiKeyWatchers)
             {
@@ -563,7 +563,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
         }
 
-        private async Task SetData(IDictionary<string, ConfigurationSetting> data, bool ignoreFailures = false, CancellationToken cancellationToken = default)
+        private async Task SetData(IDictionary<string, ConfigurationSetting> data, bool ignoreFailures, CancellationToken cancellationToken)
         {
             // Update cache of settings
             this._applicationSettings = data as Dictionary<string, ConfigurationSetting> ??
@@ -660,7 +660,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         private async Task CallWithRequestTracing(Func<Task> clientCall)
         {
             var requestType = _isInitialLoadComplete ? RequestType.Watch : RequestType.Startup;
-            await TracingUtils.CallWithRequestTracing(_requestTracingEnabled, requestType, _requestTracingOptions, clientCall).ConfigureAwait(false);
+            TracingUtils.CallWithRequestTracing(_requestTracingEnabled, requestType, _requestTracingOptions, clientCall);
         }
 
         private void SetRequestTracingOptions()

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -366,7 +366,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
         }
 
-        private async Task LoadKeyValuesRegisteredForRefresh(IDictionary<string, ConfigurationSetting> data, CancellationToken cancellationToken = default)
+        private async Task LoadKeyValuesRegisteredForRefresh(IDictionary<string, ConfigurationSetting> data, CancellationToken cancellationToken)
         {
             _watchedSettings.Clear();
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             _isInitialLoadComplete = true;
         }
 
-        public async Task RefreshAsync()
+        public async Task RefreshAsync(CancellationToken cancellationToken)
         {
             // Ensure that concurrent threads do not simultaneously execute refresh operation. 
             if (Interlocked.Exchange(ref _networkOperationsInProgress, 1) == 0)
@@ -174,15 +174,15 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                         if (InitializationCacheExpires < DateTimeOffset.UtcNow)
                         {
                             InitializationCacheExpires = DateTimeOffset.UtcNow.Add(MinCacheExpirationInterval);
-                            await LoadAll(ignoreFailures: false).ConfigureAwait(false);
+                            await LoadAll(ignoreFailures: false, cancellationToken).ConfigureAwait(false);
                         }
 
                         return;
                     }
 
-                    await RefreshIndividualKeyValues().ConfigureAwait(false);
-                    await RefreshKeyValueCollections().ConfigureAwait(false);
-                    await RefreshKeyValueAdapters().ConfigureAwait(false);
+                    await RefreshIndividualKeyValues(cancellationToken).ConfigureAwait(false);
+                    await RefreshKeyValueCollections(cancellationToken).ConfigureAwait(false);
+                    await RefreshKeyValueAdapters(cancellationToken).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -191,11 +191,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
         }
 
-        public async Task<bool> TryRefreshAsync()
+        public async Task<bool> TryRefreshAsync(CancellationToken cancellationToken)
         {
             try
             {
-                await RefreshAsync().ConfigureAwait(false);
+                await RefreshAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (RequestFailedException e)
             {
@@ -252,7 +252,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
         }
 
-        private async Task LoadAll(bool ignoreFailures)
+        private async Task LoadAll(bool ignoreFailures, CancellationToken cancellationToken = default)
         {
             IDictionary<string, ConfigurationSetting> data = null;
             string cachedData = null;
@@ -275,7 +275,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
                     await CallWithRequestTracing(async () =>
                     {
-                        await foreach (ConfigurationSetting setting in _client.GetConfigurationSettingsAsync(selector, CancellationToken.None).ConfigureAwait(false))
+                        await foreach (ConfigurationSetting setting in _client.GetConfigurationSettingsAsync(selector, cancellationToken).ConfigureAwait(false))
                         {
                             serverData[setting.Key] = setting;
                         }
@@ -303,7 +303,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
                     await CallWithRequestTracing(async () =>
                     {
-                        await foreach (ConfigurationSetting setting in _client.GetConfigurationSettingsAsync(selector, CancellationToken.None).ConfigureAwait(false))
+                        await foreach (ConfigurationSetting setting in _client.GetConfigurationSettingsAsync(selector, cancellationToken).ConfigureAwait(false))
                         {
                             serverData[setting.Key] = setting;
                         }
@@ -311,7 +311,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 }
 
                 // Block current thread for the initial load of key-values registered for refresh that are not already loaded
-                await Task.Run(() => LoadKeyValuesRegisteredForRefresh(serverData).ConfigureAwait(false).GetAwaiter().GetResult()).ConfigureAwait(false);
+                await Task.Run(() => LoadKeyValuesRegisteredForRefresh(serverData, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult()).ConfigureAwait(false);
                 data = serverData;
             }
             catch (Exception exception) when (exception is RequestFailedException ||
@@ -344,7 +344,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     adapter.InvalidateCache();
                 }
 
-                await SetData(data, ignoreFailures).ConfigureAwait(false);
+                await SetData(data, ignoreFailures, cancellationToken).ConfigureAwait(false);
 
                 // Set the cache expiration time for all refresh registered settings
                 var initialLoadTime = DateTimeOffset.UtcNow;
@@ -366,7 +366,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
         }
 
-        private async Task LoadKeyValuesRegisteredForRefresh(IDictionary<string, ConfigurationSetting> data)
+        private async Task LoadKeyValuesRegisteredForRefresh(IDictionary<string, ConfigurationSetting> data, CancellationToken cancellationToken = default)
         {
             _watchedSettings.Clear();
 
@@ -388,7 +388,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 ConfigurationSetting watchedKv = null;
                 try
                 {
-                    await CallWithRequestTracing(async () => watchedKv = await _client.GetConfigurationSettingAsync(watchedKey, watchedLabel, CancellationToken.None)).ConfigureAwait(false);
+                    await CallWithRequestTracing(async () => watchedKv = await _client.GetConfigurationSettingAsync(watchedKey, watchedLabel, cancellationToken)).ConfigureAwait(false);
                 }
                 catch (RequestFailedException e) when (e.Status == (int)HttpStatusCode.NotFound)
                 {
@@ -404,7 +404,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
         }
 
-        private async Task RefreshIndividualKeyValues()
+        private async Task RefreshIndividualKeyValues(CancellationToken cancellationToken = default)
         {
             bool shouldRefreshAll = false;
 
@@ -426,7 +426,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 {
                     KeyValueChange keyValueChange = default;
                     await TracingUtils.CallWithRequestTracing(_requestTracingEnabled, RequestType.Watch, _requestTracingOptions,
-                        async () => keyValueChange = await _client.GetKeyValueChange(watchedKv, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
+                        async () => keyValueChange = await _client.GetKeyValueChange(watchedKv, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
 
                     changeWatcher.CacheExpires = DateTimeOffset.UtcNow.Add(changeWatcher.CacheExpirationInterval);
 
@@ -459,7 +459,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
                     try
                     {
-                        await CallWithRequestTracing(async () => watchedKv = await _client.GetConfigurationSettingAsync(watchedKey, watchedLabel, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
+                        await CallWithRequestTracing(async () => watchedKv = await _client.GetConfigurationSettingAsync(watchedKey, watchedLabel, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
                     }
                     catch (RequestFailedException e) when (e.Status == (int)HttpStatusCode.NotFound)
                     {
@@ -479,40 +479,40 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
                         hasChanged = true;
 
-                            // Add the key-value if it is not loaded, or update it if it was loaded with a different label
-                            _applicationSettings[watchedKey] = watchedKv;
-                            _watchedSettings[watchedKeyLabel] = watchedKv;
+                        // Add the key-value if it is not loaded, or update it if it was loaded with a different label
+                        _applicationSettings[watchedKey] = watchedKv;
+                        _watchedSettings[watchedKeyLabel] = watchedKv;
 
-                            // Invalidate the cached Key Vault secret (if any) for this ConfigurationSetting
-                            foreach (IKeyValueAdapter adapter in _options.Adapters)
-                            {
-                                adapter.InvalidateCache(watchedKv);
-                            }
+                        // Invalidate the cached Key Vault secret (if any) for this ConfigurationSetting
+                        foreach (IKeyValueAdapter adapter in _options.Adapters)
+                        {
+                            adapter.InvalidateCache(watchedKv);
                         }
                     }
+                }
 
                 if (hasChanged)
                 {
-                    await SetData(_applicationSettings).ConfigureAwait(false);
+                    await SetData(_applicationSettings, false, cancellationToken).ConfigureAwait(false);
                 }
             }
 
             // Trigger a single refresh-all operation if a change was detected in one or more key-values with refreshAll: true
             if (shouldRefreshAll)
             {
-                await LoadAll(ignoreFailures: false).ConfigureAwait(false);
+                await LoadAll(ignoreFailures: false, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async Task RefreshKeyValueAdapters()
+        private async Task RefreshKeyValueAdapters(CancellationToken cancellationToken = default)
         {
             if (_options.Adapters.Any(adapter => adapter.NeedsRefresh()))
             {
-                SetData(_applicationSettings);
+                SetData(_applicationSettings, false, cancellationToken);
             }
         }
 
-        private async Task RefreshKeyValueCollections()
+        private async Task RefreshKeyValueCollections(CancellationToken cancellationToken = default)
         {
             foreach (KeyValueWatcher changeWatcher in _options.MultiKeyWatchers)
             {
@@ -541,13 +541,16 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     });
                 }
 
-                IEnumerable<KeyValueChange> keyValueChanges = await _client.GetKeyValueChangeCollection(currentKeyValues, new GetKeyValueChangeCollectionOptions
-                {
-                    KeyFilter = changeWatcher.Key,
-                    Label = changeWatcher.Label.NormalizeNull(),
-                    RequestTracingEnabled = _requestTracingEnabled,
-                    RequestTracingOptions = _requestTracingOptions
-                }).ConfigureAwait(false);
+                IEnumerable<KeyValueChange> keyValueChanges = await _client.GetKeyValueChangeCollection(
+                    currentKeyValues, 
+                    new GetKeyValueChangeCollectionOptions
+                    {
+                        KeyFilter = changeWatcher.Key,
+                        Label = changeWatcher.Label.NormalizeNull(),
+                        RequestTracingEnabled = _requestTracingEnabled,
+                        RequestTracingOptions = _requestTracingOptions
+                    }, 
+                    cancellationToken).ConfigureAwait(false);
 
                 changeWatcher.CacheExpires = DateTimeOffset.UtcNow.Add(changeWatcher.CacheExpirationInterval);
 
@@ -555,7 +558,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 {
                     ProcessChanges(keyValueChanges);
 
-                    await SetData(_applicationSettings).ConfigureAwait(false);
+                    await SetData(_applicationSettings, false, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
@@ -3,6 +3,7 @@
 //
 using Microsoft.Extensions.Logging;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
@@ -32,20 +33,20 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             AppConfigurationEndpoint = _provider.AppConfigurationEndpoint;
         }
 
-        public async Task RefreshAsync()
+        public async Task RefreshAsync(CancellationToken cancellationToken)
         {
             ThrowIfNullProvider(nameof(RefreshAsync));
-            await _provider.RefreshAsync().ConfigureAwait(false);
+            await _provider.RefreshAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<bool> TryRefreshAsync()
+        public async Task<bool> TryRefreshAsync(CancellationToken cancellationToken)
         {
             if (_provider == null)
             {
                 return false;
             }
 
-            return await _provider.TryRefreshAsync().ConfigureAwait(false);
+            return await _provider.TryRefreshAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public void SetDirty(TimeSpan? maxDelay)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
             };
         }
 
-        public static async Task<IEnumerable<KeyValueChange>> GetKeyValueChangeCollection(this ConfigurationClient client, IEnumerable<ConfigurationSetting> keyValues, GetKeyValueChangeCollectionOptions options, CancellationToken cancellationToken = default)
+        public static async Task<IEnumerable<KeyValueChange>> GetKeyValueChangeCollection(this ConfigurationClient client, IEnumerable<ConfigurationSetting> keyValues, GetKeyValueChangeCollectionOptions options, CancellationToken cancellationToken)
         {
             if (options == null)
             {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
             };
         }
 
-        public static async Task<IEnumerable<KeyValueChange>> GetKeyValueChangeCollection(this ConfigurationClient client, IEnumerable<ConfigurationSetting> keyValues, GetKeyValueChangeCollectionOptions options)
+        public static async Task<IEnumerable<KeyValueChange>> GetKeyValueChangeCollection(this ConfigurationClient client, IEnumerable<ConfigurationSetting> keyValues, GetKeyValueChangeCollectionOptions options, CancellationToken cancellationToken = default)
         {
             if (options == null)
             {
@@ -107,7 +107,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
             await TracingUtils.CallWithRequestTracing(options.RequestTracingEnabled, RequestType.Watch, options.RequestTracingOptions,
                 async () =>
                 {
-                    await foreach(ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector).ConfigureAwait(false))
+                    await foreach(ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector, cancellationToken).ConfigureAwait(false))
                     {
                         if (!eTagMap.TryGetValue(setting.Key, out ETag etag) || !etag.Equals(setting.ETag))
                         {
@@ -140,7 +140,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                 await TracingUtils.CallWithRequestTracing(options.RequestTracingEnabled, RequestType.Watch, options.RequestTracingOptions,
                     async () =>
                     {
-                        await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector).ConfigureAwait(false))
+                        await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector, cancellationToken).ConfigureAwait(false))
                         {
                             if (!eTagMap.TryGetValue(setting.Key, out ETag etag) || !etag.Equals(setting.ETag))
                             {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -42,11 +42,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                     // Conditionally on based on feature filters
                     for (int i = 0; i < featureFlag.Conditions.ClientFilters.Count; i++)
                     {
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
-                        }
-
                         ClientFilter clientFilter = featureFlag.Conditions.ClientFilters[i];
 
                         keyValues.Add(new KeyValuePair<string, string>($"{FeatureManagementConstants.SectionName}:{featureFlag.Id}:{FeatureManagementConstants.EnabledFor}:{i}:Name", clientFilter.Name));

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -4,6 +4,7 @@
 using Azure;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
@@ -26,18 +27,20 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// Refreshes the data from App Configuration asynchronously.
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <exception cref="KeyVaultReferenceException">An error occurred when resolving a reference to an Azure Key Vault resource.</exception>
         /// <exception cref="RequestFailedException">The request failed with an error code from the server.</exception>
         /// <exception cref="AggregateException">
         /// The refresh operation failed with one or more errors. Check <see cref="AggregateException.InnerExceptions"/> for more details.
         /// </exception>
         /// <exception cref="InvalidOperationException">The refresh operation was invoked before Azure App Configuration Provider was initialized.</exception>
-        Task RefreshAsync();
+        Task RefreshAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Refreshes the data from App Configuration asynchronously. A return value indicates whether the operation succeeded.
         /// </summary>
-        Task<bool> TryRefreshAsync();
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        Task<bool> TryRefreshAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Sets the cached value for key-values registered for refresh as dirty.

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -70,15 +70,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return false;
         }
 
-        public static async Task CallWithRequestTracing(bool tracingEnabled, RequestType requestType, RequestTracingOptions requestTracingOptions, Action clientCall)
-        {
-            await CallWithRequestTracing(tracingEnabled, requestType, requestTracingOptions, () =>
-            {
-                clientCall();
-                return Task.CompletedTask;
-            }).ConfigureAwait(false);
-        }
-
         public static async Task CallWithRequestTracing(bool tracingEnabled, RequestType requestType, RequestTracingOptions requestTracingOptions, Func<Task> clientCall)
         {
             string correlationContextHeader = "";

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -1132,6 +1132,40 @@ namespace Tests.AzureAppConfiguration
             Assert.Throws<ArgumentException>(action);
         }
 
+        [Fact]
+        public void RefreshTests_RefreshIsCancelled()
+        {
+            IConfigurationRefresher refresher = null;
+            var mockClient = GetMockConfigurationClient();
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = mockClient.Object;
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.Register("TestKey1", "label")
+                            .SetCacheExpiration(TimeSpan.FromSeconds(1));
+                    });
+
+                    refresher = options.GetRefresher();
+                })
+                .Build();
+
+            Assert.Equal("TestValue1", config["TestKey1"]);
+            FirstKeyValue.Value = "newValue1";
+
+            // Wait for the cache to expire
+            Thread.Sleep(1500);
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.Zero);  
+            Action action = () => refresher.RefreshAsync(cancellationSource.Token).Wait();
+            var exception =  Assert.Throws<AggregateException>(action);
+            Assert.IsType<TaskCanceledException>(exception.InnerException);
+            Assert.Equal("TestValue1", config["TestKey1"]);
+        }
+
         private void WaitAndRefresh(IConfigurationRefresher refresher, int millisecondsDelay)
         {
             Task.Delay(millisecondsDelay).Wait();
@@ -1145,11 +1179,21 @@ namespace Tests.AzureAppConfiguration
 
             Response<ConfigurationSetting> GetTestKey(string key, string label, CancellationToken cancellationToken)
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
                 return Response.FromValue(TestHelpers.CloneSetting(_kvCollection.FirstOrDefault(s => s.Key == key && s.Label == label)), mockResponse.Object);
             }
 
             Response<ConfigurationSetting> GetIfChanged(ConfigurationSetting setting, bool onlyIfChanged, CancellationToken cancellationToken)
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
                 var newSetting = _kvCollection.FirstOrDefault(s => (s.Key == setting.Key && s.Label == setting.Label));
                 var unchanged = (newSetting.Key == setting.Key && newSetting.Label == setting.Label && newSetting.Value == setting.Value);
                 var response = new MockResponse(unchanged ? 304 : 200);


### PR DESCRIPTION
This PR adds a cancellation token to `RefreshAsync` and `TryRefreshAsync` methods.
Since the `IConfigurationRefresher` interface has changed, this is a breaking change. However, users will still be able to call  `RefreshAsync()` and `TryRefreshAsync()` without any parameter.

Fix #275