### PR TITLE
Make AspNetCore project reference base project instead of NuGet package

### DIFF
--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="4.5.0" />
+    <ProjectReference Include="..\Microsoft.Extensions.Configuration.AzureAppConfiguration\Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj" />
   </ItemGroup>
-
+  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
   </ItemGroup>


### PR DESCRIPTION
The AspNetCore projects references `Microsoft.Extensions.Configuration.AzureAppConfiguration` package from NuGet. This causes two problems:
- We cannot release both packages in the same release because AspNetCore project needs to wait for base package to be published to NuGet first.
- When adding new features to base project, we cannot start using them in the AspNetCore project immediately. AspNetCore project needs to wait for base package to be published to NuGet first.

This PR removes the dependency on NuGet package and adds a direct reference to `Microsoft.Extensions.Configuration.AzureAppConfiguration` project in AspNetCore project.