### PR TITLE
Allow users to select only feature flags

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -597,34 +597,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         {
             var serverData = new Dictionary<string, ConfigurationSetting>(StringComparer.OrdinalIgnoreCase);
 
-            // Use default query if there are no key-values specified for use other than the feature flags
-            bool useDefaultQuery = !_options.KeyValueSelectors.Any(selector => !selector.KeyFilter.StartsWith(FeatureManagementConstants.FeatureFlagMarker));
-
-            if (useDefaultQuery)
+            foreach (var loadOption in _options.KeyValueSelectors)
             {
-                // Load all key-values with the null label.
                 var selector = new SettingSelector
                 {
-                    KeyFilter = KeyFilter.Any,
-                    LabelFilter = LabelFilter.Null
+                    KeyFilter = loadOption.KeyFilter,
+                    LabelFilter = loadOption.LabelFilter
                 };
-
-                await CallWithRequestTracing(async () =>
-                {
-                    await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector, cancellationToken).ConfigureAwait(false))
-                    {
-                        serverData[setting.Key] = setting;
-                    }
-                }).ConfigureAwait(false);
-            }
-
-                foreach (var loadOption in _options.KeyValueSelectors)
-                {
-                    var selector = new SettingSelector
-                    {
-                        KeyFilter = loadOption.KeyFilter,
-                        LabelFilter = loadOption.LabelFilter
-                    };
 
                 await CallWithRequestTracing(async () =>
                 {

--- a/tests/Tests.AzureAppConfiguration/ClientOptionsTests.cs
+++ b/tests/Tests.AzureAppConfiguration/ClientOptionsTests.cs
@@ -25,6 +25,7 @@ namespace Tests.AzureAppConfiguration
             var configBuilder = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.Connect(TestHelpers.CreateMockEndpointString());
                     options.ClientOptions.AddPolicy(requestCountPolicy, HttpPipelinePosition.PerRetry);
                     defaultMaxRetries = options.ClientOptions.Retry.MaxRetries;
@@ -45,6 +46,7 @@ namespace Tests.AzureAppConfiguration
             configBuilder = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.Connect(TestHelpers.CreateMockEndpointString());
                     options.ConfigureClientOptions(clientOptions => clientOptions.Retry.MaxRetries = maxRetries);
                     options.ClientOptions.AddPolicy(requestCountPolicy, HttpPipelinePosition.PerRetry);

--- a/tests/Tests.AzureAppConfiguration/ConnectTests.cs
+++ b/tests/Tests.AzureAppConfiguration/ConnectTests.cs
@@ -27,6 +27,7 @@ namespace Tests.AzureAppConfiguration
             var configBuilder = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
                 });
 
@@ -60,6 +61,7 @@ namespace Tests.AzureAppConfiguration
             var configBuilder = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.Connect(TestHelpers.PrimaryConfigStoreEndpoint, mockTokenCredential.Object);
                     options.Connect("Invalid connection string");
                 });
@@ -75,6 +77,7 @@ namespace Tests.AzureAppConfiguration
             configBuilder = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.Connect("invalid_connection_string");
                     options.Connect(TestHelpers.PrimaryConfigStoreEndpoint, mockTokenCredential.Object);
                     options.ClientOptions.AddPolicy(requestCountPolicy, HttpPipelinePosition.PerRetry);

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -375,6 +375,7 @@ namespace Tests.AzureAppConfiguration
             var builder = new ConfigurationBuilder();
             builder.AddAzureAppConfiguration(options =>
             {
+                options.Select("*");
                 options.ClientManager = clientManager;
                 options.UseFeatureFlags();
             }).Build();
@@ -402,6 +403,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = clientManager;
                     options.UseFeatureFlags(o => o.Label = "myLabel");
                 })
@@ -426,6 +428,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
                     options.UseFeatureFlags(o => o.CacheExpirationInterval = cacheExpirationTimeSpan);
 

--- a/tests/Tests.AzureAppConfiguration/JsonContentTypeTests.cs
+++ b/tests/Tests.AzureAppConfiguration/JsonContentTypeTests.cs
@@ -27,7 +27,11 @@ namespace Tests.AzureAppConfiguration
             var mockClientManager = GetMockConfigurationClientManager(_kvCollection);
 
             var appconfigSettings = new ConfigurationBuilder()
-                .AddAzureAppConfiguration(options => options.ClientManager = mockClientManager)
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Select("*");
+                    options.ClientManager = mockClientManager;
+                })
                 .Build()
                 .AsEnumerable();
 
