### PR TITLE
Add requirement type parsing and upgrade SDK version

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureConditions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureConditions.cs
@@ -10,8 +10,5 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
     {
         [JsonPropertyName("client_filters")]
         public List<ClientFilter> ClientFilters { get; set; } = new List<ClientFilter>();
-
-        [JsonPropertyName("requirement_type")]
-        public string RequirementType { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureConditions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureConditions.cs
@@ -10,5 +10,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
     {
         [JsonPropertyName("client_filters")]
         public List<ClientFilter> ClientFilters { get; set; } = new List<ClientFilter>();
+
+        [JsonPropertyName("requirement_type")]
+        public string RequirementType { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlag.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlag.cs
@@ -15,5 +15,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
         [JsonPropertyName("conditions")]
         public FeatureConditions Conditions { get; set; }
+
+        [JsonPropertyName("requirement_type")]
+        public string RequirementType { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
@@ -9,5 +9,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         public const string ContentType = "application/vnd.microsoft.appconfig.ff+json";
         public const string SectionName = "FeatureManagement";
         public const string EnabledFor = "EnabledFor";
+        public const string RequirementType = "RequirementType";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -60,6 +60,15 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                             keyValues.Add(new KeyValuePair<string, string>($"{FeatureManagementConstants.SectionName}:{featureFlag.Id}:{FeatureManagementConstants.EnabledFor}:{i}:Parameters:{kvp.Key}", kvp.Value));
                         }
                     }
+
+                    //
+                    // process RequirementType only when filters are not empty
+                    if (featureFlag.Conditions.RequirementType != null)
+                    {
+                        keyValues.Add(new KeyValuePair<string, string>(
+                            $"{FeatureManagementConstants.SectionName}:{featureFlag.Id}:{FeatureManagementConstants.RequirementType}", 
+                            featureFlag.Conditions.RequirementType));
+                    }
                 }
             }
             else

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -63,11 +63,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                     //
                     // process RequirementType only when filters are not empty
-                    if (featureFlag.Conditions.RequirementType != null)
+                    if (featureFlag.RequirementType != null)
                     {
                         keyValues.Add(new KeyValuePair<string, string>(
                             $"{FeatureManagementConstants.SectionName}:{featureFlag.Id}:{FeatureManagementConstants.RequirementType}", 
-                            featureFlag.Conditions.RequirementType));
+                            featureFlag.RequirementType));
                     }
                 }
             }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.2.0" />
+    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.2.1" />
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.7.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.18" />

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -185,6 +185,21 @@ namespace Tests.AzureAppConfiguration
                 eTag: new ETag("0a76e3d7-7ec1-4e37-883c-9ea6d0d89e63"),
                 contentType: "text");
 
+        readonly ConfigurationSetting Feature_RequirementTypeAll = ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "Feature_All",
+                value: @"
+                        {
+                          ""id"": ""Feature_All"",
+                          ""enabled"": true,
+                          ""conditions"": {
+                            ""requirement_type"": ""All"",
+                            ""client_filters"": []
+                          }
+                        }
+                        ",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
+
         TimeSpan CacheExpirationTime = TimeSpan.FromSeconds(1);
 
         [Fact]
@@ -1128,6 +1143,67 @@ namespace Tests.AzureAppConfiguration
         Response<ConfigurationSetting> GetTestKey(string key, string label, CancellationToken cancellationToken)
         {
             return Response.FromValue(TestHelpers.CloneSetting(FirstKeyValue), new Mock<Response>().Object);
+        }
+
+        [Fact]
+        public void WithRequirementType()
+        {
+            var emptyFilters = "[]";
+            var nonEmptyFilters = @"[
+                {
+                    ""name"": ""FilterA"",
+                    ""parameters"": {
+                        ""Foo"": ""Bar""
+                    }
+                },
+                {
+                    ""name"": ""FilterB""
+                }
+            ]";
+            var featureFlags = new List<ConfigurationSetting>()
+            {
+                _kv2,
+                featureWithRequirementType("Feature_NoFilters", "All", emptyFilters),
+                featureWithRequirementType("Feature_RequireAll", "All", nonEmptyFilters),
+                featureWithRequirementType("Feature_RequireAny", "Any", nonEmptyFilters)
+            };
+
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(new MockAsyncPageable(featureFlags));
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
+                    options.UseFeatureFlags();
+                })
+                .Build();
+
+            Assert.Null(config["FeatureManagement:MyFeature2:RequirementType"]);
+            Assert.Null(config["FeatureManagement:Feature_NoFilters:RequirementType"]);
+            Assert.Equal("All", config["FeatureManagement:Feature_RequireAll:RequirementType"]);
+            Assert.Equal("Any", config["FeatureManagement:Feature_RequireAny:RequirementType"]);
+        }
+
+        private ConfigurationSetting featureWithRequirementType(string featureId, string requirementType, string clientFiltersJsonString)
+        {
+            return ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + featureId,
+                value: $@"
+                        {{
+                          ""id"": ""{featureId}"",
+                          ""enabled"": true,
+                          ""conditions"": {{
+                            ""requirement_type"": ""{requirementType}"",
+                            ""client_filters"": {clientFiltersJsonString}
+                          }}
+                        }}
+                        ",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
         }
     }
 }

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -394,7 +394,7 @@ namespace Tests.AzureAppConfiguration
                 options.UseFeatureFlags();
             }).Build();
 
