### PR TITLE
Revert "parse requirement type of feature flags"

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureConditions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureConditions.cs
@@ -10,8 +10,5 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
     {
         [JsonPropertyName("client_filters")]
         public List<ClientFilter> ClientFilters { get; set; } = new List<ClientFilter>();
-
-        [JsonPropertyName("requirement_type")]
-        public string RequirementType { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
@@ -9,6 +9,5 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         public const string ContentType = "application/vnd.microsoft.appconfig.ff+json";
         public const string SectionName = "FeatureManagement";
         public const string EnabledFor = "EnabledFor";
-        public const string RequirementType = "RequirementType";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -51,15 +51,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                             keyValues.Add(new KeyValuePair<string, string>($"{FeatureManagementConstants.SectionName}:{featureFlag.Id}:{FeatureManagementConstants.EnabledFor}:{i}:Parameters:{kvp.Key}", kvp.Value));
                         }
                     }
-
-                    //
-                    // process RequirementType only when filters are not empty
-                    if (featureFlag.Conditions.RequirementType != null)
-                    {
-                        keyValues.Add(new KeyValuePair<string, string>(
-                            $"{FeatureManagementConstants.SectionName}:{featureFlag.Id}:{FeatureManagementConstants.RequirementType}", 
-                            featureFlag.Conditions.RequirementType));
-                    }
                 }
             }
             else


### PR DESCRIPTION
Reverts Azure/AppConfiguration-DotnetProvider#418

This is being reverted due to the requirement type feature being blocked by the Azure .NET SDK. The fix requires a breaking change in the SDK which needs some time to be released.