@@ -70,7 +74,11 @@ namespace Tests.AzureAppConfiguration
             var mockClientManager = GetMockConfigurationClientManager(_kvCollection);
 
             var config = new ConfigurationBuilder()
-                .AddAzureAppConfiguration(options => options.ClientManager = mockClientManager)
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Select("*");
+                    options.ClientManager = mockClientManager;
+                })
                 .Build();
 
             Assert.Equal("True", config["TestKey1"]);
@@ -117,7 +125,11 @@ namespace Tests.AzureAppConfiguration
             var mockClientManager = GetMockConfigurationClientManager(_kvCollection);
 
             var config = new ConfigurationBuilder()
-                .AddAzureAppConfiguration(options => options.ClientManager = mockClientManager)
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Select("*");
+                    options.ClientManager = mockClientManager;
+                })
                 .Build();
 
             Assert.Equal("true", config["TestKey1"]);
@@ -183,7 +195,11 @@ namespace Tests.AzureAppConfiguration
             var mockClientManager = GetMockConfigurationClientManager(_kvCollection);
 
             var config = new ConfigurationBuilder()
-                .AddAzureAppConfiguration(options => options.ClientManager = mockClientManager)
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Select("*");
+                    options.ClientManager = mockClientManager;
+                })
                 .Build();
 
             Assert.Null(config["MyNumberList"]);
@@ -218,7 +234,11 @@ namespace Tests.AzureAppConfiguration
             var mockClientManager = GetMockConfigurationClientManager(_kvCollection);
 
             var config = new ConfigurationBuilder()
-                .AddAzureAppConfiguration(options => options.ClientManager = mockClientManager)
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Select("*");
+                    options.ClientManager = mockClientManager;
+                })
                 .Build();
 
             Assert.Equal(compactJsonValue, config[FeatureManagementConstants.FeatureFlagMarker + "Beta"]);
@@ -239,7 +259,11 @@ namespace Tests.AzureAppConfiguration
             var mockClientManager = GetMockConfigurationClientManager(_kvCollection);
 
             var config = new ConfigurationBuilder()
-                .AddAzureAppConfiguration(options => options.ClientManager = mockClientManager)
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Select("*");
+                    options.ClientManager = mockClientManager;
+                })
                 .Build();
 
             Assert.Equal("Beta", config[FeatureManagementConstants.FeatureFlagMarker + "Beta:id"]);

--- a/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
@@ -100,6 +100,7 @@ namespace Tests.AzureAppConfiguration
             {
                 configuration = builder.AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv => kv.Register(mockSecretClient.Object));
                 }).Build();
@@ -126,6 +127,7 @@ namespace Tests.AzureAppConfiguration
             var configuration = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv => kv.Register(mockSecretClient.Object));
                 })
@@ -151,6 +153,7 @@ namespace Tests.AzureAppConfiguration
             var configuration = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv => kv.Register(mockSecretClient.Object));
                 })
@@ -176,6 +179,7 @@ namespace Tests.AzureAppConfiguration
             {
                 new ConfigurationBuilder().AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv => kv.Register(mockSecretClient.Object));
                 }).Build();
@@ -201,6 +205,7 @@ namespace Tests.AzureAppConfiguration
             {
                 new ConfigurationBuilder().AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv => kv.Register(mockSecretClient.Object));
                 }).Build();
@@ -248,6 +253,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
                     options.ConfigureKeyVault(kv => kv.Register(mockSecretClient.Object));
                 })
@@ -274,6 +280,7 @@ namespace Tests.AzureAppConfiguration
             {
                 new ConfigurationBuilder().AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv => kv.Register(mockSecretClient.Object));
                 })
@@ -299,6 +306,7 @@ namespace Tests.AzureAppConfiguration
             {
                 new ConfigurationBuilder().AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv => kv.Register(mockSecretClient.Object));
                 })
@@ -328,6 +336,7 @@ namespace Tests.AzureAppConfiguration
             var configuration = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv => kv.Register(mockSecretClient1.Object)
                                                       .Register(mockSecretClient2.Object));
@@ -351,6 +360,7 @@ namespace Tests.AzureAppConfiguration
             {
                 new ConfigurationBuilder().AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv => kv.SetCredential(new DefaultAzureCredential()));
                 })
@@ -379,6 +389,7 @@ namespace Tests.AzureAppConfiguration
                 new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv => kv.Register(mockSecretClient1.Object).Register(mockSecretClient2.Object));
                 })
@@ -402,6 +413,7 @@ namespace Tests.AzureAppConfiguration
                 new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                 })
                 .Build();
