### PR TITLE
Fix incorrect cache expiration for watched settings

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -348,6 +348,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                             {
                                 applicationSettings[change.Key] = change.Current;
                             }
+
+                            // Invalidate the cached Key Vault secret (if any) for this ConfigurationSetting
+                            foreach (IKeyValueAdapter adapter in _options.Adapters)
+                            {
+                                adapter.InvalidateCache(change.Current);
+                            }
                         }
                     }
                     else

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -330,6 +330,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                                 applicationSettings.Remove(keyValueChange.Key);
                                 watchedSettings.Remove(kvp.Key);
                             }
+
+                            // Invalidate the cached Key Vault secret (if any) for this ConfigurationSetting
+                            foreach (IKeyValueAdapter adapter in _options.Adapters)
+                            {
+                                adapter.InvalidateCache(keyValueChange.Current);
+                            }
                         }
 
                         foreach (KeyValueChange change in changedKeyValuesCollection)
@@ -341,12 +347,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                             else if (change.ChangeType == KeyValueChangeType.Modified)
                             {
                                 applicationSettings[change.Key] = change.Current;
-                            }
-
-                            // Invalidate the cached Key Vault secret (if any) for this ConfigurationSetting
-                            foreach (IKeyValueAdapter adapter in _options.Adapters)
-                            {
-                                adapter.InvalidateCache(change.Current);
                             }
                         }
                     }


### PR DESCRIPTION
## Expected

When setting up App Configuration options, users are able to set a cache expiration interval for registered key-values and feature flags. Whenever a change is observed to one of these key-values in App Configuration or the cache expiration interval has elapsed, the provider will make a request to App Configuration to update that value. It will then reset the cache expiration interval back to the user-specified value. 

## Actual

After the first time the cache expiration interval elapses or a change is observed, the cache expiration interval is not updated back to its specified value unless the registered key-value has refreshAll set to true. If a key-value is registered with refreshAll set to false or is a feature flag, the provider is requesting App Configuration to update the value every time the application refreshes after the first cache expiration.