### PR TITLE
Update cache expiration time if refresh operation failed

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -18,9 +18,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     /// </summary>
     public class AzureAppConfigurationOptions
     {
-        internal static readonly TimeSpan DefaultFeatureFlagsCacheExpirationInterval = TimeSpan.FromSeconds(30);
-        internal static readonly TimeSpan MinimumFeatureFlagsCacheExpirationInterval = TimeSpan.FromMilliseconds(1000);
-
         private const int MaxRetries = 2;
         private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(1);
 
@@ -167,10 +164,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             FeatureFlagOptions options = new FeatureFlagOptions();
             configure?.Invoke(options);
 
-            if (options.CacheExpirationInterval < MinimumFeatureFlagsCacheExpirationInterval)
+            if (options.CacheExpirationInterval < RefreshConstants.MinimumFeatureFlagsCacheExpirationInterval)
             {
                 throw new ArgumentOutOfRangeException(nameof(options.CacheExpirationInterval), options.CacheExpirationInterval.TotalMilliseconds,
-                    string.Format(ErrorMessages.CacheExpirationTimeTooShort, MinimumFeatureFlagsCacheExpirationInterval.TotalMilliseconds));
+                    string.Format(ErrorMessages.CacheExpirationTimeTooShort, RefreshConstants.MinimumFeatureFlagsCacheExpirationInterval.TotalMilliseconds));
             }
 
             if (options.FeatureFlagSelectors.Count() != 0 && options.Label != null)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -737,7 +737,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     changeWatcher.RefreshAttempt++;
                 }
 
-                cacheExpirationTime = CalculateBackoffTime(cacheExpirationTime, changeWatcher.RefreshAttempt);
+                cacheExpirationTime = CalculateBackoffTime(changeWatcher.CacheExpirationInterval, changeWatcher.RefreshAttempt);
             }
             else
             {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -728,7 +728,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         private void UpdateCacheExpirationTime(KeyValueWatcher changeWatcher, DateTimeOffset initialLoadTime, bool operationFailed = false)
         {
-            var cacheExpirationTime = changeWatcher.CacheExpirationInterval;
+            TimeSpan cacheExpirationTime;
 
             if (operationFailed)
             {
@@ -738,6 +738,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 }
 
                 cacheExpirationTime = CalculateBackoffTime(cacheExpirationTime, changeWatcher.RefreshAttempt);
+            }
+            else
+            {
+                changeWatcher.RefreshAttempt = 0;
+                cacheExpirationTime = changeWatcher.CacheExpirationInterval;
             }
 
             changeWatcher.CacheExpires = initialLoadTime.Add(cacheExpirationTime);

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -419,9 +419,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     continue;
                 }
 
+                changeWatcher.CacheExpires = DateTimeOffset.UtcNow.Add(changeWatcher.CacheExpirationInterval);
                 bool hasChanged = false;
                 KeyValueIdentifier watchedKeyLabel = new KeyValueIdentifier(watchedKey, watchedLabel);
-                changeWatcher.CacheExpires = DateTimeOffset.UtcNow.Add(changeWatcher.CacheExpirationInterval);
 
                 if (_watchedSettings.TryGetValue(watchedKeyLabel, out ConfigurationSetting watchedKv))
                 {
@@ -520,6 +520,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     continue;
                 }
 
+                changeWatcher.CacheExpires = DateTimeOffset.UtcNow.Add(changeWatcher.CacheExpirationInterval);
                 IEnumerable<ConfigurationSetting> currentKeyValues;
 
                 if (changeWatcher.Key.EndsWith("*"))
@@ -539,7 +540,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     });
                 }
 
