### PR TITLE
Update backoff time calculation

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -736,7 +736,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     changeWatcher.RefreshAttempts++;
                 }
 
-                cacheExpirationTime = changeWatcher.CacheExpirationInterval.CalculateBackoffTime(changeWatcher.RefreshAttempts);
+                cacheExpirationTime = changeWatcher.CacheExpirationInterval.CalculateBackoffTime(RefreshConstants.DefaultMinBackoff, RefreshConstants.DefaultMaxBackoff, changeWatcher.RefreshAttempts);
             }
 
             changeWatcher.CacheExpires = DateTimeOffset.UtcNow.Add(cacheExpirationTime);

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultSecretProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultSecretProvider.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
                         cachedSecret.RefreshAttempts++;
                     }
 
-                    cachedSecret.RefreshAt = DateTimeOffset.UtcNow.Add(cacheExpirationTime.CalculateBackoffTime(cachedSecret.RefreshAttempts));
+                    cachedSecret.RefreshAt = DateTimeOffset.UtcNow.Add(cacheExpirationTime.CalculateBackoffTime(RefreshConstants.DefaultMinBackoff, RefreshConstants.DefaultMaxBackoff, cachedSecret.RefreshAttempts));
                 }
             }
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
         private const int MaxAttempts = 63;
 
         /// <summary>
-        /// This method calculates randomized exponential backoff which lies between <paramref name="min"/> and <paramref name="max"/>.
+        /// This method calculates randomized exponential backoff times for operations that occur periodically on a given <paramref name="interval"/>.
         /// </summary>
-        /// <param name="interval">The maximum backoff to be used if <paramref name="interval"/> is less than <paramref name="max"/>.
+        /// <param name="interval">The periodic interval at which the operation occurs. If <paramref name="interval"/> is less than <paramref name="max"/>, <paramref name="interval"/> will be the maximum backoff time..
         /// If <paramref name="interval"/> is less than <paramref name="min"/>, <paramref name="interval"/> is returned.
         /// </param>
         /// <param name="min">The minimum backoff time if <paramref name="interval"/> is greater than <paramref name="min"/>.</param>

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
@@ -10,32 +10,33 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
         private const int MaxAttempts = 63;
 
         /// <summary>
-        /// This method calculates randomized exponential backoff which lies between <see cref="RefreshConstants.DefaultMinBackoff"/> and <see cref="RefreshConstants.DefaultMaxBackoff"/>.
+        /// This method calculates randomized exponential backoff which lies between <paramref name="min"/> and <paramref name="max"/>.
         /// </summary>
-        /// <param name="interval">The maximum backoff to be used if <paramref name="interval"/> is less than <see cref="RefreshConstants.DefaultMaxBackoff"/>.
-        /// If <paramref name="interval"/> is less than <see cref="RefreshConstants.DefaultMinBackoff"/>, <paramref name="interval"/> is returned.
+        /// <param name="interval">The maximum backoff to be used if <paramref name="interval"/> is less than <paramref name="max"/>.
+        /// If <paramref name="interval"/> is less than <paramref name="min"/>, <paramref name="interval"/> is returned.
         /// </param>
+        /// <param name="min">The minimum backoff time if <paramref name="interval"/> is greater than <paramref name="min"/>.</param>
+        /// <param name="max">The maximum backoff time if <paramref name="interval"/> is greater than <paramref name="max"/>.</param>
         /// <param name="attempts">The number of attempts made to backoff.</param>
-        /// <returns>The calculated exponential backoff time, or <paramref name="interval"/> if it is less than <see cref="RefreshConstants.DefaultMinBackoff"/>.</returns>
-        public static TimeSpan CalculateBackoffTime(this TimeSpan interval, int attempts)
+        /// <returns>The calculated exponential backoff time, or <paramref name="interval"/> if it is less than <paramref name="min"/>.</returns>
+        public static TimeSpan CalculateBackoffTime(this TimeSpan interval, TimeSpan min, TimeSpan max, int attempts)
         {
             if (attempts < 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(attempts), attempts, "The number of attempts should not be less than 1.");
             }
 
-            if (interval <= RefreshConstants.DefaultMinBackoff)
+            if (interval <= min)
             {
                 return interval;
             }
-
-            TimeSpan min = RefreshConstants.DefaultMinBackoff;
-            TimeSpan max = TimeSpan.FromTicks(Math.Min(interval.Ticks, RefreshConstants.DefaultMaxBackoff.Ticks));
 
             if (attempts == 1)
             {
                 return min;
             }
+
+            max = TimeSpan.FromTicks(Math.Min(interval.Ticks, max.Ticks));
 
             //
             // IMPORTANT: This can overflow


### PR DESCRIPTION
The existing logic for calculating randomized exponential backoff can overflow as there is no upper limit to the number of attempts. This PR:
- handles overflow, 
- removes `Math.Pow` dependency to improve performance, 
- consolidates our backoff logic with the server side logic.