### PR TITLE
Require tests pass for build pipeline

### DIFF
--- a/.pipelines/OneBranch.Official.yml
+++ b/.pipelines/OneBranch.Official.yml
@@ -171,5 +171,5 @@ extends:
              testResultsFormat: 'vstest'
              testResultsFiles: '**/*.trx'
              searchFolder: ''
-             failTaskOnFailedTests: False
+             failTaskOnFailedTests: True
              testRunTitle: Unit Tests


### PR DESCRIPTION
Default behavior is to allow the pipeline to pass even while tests fail. This PR changes it to require passing tests for the pipeline to succeed.