-            bool performedDefaultQuery = mockTransport.Requests.Any(r => r.Uri.PathAndQuery.Contains("/kv/?key=%2A&label=%00"));
+            bool performedDefaultQuery = mockTransport.Requests.Any(r => r.Uri.PathAndQuery.Contains("/kv?key=%2A&label=%00"));
             bool queriedFeatureFlags = mockTransport.Requests.Any(r => r.Uri.PathAndQuery.Contains(Uri.EscapeDataString(FeatureManagementConstants.FeatureFlagMarker)));
 
             Assert.True(performedDefaultQuery);
@@ -422,7 +422,7 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            bool performedDefaultQuery = mockTransport.Requests.Any(r => r.Uri.PathAndQuery.Contains("/kv/?key=%2A&label=%00"));
+            bool performedDefaultQuery = mockTransport.Requests.Any(r => r.Uri.PathAndQuery.Contains("/kv?key=%2A&label=%00"));
             bool queriedFeatureFlags = mockTransport.Requests.Any(r => r.Uri.PathAndQuery.Contains(Uri.EscapeDataString(FeatureManagementConstants.FeatureFlagMarker)));
 
             Assert.True(performedDefaultQuery);
@@ -1196,8 +1196,8 @@ namespace Tests.AzureAppConfiguration
                         {{
                           ""id"": ""{featureId}"",
                           ""enabled"": true,
+                          ""requirement_type"": ""{requirementType}"",
                           ""conditions"": {{
-                            ""requirement_type"": ""{requirementType}"",
                             ""client_filters"": {clientFiltersJsonString}
                           }}
                         }}

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -185,21 +185,6 @@ namespace Tests.AzureAppConfiguration
                 eTag: new ETag("0a76e3d7-7ec1-4e37-883c-9ea6d0d89e63"),
                 contentType: "text");
 
-        readonly ConfigurationSetting Feature_RequirementTypeAll = ConfigurationModelFactory.ConfigurationSetting(
-            key: FeatureManagementConstants.FeatureFlagMarker + "Feature_All",
-                value: @"
-                        {
-                          ""id"": ""Feature_All"",
-                          ""enabled"": true,
-                          ""conditions"": {
-                            ""requirement_type"": ""All"",
-                            ""client_filters"": []
-                          }
-                        }
-                        ",
-                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
-                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
-
         TimeSpan CacheExpirationTime = TimeSpan.FromSeconds(1);
 
         [Fact]
@@ -304,7 +289,6 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("Edge", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
             Assert.Equal("SuperUsers", config["FeatureManagement:MyFeature2:EnabledFor:0:Name"]);
         }
-
 
         [Fact]
         public void SkipRefreshIfCacheNotExpired()
@@ -1163,9 +1147,9 @@ namespace Tests.AzureAppConfiguration
             var featureFlags = new List<ConfigurationSetting>()
             {
                 _kv2,
-                featureWithRequirementType("Feature_NoFilters", "All", emptyFilters),
-                featureWithRequirementType("Feature_RequireAll", "All", nonEmptyFilters),
-                featureWithRequirementType("Feature_RequireAny", "Any", nonEmptyFilters)
+                FeatureWithRequirementType("Feature_NoFilters", "All", emptyFilters),
+                FeatureWithRequirementType("Feature_RequireAll", "All", nonEmptyFilters),
+                FeatureWithRequirementType("Feature_RequireAny", "Any", nonEmptyFilters)
             };
 
             var mockResponse = new Mock<Response>();
@@ -1188,7 +1172,7 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("Any", config["FeatureManagement:Feature_RequireAny:RequirementType"]);
         }
 
-        private ConfigurationSetting featureWithRequirementType(string featureId, string requirementType, string clientFiltersJsonString)
+        private ConfigurationSetting FeatureWithRequirementType(string featureId, string requirementType, string clientFiltersJsonString)
         {
             return ConfigurationModelFactory.ConfigurationSetting(
                 key: FeatureManagementConstants.FeatureFlagMarker + featureId,


### PR DESCRIPTION
We can now use the changes (with slight adjustments) added in #418 with the new Azure .NET SDK [version 1.2.1](https://github.com/Azure/azure-sdk-for-net/releases/tag/Azure.Data.AppConfiguration_1.2.1).