### PR TITLE
Remove `Connect` API for geo-replication temporarily

### DIFF
--- a/examples/ConsoleAppWithFailOver/Program.cs
+++ b/examples/ConsoleAppWithFailOver/Program.cs
@@ -43,7 +43,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Examples.Cons
             // Augment the configuration builder with Azure App Configuration
             builder.AddAzureAppConfiguration(options =>
             {
-                options.Connect(endpoints, new DefaultAzureCredential());
+                // Pass the list of endpoints when `Connect(List<Uri>, TokenCredential)` becomes public.
+                options.Connect(endpoints.First(), new DefaultAzureCredential());
             });
 
             Configuration = builder.Build();

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// </summary>
         /// <param name="endpoints">The list of endpoints of an Azure App Configuration store and its replicas to connect to.</param>
         /// <param name="credential">Token credential to use to connect.</param>
-        public AzureAppConfigurationOptions Connect(IEnumerable<Uri> endpoints, TokenCredential credential)
+        internal AzureAppConfigurationOptions Connect(IEnumerable<Uri> endpoints, TokenCredential credential)
         {
             if (endpoints == null || !endpoints.Any())
             {


### PR DESCRIPTION
Removes the `Connect(List<Uri> endpoints, TokenCredential credential)` API temporarily so that failover logic can be released for preview without having any dependency on server-side geo replication