@@ -442,6 +454,7 @@ namespace Tests.AzureAppConfiguration
             IConfiguration config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv =>
                     {
@@ -519,6 +532,7 @@ namespace Tests.AzureAppConfiguration
             IConfiguration config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv =>
                     {
@@ -554,6 +568,7 @@ namespace Tests.AzureAppConfiguration
             var configuration = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv =>
                     {
@@ -631,6 +646,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
 
                     options.ConfigureKeyVault(kv =>
@@ -704,6 +720,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv =>
                     {
@@ -757,6 +774,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv =>
                     {
@@ -800,6 +818,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv =>
                     {
@@ -846,6 +865,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
                     options.ConfigureKeyVault(kv =>
                     {

--- a/tests/Tests.AzureAppConfiguration/LoggingTests.cs
+++ b/tests/Tests.AzureAppConfiguration/LoggingTests.cs
@@ -184,6 +184,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = mockClientManager;
                     options.ConfigureRefresh(refreshOptions =>
                     {
@@ -364,6 +365,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = mockClientManager;
                     options.ConfigureRefresh(refreshOptions =>
                     {
@@ -423,6 +425,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = mockClientManager;
                     options.ConfigureRefresh(refreshOptions =>
                     {

--- a/tests/Tests.AzureAppConfiguration/MapTests.cs
+++ b/tests/Tests.AzureAppConfiguration/MapTests.cs
@@ -64,6 +64,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = mockClientManager;
                     options.Map((setting) =>
                     {
@@ -109,6 +110,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = mockClientManager;
                     options.ConfigureKeyVault(kv => kv.Register(mockSecretClient.Object));
                     options.Map((setting) =>
@@ -140,6 +142,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = mockClientManager;
                     options.ConfigureRefresh(refreshOptions =>
                     {
@@ -193,6 +196,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = mockClientManager;
                     options.ConfigureRefresh(refreshOptions =>
                     {
@@ -243,6 +247,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = mockClientManager;
                     options.ConfigureRefresh(refreshOptions =>
                     {
@@ -291,6 +296,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = mockClientManager;
                     options.ConfigureRefresh(refreshOptions =>
                     {
@@ -339,6 +345,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = mockClientManager;
                     options.ConfigureRefresh(refreshOptions =>
                     {
@@ -394,6 +401,7 @@ namespace Tests.AzureAppConfiguration
                 var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = mockClientManager;
                     options.ConfigureKeyVault(kv => kv.Register(mockSecretClient.Object).SetSecretRefreshInterval(TimeSpan.FromSeconds(1)));
                     options.Map((setting) =>
@@ -430,6 +438,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
             .AddAzureAppConfiguration(options =>
             {
+                options.Select("*");
                 options.ClientManager = mockClientManager;
                 options.ConfigureKeyVault(kv => kv.Register(mockSecretClient.Object).SetSecretRefreshInterval(TimeSpan.FromSeconds(1)));
                 options.Map(async (setting) =>
@@ -475,6 +484,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = mockClientManager;
                     options.ConfigureRefresh(refreshOptions =>
                     {

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -485,6 +485,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
                     options.ConfigureRefresh(refreshOptions =>
                     {

--- a/tests/Tests.AzureAppConfiguration/Tests.cs
+++ b/tests/Tests.AzureAppConfiguration/Tests.cs
@@ -56,7 +56,11 @@ namespace Tests.AzureAppConfiguration
                 .ReturnsAsync(Response.FromValue(_kv, mockResponse.Object));
 
             var config = new ConfigurationBuilder()
-                .AddAzureAppConfiguration(options => options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object))
+                .AddAzureAppConfiguration(options => 
+                {
+                    options.Select("*");
+                    options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
+                })
                 .Build();
 
             Assert.True(config["TestKey1"] == "TestValue1");
@@ -107,6 +111,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
                     options.TrimKeyPrefix(keyPrefix1).TrimKeyPrefix(keyPrefix2).TrimKeyPrefix(keyPrefix3);
                 })
@@ -139,6 +144,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
                     options.TrimKeyPrefix(keyPrefix3).TrimKeyPrefix(keyPrefix2).TrimKeyPrefix(keyPrefix1);
                 })
@@ -200,6 +206,7 @@ namespace Tests.AzureAppConfiguration
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
                 {
+                    options.Select("*");
                     options.ClientManager = clientManager;
                 }).Build();
 


### PR DESCRIPTION
This allows users to select only feature flags or key vault values, but it's a breaking change since it removes the default select query.