### PR TITLE
Make AzureAppConfigurationOptions.KeyValueSelectors internal

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// A collection of <see cref="KeyValueSelector"/>.
         /// </summary>
-        public IEnumerable<KeyValueSelector> KeyValueSelectors => _kvSelectors;
+        internal IEnumerable<KeyValueSelector> KeyValueSelectors => _kvSelectors;
 
         /// <summary>
         /// A collection of <see cref="KeyValueWatcher"/>.


### PR DESCRIPTION
## Breaking Change

There's no need for `AzureAppConfigurationOptions.KeyValueSelectors` to be a public property. The correct way to set KeyValueSelectors is through the `Select` API.