-                changeWatcher.CacheExpires = DateTimeOffset.UtcNow.Add(changeWatcher.CacheExpirationInterval);
                 IEnumerable<KeyValueChange> keyValueChanges = await _client.GetKeyValueChangeCollection(
                     currentKeyValues, 
                     new GetKeyValueChangeCollectionOptions

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -38,9 +38,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         private static readonly TimeSpan MinDelayForUnhandledFailure = TimeSpan.FromSeconds(5);
         private static readonly TimeSpan DefaultMaxSetDirtyDelay = TimeSpan.FromSeconds(30);
-        
-        private static readonly TimeSpan DefaultBackoffDuringRefreshErrors = TimeSpan.FromSeconds(1);
-        private static readonly TimeSpan MaxBackoffDuringRefreshErrors = TimeSpan.FromMinutes(10);
         private const int MaxRefreshAttempts = 20;
 
         // To avoid concurrent network operations, this flag is used to achieve synchronization between multiple threads.
@@ -260,6 +257,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         {
             IDictionary<string, ConfigurationSetting> data = null;
             string cachedData = null;
+            bool success = false;
 
             try
             {
@@ -317,8 +315,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 // Block current thread for the initial load of key-values registered for refresh that are not already loaded
                 await Task.Run(() => LoadKeyValuesRegisteredForRefresh(serverData, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult()).ConfigureAwait(false);
                 data = serverData;
+                success = true;
             }
-            catch (Exception exception) when (CanHandleException(exception))
+            catch (Exception exception) when (exception is RequestFailedException ||
+                                            ((exception as AggregateException)?.InnerExceptions?.All(e => e is RequestFailedException) ?? false) ||
+                                            exception is OperationCanceledException)
             {
                 if (_options.OfflineCache != null)
                 {
@@ -334,8 +335,15 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 // If we're unable to load data from offline cache, check if we need to ignore or rethrow the exception 
                 if (data == null && !ignoreFailures)
                 {
-                    UpdateCacheExpirationTimeForAllChangeWatchers(DateTimeOffset.UtcNow, operationFailed: true);
                     throw;
+                }
+            }
+            finally
+            {
+                // Update the cache expiration time for all refresh registered settings and feature flags
+                foreach (KeyValueWatcher changeWatcher in _options.ChangeWatchers.Concat(_options.MultiKeyWatchers))
+                {
+                    UpdateCacheExpirationTime(changeWatcher, success);
                 }
             }
 
@@ -346,8 +354,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 {
                     adapter.InvalidateCache();
                 }
-
-                UpdateCacheExpirationTimeForAllChangeWatchers(DateTimeOffset.UtcNow, operationFailed: false);
 
                 await SetData(data, ignoreFailures, cancellationToken).ConfigureAwait(false);
                 
@@ -399,6 +405,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         private async Task RefreshIndividualKeyValues(CancellationToken cancellationToken)
         {
             bool shouldRefreshAll = false;
+            bool success = false;
 
             foreach (KeyValueWatcher changeWatcher in _options.ChangeWatchers)
             {
@@ -422,11 +429,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     {
                         await TracingUtils.CallWithRequestTracing(_requestTracingEnabled, RequestType.Watch, _requestTracingOptions,
                             async () => keyValueChange = await _client.GetKeyValueChange(watchedKv, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
+
+                        success = true;
                     }
-                    catch (Exception exception) when (CanHandleException(exception))
+                    finally
                     {
-                        UpdateCacheExpirationTime(changeWatcher, DateTime.UtcNow, operationFailed: true);
-                        throw;
+                        UpdateCacheExpirationTime(changeWatcher, success);
                     }
 
                     // Check if a change has been detected in the key-value registered for refresh
@@ -459,15 +467,16 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     try
                     {
                         await CallWithRequestTracing(async () => watchedKv = await _client.GetConfigurationSettingAsync(watchedKey, watchedLabel, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
+                        success = true;
                     }
                     catch (RequestFailedException e) when (e.Status == (int)HttpStatusCode.NotFound)
                     {
                         watchedKv = null;
+                        success = true;
                     }
-                    catch (Exception exception) when (CanHandleException(exception))
+                    finally
                     {
-                        UpdateCacheExpirationTime(changeWatcher, DateTime.UtcNow, operationFailed: true);
-                        throw;
+                        UpdateCacheExpirationTime(changeWatcher, success);
                     }
 
                     if (watchedKv != null)
@@ -492,8 +501,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     }
                 }
                 
-                UpdateCacheExpirationTime(changeWatcher, DateTime.UtcNow, operationFailed: false);
-
                 if (hasChanged)
                 {
                     await SetData(_applicationSettings, false, cancellationToken).ConfigureAwait(false);
@@ -519,6 +526,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         private async Task RefreshKeyValueCollections(CancellationToken cancellationToken)
         {
+            bool success = false;
+
             foreach (KeyValueWatcher changeWatcher in _options.MultiKeyWatchers)
             {
                 // Skip the refresh for this key-prefix if the cached value has not expired
@@ -559,16 +568,15 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                             RequestTracingOptions = _requestTracingOptions
                         },
                         cancellationToken).ConfigureAwait(false);
+
+                    success = true;
                 }
-                catch (Exception exception) when (CanHandleException(exception))
+                finally
                 {
-                    UpdateCacheExpirationTime(changeWatcher, DateTime.UtcNow, operationFailed: true);
-                    throw;
+                    UpdateCacheExpirationTime(changeWatcher, success);
                 }
 
-                UpdateCacheExpirationTime(changeWatcher, DateTime.UtcNow, operationFailed: false);
-
-                if (keyValueChanges?.Any() == true)
+                if (keyValueChanges.Any())
                 {
                     ProcessChanges(keyValueChanges);
 
@@ -710,52 +718,26 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return false;
         }
 
-        private bool CanHandleException(Exception exception)
-        {
-            return exception is RequestFailedException ||
-                    ((exception as AggregateException)?.InnerExceptions?.All(e => e is RequestFailedException) ?? false) ||
-                    exception is OperationCanceledException;
-        }
-
-        private void UpdateCacheExpirationTimeForAllChangeWatchers(DateTimeOffset initialLoadTime, bool operationFailed = false)
-        {
-            // Update the cache expiration time for all refresh registered settings and feature flags
-            foreach (KeyValueWatcher changeWatcher in _options.ChangeWatchers.Concat(_options.MultiKeyWatchers))
-            {
-                UpdateCacheExpirationTime(changeWatcher, initialLoadTime, operationFailed);
-            }
-        }
-
-        private void UpdateCacheExpirationTime(KeyValueWatcher changeWatcher, DateTimeOffset initialLoadTime, bool operationFailed = false)
+        private void UpdateCacheExpirationTime(KeyValueWatcher changeWatcher, bool success)
         {
             TimeSpan cacheExpirationTime;
 
-            if (operationFailed)
+            if (success)
             {
-                if (changeWatcher.RefreshAttempt < MaxRefreshAttempts)
-                {
-                    changeWatcher.RefreshAttempt++;
-                }
-
-                cacheExpirationTime = CalculateBackoffTime(changeWatcher.CacheExpirationInterval, changeWatcher.RefreshAttempt);
+                changeWatcher.RefreshAttempts = 0;
+                cacheExpirationTime = changeWatcher.CacheExpirationInterval;
             }
             else
             {
-                changeWatcher.RefreshAttempt = 0;
-                cacheExpirationTime = changeWatcher.CacheExpirationInterval;
+                if (changeWatcher.RefreshAttempts < MaxRefreshAttempts)
+                {
+                    changeWatcher.RefreshAttempts++;
+                }
+
+                cacheExpirationTime = changeWatcher.CacheExpirationInterval.CalculateBackoffTime(changeWatcher.RefreshAttempts);
             }
 
-            changeWatcher.CacheExpires = initialLoadTime.Add(cacheExpirationTime);
-        }
-
-        private TimeSpan CalculateBackoffTime(TimeSpan cacheExpirationTime, int attempts)
-        {
-            TimeSpan maxBackoff = cacheExpirationTime < MaxBackoffDuringRefreshErrors ? cacheExpirationTime : MaxBackoffDuringRefreshErrors;
-
-            long ticks = DefaultBackoffDuringRefreshErrors.Ticks * new Random().Next(0, (int)Math.Min(Math.Pow(2, attempts - 1), int.MaxValue));
-            TimeSpan calculatedBackoff = TimeSpan.FromTicks(Math.Max(DefaultBackoffDuringRefreshErrors.Ticks, ticks));
-            
-            return maxBackoff < calculatedBackoff ? maxBackoff : calculatedBackoff;
+            changeWatcher.CacheExpires = DateTimeOffset.UtcNow.Add(cacheExpirationTime);
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         private static readonly TimeSpan MinDelayForUnhandledFailure = TimeSpan.FromSeconds(5);
         private static readonly TimeSpan DefaultMaxSetDirtyDelay = TimeSpan.FromSeconds(30);
-        private const int MaxRefreshAttempts = 20;
 
         // To avoid concurrent network operations, this flag is used to achieve synchronization between multiple threads.
         private int _networkOperationsInProgress = 0;
@@ -405,7 +404,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         private async Task RefreshIndividualKeyValues(CancellationToken cancellationToken)
         {
             bool shouldRefreshAll = false;
-            bool success = false;
 
             foreach (KeyValueWatcher changeWatcher in _options.ChangeWatchers)
             {
@@ -424,6 +422,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 if (_watchedSettings.TryGetValue(watchedKeyLabel, out ConfigurationSetting watchedKv))
                 {
                     KeyValueChange keyValueChange = default;
+                    bool success = false;
 
                     try
                     {
@@ -463,6 +462,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 {
                     // Load the key-value in case the previous load attempts had failed
                     var options = new SettingSelector { LabelFilter = watchedLabel };
+                    bool success = false;
 
                     try
                     {
@@ -729,7 +729,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             }
             else
             {
-                if (changeWatcher.RefreshAttempts < MaxRefreshAttempts)
+                if (changeWatcher.RefreshAttempts < int.MaxValue)
                 {
                     changeWatcher.RefreshAttempts++;
                 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefreshOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefreshOptions.cs
@@ -12,10 +12,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     /// </summary>
     public class AzureAppConfigurationRefreshOptions
     {
-        internal static readonly TimeSpan DefaultCacheExpirationInterval = TimeSpan.FromSeconds(30);
-        internal static readonly TimeSpan MinimumCacheExpirationInterval = TimeSpan.FromMilliseconds(1000);
-
-        internal TimeSpan CacheExpirationInterval { get; private set; } = DefaultCacheExpirationInterval;
+        internal TimeSpan CacheExpirationInterval { get; private set; } = RefreshConstants.DefaultCacheExpirationInterval;
         internal ISet<KeyValueWatcher> RefreshRegistrations = new HashSet<KeyValueWatcher>();
         
         /// <summary>
@@ -55,10 +52,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <param name="cacheExpiration">Minimum time that must elapse before the cache is expired.</param>
         public AzureAppConfigurationRefreshOptions SetCacheExpiration(TimeSpan cacheExpiration)
         {
-            if (cacheExpiration < MinimumCacheExpirationInterval)
+            if (cacheExpiration < RefreshConstants.MinimumCacheExpirationInterval)
             {
                 throw new ArgumentOutOfRangeException(nameof(cacheExpiration), cacheExpiration.TotalMilliseconds,
-                    string.Format(ErrorMessages.CacheExpirationTimeTooShort, MinimumCacheExpirationInterval.TotalMilliseconds));
+                    string.Format(ErrorMessages.CacheExpirationTimeTooShort, RefreshConstants.MinimumCacheExpirationInterval.TotalMilliseconds));
             }
 
             CacheExpirationInterval = cacheExpiration;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultSecretProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultSecretProvider.cs
@@ -20,8 +20,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
         private string _nextRefreshKey;
         private DateTimeOffset? _nextRefreshTime;
         private const string AzureIdentityAssemblyName = "Azure.Identity";
-        private static readonly TimeSpan DefaultBackoffDuringRefreshErrors = TimeSpan.FromSeconds(1);
-        private static readonly TimeSpan MaxBackoffDuringRefreshErrors = TimeSpan.FromMinutes(10);
         private const int MaxRefreshAttempts = 20;
 
         public AzureKeyVaultSecretProvider(AzureAppConfigurationKeyVaultOptions keyVaultOptions = null)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultSecretProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultSecretProvider.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
         private readonly Dictionary<string, CachedKeyVaultSecret> _cachedKeyVaultSecrets;
         private string _nextRefreshKey;
         private DateTimeOffset? _nextRefreshTime;
-        private const string AzureIdentityAssemblyName = "Azure.Identity";
-        private const int MaxRefreshAttempts = 20;
 
         public AzureKeyVaultSecretProvider(AzureAppConfigurationKeyVaultOptions keyVaultOptions = null)
         {
@@ -179,7 +177,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
         {
             DateTimeOffset? refreshSecretAt = null;
 
-            if (cachedSecret.RefreshAttempts < MaxRefreshAttempts)
+            if (cachedSecret.RefreshAttempts < int.MaxValue)
             {
                 cachedSecret.RefreshAttempts++;
             }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/CachedKeyVaultSecret.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/CachedKeyVaultSecret.cs
@@ -17,10 +17,16 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
         /// </summary>
         public DateTimeOffset? RefreshAt { get; set; }
 
-        public CachedKeyVaultSecret(string secretValue, DateTimeOffset? refreshAt)
+        /// <summary>
+        /// The number of times we tried to reload this secret with exponential backoff strategy.
+        /// </summary>
+        public int RefreshAttempt { get; set; }
+
+        public CachedKeyVaultSecret(string secretValue, DateTimeOffset? refreshAt, int refreshAttempt = 0)
         {
             SecretValue = secretValue;
             RefreshAt = refreshAt;
+            RefreshAttempt = refreshAttempt;
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/CachedKeyVaultSecret.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/CachedKeyVaultSecret.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
         /// </summary>
         public int RefreshAttempts { get; set; }
 
-        public CachedKeyVaultSecret(string secretValue, DateTimeOffset? refreshAt, int refreshAttempt = 0)
+        public CachedKeyVaultSecret(string secretValue, DateTimeOffset? refreshAt, int refreshAttempts = 0)
         {
             SecretValue = secretValue;
             RefreshAt = refreshAt;
-            RefreshAttempts = refreshAttempt;
+            RefreshAttempts = refreshAttempts;
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/CachedKeyVaultSecret.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/CachedKeyVaultSecret.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
         /// </summary>
         public int RefreshAttempts { get; set; }
 
-        public CachedKeyVaultSecret(string secretValue, DateTimeOffset? refreshAt = null, int refreshAttempts = 0)
+        public CachedKeyVaultSecret(string secretValue = null, DateTimeOffset? refreshAt = null, int refreshAttempts = 0)
         {
             SecretValue = secretValue;
             RefreshAt = refreshAt;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/CachedKeyVaultSecret.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/CachedKeyVaultSecret.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
         /// <summary>
         /// The number of times we tried to reload this secret with exponential backoff strategy.
         /// </summary>
-        public int RefreshAttempt { get; set; }
+        public int RefreshAttempts { get; set; }
 
         public CachedKeyVaultSecret(string secretValue, DateTimeOffset? refreshAt, int refreshAttempt = 0)
         {
             SecretValue = secretValue;
             RefreshAt = refreshAt;
-            RefreshAttempt = refreshAttempt;
+            RefreshAttempts = refreshAttempt;
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/CachedKeyVaultSecret.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/CachedKeyVaultSecret.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
         public DateTimeOffset? RefreshAt { get; set; }
 
         /// <summary>
-        /// The number of times we tried to reload this secret with exponential backoff strategy.
+        /// The number of times we tried to reload this secret.
         /// </summary>
         public int RefreshAttempts { get; set; }
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/CachedKeyVaultSecret.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/CachedKeyVaultSecret.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
         /// </summary>
         public int RefreshAttempts { get; set; }
 
-        public CachedKeyVaultSecret(string secretValue, DateTimeOffset? refreshAt, int refreshAttempts = 0)
+        public CachedKeyVaultSecret(string secretValue, DateTimeOffset? refreshAt = null, int refreshAttempts = 0)
         {
             SecretValue = secretValue;
             RefreshAt = refreshAt;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RefreshConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RefreshConstants.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public static readonly TimeSpan MinimumSecretRefreshInterval = TimeSpan.FromMilliseconds(1000);
 
         // Backoff during refresh failures
+        public static readonly TimeSpan DefaultMinBackoff = TimeSpan.FromSeconds(30);
         public static readonly TimeSpan DefaultMaxBackoff = TimeSpan.FromMinutes(10);
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RefreshConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RefreshConstants.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
+
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+{
+    internal class RefreshConstants
+    {
+        // Key-values
+        public static readonly TimeSpan DefaultCacheExpirationInterval = TimeSpan.FromSeconds(30);
+        public static readonly TimeSpan MinimumCacheExpirationInterval = TimeSpan.FromMilliseconds(1000);
+
+        // Feature flags
+        public static readonly TimeSpan DefaultFeatureFlagsCacheExpirationInterval = TimeSpan.FromSeconds(30);
+        public static readonly TimeSpan MinimumFeatureFlagsCacheExpirationInterval = TimeSpan.FromMilliseconds(1000);
+
+        // Key Vault secrets
+        public static readonly TimeSpan MinimumSecretRefreshInterval = TimeSpan.FromMilliseconds(1000);
+
+        // Backoff during refresh failures
+        public static readonly TimeSpan DefaultMaxBackoff = TimeSpan.FromMinutes(10);
+    }
+}

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RefreshConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RefreshConstants.cs
@@ -9,14 +9,14 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     {
         // Key-values
         public static readonly TimeSpan DefaultCacheExpirationInterval = TimeSpan.FromSeconds(30);
-        public static readonly TimeSpan MinimumCacheExpirationInterval = TimeSpan.FromMilliseconds(1000);
+        public static readonly TimeSpan MinimumCacheExpirationInterval = TimeSpan.FromSeconds(1);
 
         // Feature flags
         public static readonly TimeSpan DefaultFeatureFlagsCacheExpirationInterval = TimeSpan.FromSeconds(30);
-        public static readonly TimeSpan MinimumFeatureFlagsCacheExpirationInterval = TimeSpan.FromMilliseconds(1000);
+        public static readonly TimeSpan MinimumFeatureFlagsCacheExpirationInterval = TimeSpan.FromSeconds(1);
 
         // Key Vault secrets
-        public static readonly TimeSpan MinimumSecretRefreshInterval = TimeSpan.FromMilliseconds(1000);
+        public static readonly TimeSpan MinimumSecretRefreshInterval = TimeSpan.FromSeconds(1);
 
         // Backoff during refresh failures
         public static readonly TimeSpan DefaultMinBackoff = TimeSpan.FromSeconds(30);

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
@@ -5,22 +5,28 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
     internal static class TimeSpanExtensions
     {
         private static readonly TimeSpan MinBackoff = TimeSpan.FromSeconds(1);
+        private static readonly TimeSpan MaxBackoff = TimeSpan.FromMinutes(10);
 
         /// <summary>
-        /// This method calculates a random exponential backoff which lies between <see cref="MinBackoff"/> and the passed value of maxBackoff.
+        /// This method calculates a random exponential backoff which lies between <see cref="MinBackoff"/> and <see cref="MaxBackoff"/>.
         /// </summary>
-        /// <param name="maxBackoff">The maximum backoff time.</param>
+        /// <param name="interval">The maximum backoff to be used if <paramref name="interval"/> is less than <see cref="MaxBackoff"/>.</param>
         /// <param name="attempts">The number of attempts made to backoff.</param>
         /// <returns>The calculated exponential backoff time.</returns>
-        public static TimeSpan CalculateBackoffTime(this TimeSpan maxBackoff, int attempts)
+        public static TimeSpan CalculateBackoffTime(this TimeSpan interval, int attempts)
         {
             if (attempts < 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(attempts), attempts, "The number of attempts should not be less than 1.");
             }
 
-            long ticks = MinBackoff.Ticks * new Random().Next(1, (int)Math.Min(Math.Pow(2, attempts - 1), int.MaxValue));
-            TimeSpan calculatedBackoff = TimeSpan.FromTicks(ticks);
+            if (interval < MinBackoff)
+            {
+                throw new ArgumentOutOfRangeException(nameof(interval), interval, $"The interval cannot be less than {nameof(MinBackoff)}.");
+            }
+
+            TimeSpan maxBackoff = TimeSpan.FromTicks(Math.Min(interval.Ticks, MaxBackoff.Ticks));
+            TimeSpan calculatedBackoff = TimeSpan.FromTicks(MinBackoff.Ticks * new Random().Next(1, (int)Math.Min(Math.Pow(2, attempts - 1), int.MaxValue)));
 
             return TimeSpan.FromTicks(Math.Min(maxBackoff.Ticks, calculatedBackoff.Ticks));
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                 throw new ArgumentOutOfRangeException(nameof(attempts), attempts, "The number of attempts should not be less than 1.");
             }
 
-            if (interval < RefreshConstants.DefaultMinBackoff)
+            if (interval <= RefreshConstants.DefaultMinBackoff)
             {
                 return interval;
             }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
     internal static class TimeSpanExtensions
     {
         /// <summary>
-        /// This method calculates a random exponential backoff which lies between <see cref="RefreshConstants.DefaultCacheExpirationInterval"/> and <see cref="RefreshConstants.DefaultMaxBackoff"/>.
+        /// This method calculates a random exponential backoff which lies between <see cref="RefreshConstants.DefaultMinBackoff"/> and <see cref="RefreshConstants.DefaultMaxBackoff"/>.
         /// </summary>
         /// <param name="interval">The maximum backoff to be used if <paramref name="interval"/> is less than <see cref="RefreshConstants.DefaultMaxBackoff"/>.
-        /// If <paramref name="interval"/> is less than <see cref="RefreshConstants.DefaultCacheExpirationInterval"/>, <paramref name="interval"/> is returned.
+        /// If <paramref name="interval"/> is less than <see cref="RefreshConstants.DefaultMinBackoff"/>, <paramref name="interval"/> is returned.
         /// </param>
         /// <param name="attempts">The number of attempts made to backoff.</param>
-        /// <returns>The calculated exponential backoff time, or <paramref name="interval"/> if it is less than <see cref="RefreshConstants.DefaultCacheExpirationInterval"/>.</returns>
+        /// <returns>The calculated exponential backoff time, or <paramref name="interval"/> if it is less than <see cref="RefreshConstants.DefaultMinBackoff"/>.</returns>
         public static TimeSpan CalculateBackoffTime(this TimeSpan interval, int attempts)
         {
             if (attempts < 1)
@@ -22,13 +22,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                 throw new ArgumentOutOfRangeException(nameof(attempts), attempts, "The number of attempts should not be less than 1.");
             }
 
-            if (interval < RefreshConstants.DefaultCacheExpirationInterval)
+            if (interval < RefreshConstants.DefaultMinBackoff)
             {
                 return interval;
             }
 
             TimeSpan maxBackoff = TimeSpan.FromTicks(Math.Min(interval.Ticks, RefreshConstants.DefaultMaxBackoff.Ticks));
-            TimeSpan calculatedBackoff = TimeSpan.FromTicks(RefreshConstants.DefaultCacheExpirationInterval.Ticks * new Random().Next(1, (int)Math.Min(Math.Pow(2, attempts - 1), int.MaxValue)));
+            TimeSpan calculatedBackoff = TimeSpan.FromTicks(RefreshConstants.DefaultMinBackoff.Ticks * new Random().Next(1, (int)Math.Min(Math.Pow(2, attempts - 1), int.MaxValue)));
 
             return TimeSpan.FromTicks(Math.Min(maxBackoff.Ticks, calculatedBackoff.Ticks));
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
@@ -4,17 +4,20 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
 {
     internal static class TimeSpanExtensions
     {
-        private static readonly TimeSpan DefaultBackoffDuringRefreshErrors = TimeSpan.FromSeconds(1);
-        private static readonly TimeSpan MaxBackoffDuringRefreshErrors = TimeSpan.FromMinutes(10);
+        private static readonly TimeSpan MinBackoff = TimeSpan.FromSeconds(1);
 
-        public static TimeSpan CalculateBackoffTime(this TimeSpan cacheExpirationTime, int attempts)
+        /// <summary>
+        /// This method calculates a random exponential backoff which lies between <see cref="MinBackoff"/> and the passed value of maxBackoff.
+        /// </summary>
+        /// <param name="maxBackoff">The maximum backoff time.</param>
+        /// <param name="attempts">The number of attempts made to backoff.</param>
+        /// <returns>The calculated exponential backoff time.</returns>
+        public static TimeSpan CalculateBackoffTime(this TimeSpan maxBackoff, int attempts)
         {
-            TimeSpan maxBackoff = cacheExpirationTime < MaxBackoffDuringRefreshErrors ? cacheExpirationTime : MaxBackoffDuringRefreshErrors;
+            long ticks = MinBackoff.Ticks * new Random().Next(0, (int)Math.Min(Math.Pow(2, attempts - 1), int.MaxValue));
+            TimeSpan calculatedBackoff = TimeSpan.FromTicks(Math.Max(MinBackoff.Ticks, ticks));
 
-            long ticks = DefaultBackoffDuringRefreshErrors.Ticks * new Random().Next(0, (int)Math.Min(Math.Pow(2, attempts - 1), int.MaxValue));
-            TimeSpan calculatedBackoff = TimeSpan.FromTicks(Math.Max(DefaultBackoffDuringRefreshErrors.Ticks, ticks));
-
-            return maxBackoff < calculatedBackoff ? maxBackoff : calculatedBackoff;
+            return TimeSpan.FromTicks(Math.Min(maxBackoff.Ticks, calculatedBackoff.Ticks));
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
@@ -14,8 +14,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
         /// <returns>The calculated exponential backoff time.</returns>
         public static TimeSpan CalculateBackoffTime(this TimeSpan maxBackoff, int attempts)
         {
-            long ticks = MinBackoff.Ticks * new Random().Next(0, (int)Math.Min(Math.Pow(2, attempts - 1), int.MaxValue));
-            TimeSpan calculatedBackoff = TimeSpan.FromTicks(Math.Max(MinBackoff.Ticks, ticks));
+            if (attempts < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(attempts), attempts, "The number of attempts should not be less than 1.");
+            }
+
+            long ticks = MinBackoff.Ticks * new Random().Next(1, (int)Math.Min(Math.Pow(2, attempts - 1), int.MaxValue));
+            TimeSpan calculatedBackoff = TimeSpan.FromTicks(ticks);
 
             return TimeSpan.FromTicks(Math.Min(maxBackoff.Ticks, calculatedBackoff.Ticks));
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
+{
+    internal static class TimeSpanExtensions
+    {
+        private static readonly TimeSpan DefaultBackoffDuringRefreshErrors = TimeSpan.FromSeconds(1);
+        private static readonly TimeSpan MaxBackoffDuringRefreshErrors = TimeSpan.FromMinutes(10);
+
+        public static TimeSpan CalculateBackoffTime(this TimeSpan cacheExpirationTime, int attempts)
+        {
+            TimeSpan maxBackoff = cacheExpirationTime < MaxBackoffDuringRefreshErrors ? cacheExpirationTime : MaxBackoffDuringRefreshErrors;
+
+            long ticks = DefaultBackoffDuringRefreshErrors.Ticks * new Random().Next(0, (int)Math.Min(Math.Pow(2, attempts - 1), int.MaxValue));
+            TimeSpan calculatedBackoff = TimeSpan.FromTicks(Math.Max(DefaultBackoffDuringRefreshErrors.Ticks, ticks));
+
+            return maxBackoff < calculatedBackoff ? maxBackoff : calculatedBackoff;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
@@ -1,18 +1,20 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
 {
     internal static class TimeSpanExtensions
     {
-        private static readonly TimeSpan MinBackoff = TimeSpan.FromSeconds(1);
-        private static readonly TimeSpan MaxBackoff = TimeSpan.FromMinutes(10);
-
         /// <summary>
-        /// This method calculates a random exponential backoff which lies between <see cref="MinBackoff"/> and <see cref="MaxBackoff"/>.
+        /// This method calculates a random exponential backoff which lies between <see cref="RefreshConstants.DefaultCacheExpirationInterval"/> and <see cref="RefreshConstants.DefaultMaxBackoff"/>.
         /// </summary>
-        /// <param name="interval">The maximum backoff to be used if <paramref name="interval"/> is less than <see cref="MaxBackoff"/>.</param>
+        /// <param name="interval">The maximum backoff to be used if <paramref name="interval"/> is less than <see cref="RefreshConstants.DefaultMaxBackoff"/>.
+        /// If <paramref name="interval"/> is less than <see cref="RefreshConstants.DefaultCacheExpirationInterval"/>, <paramref name="interval"/> is returned.
+        /// </param>
         /// <param name="attempts">The number of attempts made to backoff.</param>
-        /// <returns>The calculated exponential backoff time.</returns>
+        /// <returns>The calculated exponential backoff time, or <paramref name="interval"/> if it is less than <see cref="RefreshConstants.DefaultCacheExpirationInterval"/>.</returns>
         public static TimeSpan CalculateBackoffTime(this TimeSpan interval, int attempts)
         {
             if (attempts < 1)
@@ -20,13 +22,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                 throw new ArgumentOutOfRangeException(nameof(attempts), attempts, "The number of attempts should not be less than 1.");
             }
 
-            if (interval < MinBackoff)
+            if (interval < RefreshConstants.DefaultCacheExpirationInterval)
             {
-                throw new ArgumentOutOfRangeException(nameof(interval), interval, $"The interval cannot be less than {nameof(MinBackoff)}.");
+                return interval;
             }
 
-            TimeSpan maxBackoff = TimeSpan.FromTicks(Math.Min(interval.Ticks, MaxBackoff.Ticks));
-            TimeSpan calculatedBackoff = TimeSpan.FromTicks(MinBackoff.Ticks * new Random().Next(1, (int)Math.Min(Math.Pow(2, attempts - 1), int.MaxValue)));
+            TimeSpan maxBackoff = TimeSpan.FromTicks(Math.Min(interval.Ticks, RefreshConstants.DefaultMaxBackoff.Ticks));
+            TimeSpan calculatedBackoff = TimeSpan.FromTicks(RefreshConstants.DefaultCacheExpirationInterval.Ticks * new Random().Next(1, (int)Math.Min(Math.Pow(2, attempts - 1), int.MaxValue)));
 
             return TimeSpan.FromTicks(Math.Min(maxBackoff.Ticks, calculatedBackoff.Ticks));
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlagOptions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         /// <summary>
         /// The time after which the cached values of the feature flags expire.  Must be greater than or equal to 1 second.
         /// </summary>
-        public TimeSpan CacheExpirationInterval { get; set; } = AzureAppConfigurationOptions.DefaultFeatureFlagsCacheExpirationInterval;
+        public TimeSpan CacheExpirationInterval { get; set; } = RefreshConstants.DefaultFeatureFlagsCacheExpirationInterval;
 
         /// <summary>
         /// Specify what feature flags to include in the configuration provider.

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
         /// </summary>
         public DateTimeOffset CacheExpires { get; set; }
 
+        /// <summary>
+        /// The number of times we tried to reload this key-value with exponential backoff strategy.
+        /// </summary>
+        public int RefreshAttempt { get; set; } = 0;
+
         public override bool Equals(object obj)
         {
             if (obj is KeyValueWatcher kvWatcher)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
         /// <summary>
         /// The number of times we tried to reload this key-value with exponential backoff strategy.
         /// </summary>
-        public int RefreshAttempt { get; set; } = 0;
+        public int RefreshAttempts { get; set; } = 0;
 
         public override bool Equals(object obj)
         {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
         public DateTimeOffset CacheExpires { get; set; }
 
         /// <summary>
-        /// The number of times we tried to reload this key-value with exponential backoff strategy.
+        /// The number of times we tried to reload this key-value.
         /// </summary>
         public int RefreshAttempts { get; set; } = 0;
 

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -1166,6 +1166,46 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("TestValue1", config["TestKey1"]);
         }
 
+        [Fact]
+        public void RefreshTests_UpdateCacheExpirationTimeForFailedRefreshOperations()
+        {
+            IConfigurationRefresher refresher = null;
+            var mockClient = GetMockConfigurationClient();
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Client = mockClient.Object;
+                    options.Select("TestKey*");
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.Register("TestKey1", "label")
+                            .SetCacheExpiration(TimeSpan.FromSeconds(2));
+                    });
+
+                    refresher = options.GetRefresher();
+                })
+                .Build();
+
+            Assert.Equal("TestValue1", config["TestKey1"]);
+            FirstKeyValue.Value = "newValue";
+
+            mockClient.Setup(c => c.GetConfigurationSettingAsync(It.IsAny<ConfigurationSetting>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Throws(new RequestFailedException("Request failed."));
+
+            // Wait for the cache to expire
+            Thread.Sleep(2500);
+
+            bool result = refresher.TryRefreshAsync().Result;
+            Assert.False(result);
+
+            // refresh again will be no-op
+            result = refresher.TryRefreshAsync().Result;
+            Assert.True(result);
+
+            Assert.NotEqual("newValue", config["TestKey1"]);
+        }
+
         private void WaitAndRefresh(IConfigurationRefresher refresher, int millisecondsDelay)
         {
             Task.Delay(millisecondsDelay).Wait();


### PR DESCRIPTION
When a refresh operation fails, we should also extend the cache expiration time for all refresh registered settings. This avoids making excessive requests to AppConfig service in case of failed refresh operations.
