### PR TITLE
- Add updated watchers

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -24,10 +24,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         private List<KeyValueWatcher> _changeWatchers = new List<KeyValueWatcher>();
         private List<KeyValueWatcher> _multiKeyWatchers = new List<KeyValueWatcher>();
-        private List<IKeyValueAdapter> _adapters = new List<IKeyValueAdapter>() 
-        { 
+        private List<IKeyValueAdapter> _adapters = new List<IKeyValueAdapter>()
+        {
             new AzureKeyVaultKeyValueAdapter(new AzureKeyVaultSecretProvider()),
-            new JsonKeyValueAdapter() 
+            new JsonKeyValueAdapter()
         };
         private List<Func<ConfigurationSetting, ValueTask<ConfigurationSetting>>> _mappers = new List<Func<ConfigurationSetting, ValueTask<ConfigurationSetting>>>();
         private List<KeyValueSelector> _kvSelectors = new List<KeyValueSelector>();
@@ -182,7 +182,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             {
                 throw new InvalidOperationException($"Please select feature flags by either the {nameof(options.Select)} method or by setting the {nameof(options.Label)} property, not both.");
             }
-            
+
             if (options.FeatureFlagSelectors.Count() == 0)
             {
                 // Select clause is not present
@@ -190,7 +190,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 {
                     KeyFilter = FeatureManagementConstants.FeatureFlagMarker + "*",
                     LabelFilter = options.Label == null ? LabelFilter.Null : options.Label
-                });  
+                });
             }
 
             foreach (var featureFlagSelector in options.FeatureFlagSelectors)
@@ -348,9 +348,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             configure?.Invoke(refreshOptions);
 
             if (!refreshOptions.RefreshRegistrations.Any())
-            {
-                throw new ArgumentException($"{nameof(ConfigureRefresh)}() must have at least one key-value registered for refresh.");
-            }
+                if (!refreshOptions.RefreshRegistrations.Any() && !refreshOptions.RefreshUpdatesOnly)
+                {
+                    throw new ArgumentException($"{nameof(ConfigureRefresh)}() must have at least one key-value registered for refresh.");
+                }
 
             foreach (var item in refreshOptions.RefreshRegistrations)
             {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -505,8 +505,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
 
             if (_configClientManager.UpdateSyncToken(keyValueNotification.ResourceUri, keyValueNotification.SyncToken) &&
-                _options.KeyValueSelectors.Any(k => keyValueNotification.Label == k.LabelFilter && k.KeyFilter == KeyFilter.Any ||
-                k.KeyFilter.Contains(KeyFilter.Any) ? keyValueNotification.Key.StartsWith(k.KeyFilter.Split('*').First()) : keyValueNotification.Key.StartsWith(k.KeyFilter)))
+                _options.KeyValueSelectors.Any(k => keyValueNotification.Label == k.LabelFilter && (k.KeyFilter == KeyFilter.Any ||
+                k.KeyFilter.Contains(KeyFilter.Any) ? keyValueNotification.Key.StartsWith(k.KeyFilter.Split('*').First()) : keyValueNotification.Key.StartsWith(k.KeyFilter))))
             {
                 var watcher = _updatedWatchers.GetOrAdd(
                     new KeyValueIdentifier()

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return true;
         }
 
-        public void ProcessKeyValueNotification(KeyValueNotification keyValueNotification, TimeSpan? maxDelay)
+        public void ProcessKeyValuePushNotification(KeyValuePushNotification keyValueNotification, TimeSpan? maxDelay)
         {
             if (keyValueNotification == null)
             {
@@ -505,7 +505,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
 
             if (_configClientManager.UpdateSyncToken(keyValueNotification.ResourceUri, keyValueNotification.SyncToken) &&
-                _options.KeyValueSelectors.Any(k => keyValueNotification.Key.StartsWith(k.KeyFilter) && keyValueNotification.Label == k.LabelFilter))
+                _options.KeyValueSelectors.Any(k => keyValueNotification.Label == k.LabelFilter && k.KeyFilter == KeyFilter.Any ||
+                k.KeyFilter.Contains(KeyFilter.Any) ? keyValueNotification.Key.StartsWith(k.KeyFilter.Split('*').First()) : keyValueNotification.Key.StartsWith(k.KeyFilter)))
             {
                 var watcher = _updatedWatchers.GetOrAdd(
                     new KeyValueIdentifier()

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefreshOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefreshOptions.cs
@@ -14,7 +14,18 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     {
         internal TimeSpan CacheExpirationInterval { get; private set; } = RefreshConstants.DefaultCacheExpirationInterval;
         internal ISet<KeyValueWatcher> RefreshRegistrations = new HashSet<KeyValueWatcher>();
-        
+        internal bool RefreshUpdatesOnly { get; private set; } = false;
+
+        /// <summary>
+        /// Register the marked as updated key-values to be refreshed when the configuration provider's <see cref="IConfigurationRefresher"/> triggers a refresh.
+        /// The <see cref="IConfigurationRefresher"/> instance can be obtained by calling <see cref="AzureAppConfigurationOptions.GetRefresher()"/>.
+        /// </summary>
+        public AzureAppConfigurationRefreshOptions RegisterUpdatesOnly()
+        {
+            RefreshUpdatesOnly = true;
+            return this;
+        }
+
         /// <summary>
         /// Register the specified individual key-value to be refreshed when the configuration provider's <see cref="IConfigurationRefresher"/> triggers a refresh.
         /// The <see cref="IConfigurationRefresher"/> instance can be obtained by calling <see cref="AzureAppConfigurationOptions.GetRefresher()"/>.

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationRefresher.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using Microsoft.Extensions.Configuration.AzureAppConfiguration.Models;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -40,6 +41,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             ThrowIfNullProvider(nameof(ProcessPushNotification));
 
             _provider.ProcessPushNotification(pushNotification, maxDelay);
+        }
+
+        public void ProcessKeyValuePushNotification(KeyValuePushNotification keyValuePushNotification, TimeSpan? maxDelay)
+        {
+            ThrowIfNullProvider(nameof(ProcessKeyValuePushNotification));
+
+            _provider.ProcessKeyValuePushNotification(keyValuePushNotification, maxDelay);
         }
 
         private void ThrowIfNullProvider(string operation)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public const string RefreshFeatureFlagUpdated = "Feature flag updated.";
 
         // Other
+        public const string KeyValueMatchFailed = "Key {0} with label {1} did not match with configuration";
         public const string RefreshSkippedNoClientAvailable = "Refresh skipped because no endpoint is accessible.";
         public const string RefreshFailedToGetSettingsFromEndpoint = "Failed to get configuration settings from endpoint";
         public const string FailingOverToEndpoint = "Failing over to endpoint";

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RefreshConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RefreshConstants.cs
@@ -21,5 +21,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         // Backoff during refresh failures
         public static readonly TimeSpan DefaultMinBackoff = TimeSpan.FromSeconds(30);
         public static readonly TimeSpan DefaultMaxBackoff = TimeSpan.FromMinutes(10);
+
+        // Event Types
+        public static readonly string KeyValueModified = "Microsoft.AppConfiguration.KeyValueModified";
+        public static readonly string KeyValueDeleted = "Microsoft.AppConfiguration.KeyValueDeleted";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/EventGridEventExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/EventGridEventExtensions.cs
@@ -94,14 +94,15 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                 }
 
                 if (eventGridEventData.ValueKind == JsonValueKind.Object && eventGridEventData.TryGetProperty(SyncTokenPropertyName, out JsonElement syncToken) && syncToken.ValueKind == JsonValueKind.String &&
-                    eventGridEventData.TryGetProperty(KeyPropertyName, out JsonElement key) && key.ValueKind == JsonValueKind.String &&
-                    eventGridEventData.TryGetProperty(LabelPropertyName, out JsonElement label) && label.ValueKind == JsonValueKind.String &&
-                    eventGridEventData.TryGetProperty(EtagPropertyName, out JsonElement etag) && etag.ValueKind == JsonValueKind.String)
+                    eventGridEventData.TryGetProperty(KeyPropertyName, out JsonElement key) && key.ValueKind == JsonValueKind.String &&                    
+                    eventGridEventData.TryGetProperty(EtagPropertyName, out JsonElement etag) && etag.ValueKind == JsonValueKind.String &&
+                    eventGridEventData.TryGetProperty(LabelPropertyName, out JsonElement label) && 
+                    (label.ValueKind == JsonValueKind.String || label.ValueKind == JsonValueKind.Null))
                 {
                     keyValuePushNotification = new KeyValuePushNotification()
                     {
                         Key = key.ToString(),
-                        Label = label.ToString(),
+                        Label = label.ValueKind == JsonValueKind.Null ? LabelFilter.Null : label.ToString(),
                         Etag = etag.ToString(),
                         SyncToken = syncToken.GetString(),
                         EventType = eventGridEvent.EventType,

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/EventGridEventExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/EventGridEventExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
         /// Tries to create the <see cref="PushNotification"/> object from the details in <see cref="EventGridEvent"/> object. Return value indicates whether the operation succeeded or failed.
         /// </summary>
         /// <param name="eventGridEvent"> EventGridEvent from EventGrid</param>
-        /// <param name="pushNotification"> If this method returns true, the pushNotification  object contains details populated from eventGridEvent. If this method returns false, the pushNotification object is null. </param>
+        /// <param name="pushNotification"> If this method returns true, the pushNotification object contains details populated from eventGridEvent. If this method returns false, the pushNotification object is null. </param>
         /// <returns></returns>
         public static bool TryCreatePushNotification(this EventGridEvent eventGridEvent, out PushNotification pushNotification)
         {
@@ -47,37 +47,68 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                 }
 
                 if (eventGridEventData.ValueKind == JsonValueKind.Object &&
-                if (eventGridEvent.EventType == "KeyValueModified" || eventGridEvent.EventType == "KeyValueDeleted")
-                    {
-                        if (eventGridEventData.ValueKind == JsonValueKind.Object && eventGridEventData.TryGetProperty(SyncTokenPropertyName, out JsonElement syncToken) && syncToken.ValueKind == JsonValueKind.String &&
-                        eventGridEventData.TryGetProperty(KeyPropertyName, out JsonElement key) && key.ValueKind == JsonValueKind.String &&
-                        eventGridEventData.TryGetProperty(LabelPropertyName, out JsonElement label) && label.ValueKind == JsonValueKind.String &&
-                        eventGridEventData.TryGetProperty(EtagPropertyName, out JsonElement etag) && etag.ValueKind == JsonValueKind.String)
-                        {
-                            pushNotification = new KeyValueNotification()
-                            {
-                                Key = key.ToString(),
-                                Label = label.ToString(),
-                                Etag = etag.ToString(),
-                                SyncToken = syncToken.GetString(),
-                                EventType = eventGridEvent.EventType,
-                                ResourceUri = resourceUri
-                            };
-                            return true;
-                        }
-                    }
-                    else if (eventGridEventData.ValueKind == JsonValueKind.Object &&
                         eventGridEventData.TryGetProperty(SyncTokenPropertyName, out JsonElement syncTokenJson) &&
                         syncTokenJson.ValueKind == JsonValueKind.String)
+                {
+                    pushNotification = new PushNotification()
                     {
-                        pushNotification = new PushNotification()
-                        {
-                            SyncToken = syncTokenJson.GetString(),
-                            EventType = eventGridEvent.EventType,
-                            ResourceUri = resourceUri
-                        };
-                        return true;
-                    }
+                        SyncToken = syncTokenJson.GetString(),
+                        EventType = eventGridEvent.EventType,
+                        ResourceUri = resourceUri
+                    };
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to create the <see cref="KeyValuePushNotification"/> object from the details in <see cref="EventGridEvent"/> object. Return value indicates whether the operation succeeded or failed.
+        /// Should be used for KeyValueModified and KeyValueDeleted EventType.
+        /// </summary>
+        /// <param name="eventGridEvent"> EventGridEvent from EventGrid</param>
+        /// <param name="keyValuePushNotification"> If this method returns true, the keyValuePushNotification object contains details populated from eventGridEvent. If this method returns false, the pushNotification object is null. </param>
+        /// <returns></returns>
+        public static bool TryCreateKeyValuePushNotification(this EventGridEvent eventGridEvent, out KeyValuePushNotification keyValuePushNotification)
+        {
+            keyValuePushNotification = null;
+
+            if (eventGridEvent.Data == null || (!eventGridEvent.EventType.EndsWith("KeyValueModified") && !eventGridEvent.EventType.EndsWith("KeyValueDeleted")) || 
+                eventGridEvent.Subject == null)
+            {
+                return false;
+            }
+
+            if (Uri.TryCreate(eventGridEvent.Subject, UriKind.Absolute, out Uri resourceUri))
+            {
+                JsonElement eventGridEventData;
+
+                try
+                {
+                    eventGridEventData = JsonDocument.Parse(eventGridEvent.Data.ToString()).RootElement;
+                }
+                catch (JsonException)
+                {
+                    return false;
+                }
+
+                if (eventGridEventData.ValueKind == JsonValueKind.Object && eventGridEventData.TryGetProperty(SyncTokenPropertyName, out JsonElement syncToken) && syncToken.ValueKind == JsonValueKind.String &&
+                    eventGridEventData.TryGetProperty(KeyPropertyName, out JsonElement key) && key.ValueKind == JsonValueKind.String &&
+                    eventGridEventData.TryGetProperty(LabelPropertyName, out JsonElement label) && label.ValueKind == JsonValueKind.String &&
+                    eventGridEventData.TryGetProperty(EtagPropertyName, out JsonElement etag) && etag.ValueKind == JsonValueKind.String)
+                {
+                    keyValuePushNotification = new KeyValuePushNotification()
+                    {
+                        Key = key.ToString(),
+                        Label = label.ToString(),
+                        Etag = etag.ToString(),
+                        SyncToken = syncToken.GetString(),
+                        EventType = eventGridEvent.EventType,
+                        ResourceUri = resourceUri
+                    };
+                    return true;
+                }
             }
 
             return false;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/EventGridEventExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/EventGridEventExtensions.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
         {
             keyValuePushNotification = null;
 
-            if (eventGridEvent.Data == null || (!eventGridEvent.EventType.EndsWith("KeyValueModified") && !eventGridEvent.EventType.EndsWith("KeyValueDeleted")) || 
+            if (eventGridEvent.Data == null || (eventGridEvent.EventType != RefreshConstants.KeyValueModified && eventGridEvent.EventType != RefreshConstants.KeyValueDeleted) || 
                 eventGridEvent.Subject == null)
             {
                 return false;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 //
 using Azure;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration.Models;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading;
@@ -44,5 +45,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <param name="pushNotification">Fully populated <see cref="PushNotification"/> object.</param>
         /// /// <param name="maxDelay">Maximum delay before the cached value is marked as dirty. Default value is 30 seconds.</param>
         void ProcessPushNotification(PushNotification pushNotification, TimeSpan? maxDelay = null);
+
+        /// <summary>
+        /// Process the details of a <see cref="KeyValuePushNotification"/> object to ensure the latest key-values are provided in 
+        /// the next request to App Configuration. The next request will be made after the cached values have been marked as dirty.
+        /// </summary>
+        /// <param name="keyValuePushNotification">Fully populated <see cref="KeyValuePushNotification"/> object.</param>
+        /// /// <param name="maxDelay">Maximum delay before the cached value is marked as dirty. Default value is 30 seconds.</param>
+        void ProcessKeyValuePushNotification(KeyValuePushNotification keyValuePushNotification, TimeSpan? maxDelay = null);
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/LogHelper.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/LogHelper.cs
@@ -75,6 +75,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return $"{LoggingConstants.PushNotificationUnregisteredEndpoint} '{resourceUri}'.";
         }
 
+        public static string BuildKeyValuePushNotificationMatchFailedMessage(string key, string label)
+        {
+            return string.Format(LoggingConstants.KeyValueMatchFailed, key, label);
+        }
+
         public static string BuildFailoverMessage(string originalEndpoint, string currentEndpoint)
         {
             return $"{LoggingConstants.RefreshFailedToGetSettingsFromEndpoint} '{originalEndpoint?.TrimEnd('/')}'. {LoggingConstants.FailingOverToEndpoint} '{currentEndpoint?.TrimEnd('/')}'.";

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueNotification.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueNotification.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
+{
+    /// <summary>
+    /// An Object containing the details of a push Notification received from the Azure App Configuration service specificaly for the KeyValueModified and KeyValueDeleted event type.
+    /// </summary>
+    public class KeyValueNotification : PushNotification
+    {
+        /// <summary>
+        /// Key within the data sent by the eventgrid
+        /// </summary>
+        public string Key { get; set; }
+
+        /// <summary>
+        /// Label within the data sent by the eventgrid
+        /// </summary>
+        public string Label { get; set; } = LabelFilter.Null;
+
+        /// <summary>
+        /// Etag within the data sent by the eventgrid
+        /// </summary>
+        public string Etag { get; set; }
+    }
+}

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValuePushNotification.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValuePushNotification.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
     /// <summary>
     /// An Object containing the details of a push Notification received from the Azure App Configuration service specificaly for the KeyValueModified and KeyValueDeleted event type.
     /// </summary>
-    public class KeyValueNotification : PushNotification
+    public class KeyValuePushNotification : PushNotification
     {
         /// <summary>
         /// Key within the data sent by the eventgrid

--- a/tests/Tests.AzureAppConfiguration/PushRefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/PushRefreshTests.cs
@@ -222,35 +222,35 @@ namespace Tests.AzureAppConfiguration
         Dictionary<(string, string, string), EventGridEvent> _eventGridEvents = new Dictionary<(string, string, string), EventGridEvent>
         {
             {
-                ("sn;Vxujfidne", "searchQuery1", "\\0"),
+                ("sn;Vxujfidne", "searchQuery1", LabelFilter.Null),
             new EventGridEvent(
                 "https://store1.resource.io/kv/searchQuery1",
                 "Microsoft.AppConfiguration.KeyValueModified", "2",
-                BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\":\"\\\\0\", \"etag\":\"etagValue1\",\"syncToken\":\"sn;Vxujfidne\"}")
+                BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\": null, \"etag\":\"etagValue1\",\"syncToken\":\"sn;Vxujfidne\"}")
                 )
             },
             {
-                ("sn;AxRty78B", "searchQuery1", "\\0"),
+                ("sn;AxRty78B", "searchQuery1", LabelFilter.Null),
             new EventGridEvent(
                 "https://store2.resource.io/kv/searchQuery1",
                 "Microsoft.AppConfiguration.KeyValueDeleted", "2",
-                BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\":\"\\\\0\", \"etag\":\"etagValue1\",\"syncToken\":\"sn;AxRty78B\"}")
+                BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\": null, \"etag\":\"etagValue1\",\"syncToken\":\"sn;AxRty78B\"}")
                 )
             },
             {
-                ("sn;Ttylmable", "searchQuery1", "\\0"),
+                ("sn;Ttylmable", "searchQuery1", LabelFilter.Null),
             new EventGridEvent(
                 "https://store1.resource.io/kv/searchQuery2",
                 "Microsoft.AppConfiguration.KeyValueDeleted", "2",
-                BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\":\"\\\\0\", \"etag\":\"etagValue1\",\"syncToken\":\"sn;Ttylmable\"}")
+                BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\": null, \"etag\":\"etagValue1\",\"syncToken\":\"sn;Ttylmable\"}")
                 )
             },
             {
-                ("sn;CRAle3342", "searchQuery1", "\\0"),
+                ("sn;CRAle3342", "searchQuery1", LabelFilter.Null),
             new EventGridEvent(
                 "https://store2.resource.io/kv/searchQuery2",
                 "Microsoft.AppConfiguration.KeyValueModified", "2",
-                BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\":\"\\\\0\", \"etag\":\"etagValue1\",\"syncToken\":\"sn;CRAle3342\"}")
+                BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\": null, \"etag\":\"etagValue1\",\"syncToken\":\"sn;CRAle3342\"}")
                 )
             }
         };
@@ -303,7 +303,7 @@ namespace Tests.AzureAppConfiguration
                 .AddAzureAppConfiguration(options =>
                 {
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
-                    options.Select("*");
+                    options.Select(KeyFilter.Any);
                     options.ConfigureRefresh(refreshOptions =>
                     {
                         refreshOptions.RegisterUpdatesOnly()
@@ -337,7 +337,7 @@ namespace Tests.AzureAppConfiguration
                 .AddAzureAppConfiguration(options =>
                 {
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
-                    options.Select("*");
+                    options.Select(KeyFilter.Any);
                     options.ConfigureRefresh(refreshOptions =>
                     {
                         refreshOptions.Register("TestKey1", "label")

--- a/tests/Tests.AzureAppConfiguration/PushRefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/PushRefreshTests.cs
@@ -8,69 +8,76 @@ using Azure.Messaging.EventGrid;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration.Models;
 using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Tests.AzureAppConfiguration
 {
     public class PushRefreshTests
-	{
+    {
         static readonly Uri PrimaryResourceUri = new Uri(TestHelpers.PrimaryConfigStoreEndpoint.ToString() + "/kv/searchQuery1");
         static readonly Uri SecondaryResourceUri = new Uri(TestHelpers.SecondaryConfigStoreEndpoint.ToString() + "/kv/searchQuery2");
 
         List<ConfigurationSetting> _kvCollection = new List<ConfigurationSetting>
-		{
-			ConfigurationModelFactory.ConfigurationSetting(
-				key: "TestKey1",
-				label: "label",
-				value: "TestValue1",
-				eTag: new ETag("0a76e3d7-7ec1-4e37-883c-9ea6d0d89e63"),
-				contentType: "text"),
+        {
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: "TestKey1",
+                label: "label",
+                value: "TestValue1",
+                eTag: new ETag("0a76e3d7-7ec1-4e37-883c-9ea6d0d89e63"),
+                contentType: "text"),
 
-			ConfigurationModelFactory.ConfigurationSetting(
-				key: "TestKey2",
-				label: "label",
-				value: "TestValue2",
-				eTag: new ETag("31c38369-831f-4bf1-b9ad-79db56c8b989"),
-				contentType: "text"),
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: "TestKey2",
+                label: "label",
+                value: "TestValue2",
+                eTag: new ETag("31c38369-831f-4bf1-b9ad-79db56c8b989"),
+                contentType: "text"),
 
-			ConfigurationModelFactory.ConfigurationSetting(
-				key: "TestKey3",
-				label: "label",
-				value: "TestValue3",
-				eTag: new ETag("bb203f2b-c113-44fc-995d-b933c2143339"),
-				contentType: "text"),
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: "TestKey3",
+                label: "label",
+                value: "TestValue3",
+                eTag: new ETag("bb203f2b-c113-44fc-995d-b933c2143339"),
+                contentType: "text"),
 
-			ConfigurationModelFactory.ConfigurationSetting(
-				key: "TestKeyWithMultipleLabels",
-				label: "label1",
-				value: "TestValueForLabel1",
-				eTag: new ETag("bb203f2b-c113-44fc-995d-b933c2143339"),
-				contentType: "text"),
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: "TestKeyWithMultipleLabels",
+                label: "label1",
+                value: "TestValueForLabel1",
+                eTag: new ETag("bb203f2b-c113-44fc-995d-b933c2143339"),
+                contentType: "text"),
 
-			ConfigurationModelFactory.ConfigurationSetting(
-				key: "TestKeyWithMultipleLabels",
-				label: "label2",
-				value: "TestValueForLabel2",
-				eTag: new ETag("bb203f2b-c113-44fc-995d-b933c2143339"),
-				contentType: "text")
-		};
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: "TestKeyWithMultipleLabels",
+                label: "label2",
+                value: "TestValueForLabel2",
+                eTag: new ETag("bb203f2b-c113-44fc-995d-b933c2143339"),
+                contentType: "text"),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: "TestKey6",
+                label: "\\0",
+                value: "TestValue6",
+                eTag: new ETag("0a76e3d7-7ec1-4e37-883c-9ea6d0d89e63"),
+                contentType: "text"),
+        };
 
         List<PushNotification> _pushNotificationList = new List<PushNotification>
             {
               new PushNotification  {
                                     ResourceUri = PrimaryResourceUri,
-									EventType = "eventType.KeyValueModified",
+                                    EventType = "eventType.KeyValueModified",
                                     SyncToken = "SyncToken1;sn=001",
                                     },
               new PushNotification  {
                                     ResourceUri = PrimaryResourceUri,
-									EventType = "eventType.KeyValueModified",
+                                    EventType = "eventType.KeyValueModified",
                                     SyncToken = "SyncToken2",
                                     },
               new PushNotification  {
@@ -105,6 +112,24 @@ namespace Tests.AzureAppConfiguration
                                     }
             };
 
+        List<KeyValuePushNotification> _keyValuePushNotificationList = new List<KeyValuePushNotification>
+            {
+              new KeyValuePushNotification  {
+                                    ResourceUri = PrimaryResourceUri,
+                                    EventType = "eventType.KeyValueModified",
+                                    SyncToken = "SyncToken1;sn=001",
+                                    Key = "TestKey6",
+                                    Label = "\\0"
+                                    },
+              new KeyValuePushNotification  {
+                                    ResourceUri = SecondaryResourceUri,
+                                    EventType = "eventType.KeyValueModified",
+                                    SyncToken = "SyncToken1",
+                                    Key = "TestKey3",
+                                    Label = "label"
+                                    },
+            };
+
         List<PushNotification> _invalidPushNotificationList = new List<PushNotification>
             {
               new PushNotification  {
@@ -114,12 +139,12 @@ namespace Tests.AzureAppConfiguration
                                     },
               new PushNotification  {
                                     ResourceUri = SecondaryResourceUri,
-									EventType = null,
+                                    EventType = null,
                                     SyncToken = "SyncToken2"
                                     },
               new PushNotification  {
                                     ResourceUri = PrimaryResourceUri,
-									EventType = "eventType.KeyValueDeleted",
+                                    EventType = "eventType.KeyValueDeleted",
                                     SyncToken = null
                                     },
               new PushNotification  {
@@ -134,203 +159,344 @@ namespace Tests.AzureAppConfiguration
                                     }
             };
 
-		Dictionary<string, EventGridEvent> _eventGridEvents = new Dictionary<string, EventGridEvent>
-		{
+        List<KeyValuePushNotification> _invalidKeyValuePushNotificationList = new List<KeyValuePushNotification>
             {
-                "sn;Vxujfidne",
+              new KeyValuePushNotification  {
+                                    ResourceUri = null,
+                                    EventType = "eventType.KeyValueModified",
+                                    SyncToken = "SyncToken1;sn=001",
+                                    Key = null,
+                                    Label = null
+                                    },
+              new KeyValuePushNotification  {
+                                    ResourceUri = SecondaryResourceUri,
+                                    EventType = null,
+                                    SyncToken = "SyncToken2",
+                                    Key = null,
+                                    Label = null
+                                    },
+              new KeyValuePushNotification  {
+                                    ResourceUri = PrimaryResourceUri,
+                                    EventType = "eventType.KeyValueDeleted",
+                                    SyncToken = null,
+                                    Key = null,
+                                    Label = null
+                                    },
+              new KeyValuePushNotification  {
+                                    ResourceUri = null,
+                                    EventType = "eventType.KeyValueDeleted",
+                                    SyncToken = null,
+                                    Key = null,
+                                    Label = null
+                                    },
+              new KeyValuePushNotification  {
+                                    ResourceUri = null,
+                                    EventType = null,
+                                    SyncToken = null,
+                                    Key = null,
+                                    Label = null
+                                    },
+              new KeyValuePushNotification  {
+                                    ResourceUri = PrimaryResourceUri,
+                                    EventType = "eventType.KeyValueModified",
+                                    SyncToken = "SyncToken3;sn=003",
+                                    Key = "Key1",
+                                    Label = null
+                                    },
+              new KeyValuePushNotification  {
+                                    ResourceUri = PrimaryResourceUri,
+                                    EventType = "eventType.KeyValueModified",
+                                    SyncToken = "SyncToken4;sn=004",
+                                    Key = null,
+                                    Label = "Label1"
+                                    },
+            };
+
+        Dictionary<(string, string, string), EventGridEvent> _eventGridEvents = new Dictionary<(string, string, string), EventGridEvent>
+        {
+            {
+                ("sn;Vxujfidne", "searchQuery1", "\\0"),
             new EventGridEvent(
                 "https://store1.resource.io/kv/searchQuery1",
-				"Microsoft.AppConfiguration.KeyValueModified", "2",
-                BinaryData.FromString("{\"key\":\"searchQuery1\",\"etag\":\"etagValue1\",\"syncToken\":\"sn;Vxujfidne\"}")
+                "Microsoft.AppConfiguration.KeyValueModified", "2",
+                BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\":\"\\\\0\", \"etag\":\"etagValue1\",\"syncToken\":\"sn;Vxujfidne\"}")
                 )
             },
-
             {
-                "sn;AxRty78B",
+                ("sn;AxRty78B", "searchQuery1", "\\0"),
             new EventGridEvent(
                 "https://store2.resource.io/kv/searchQuery1",
                 "Microsoft.AppConfiguration.KeyValueDeleted", "2",
-                BinaryData.FromString("{\"key\":\"searchQuery1\",\"etag\":\"etagValue1\",\"syncToken\":\"sn;AxRty78B\"}")
+                BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\":\"\\\\0\", \"etag\":\"etagValue1\",\"syncToken\":\"sn;AxRty78B\"}")
                 )
             },
-
             {
-                "sn;Ttylmable",
+                ("sn;Ttylmable", "searchQuery1", "\\0"),
             new EventGridEvent(
                 "https://store1.resource.io/kv/searchQuery2",
-				"Microsoft.AppConfiguration.KeyValueDeleted", "2",
-                BinaryData.FromString("{\"key\":\"searchQuery1\",\"etag\":\"etagValue1\",\"syncToken\":\"sn;Ttylmable\"}")
+                "Microsoft.AppConfiguration.KeyValueDeleted", "2",
+                BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\":\"\\\\0\", \"etag\":\"etagValue1\",\"syncToken\":\"sn;Ttylmable\"}")
                 )
             },
-
             {
-                "sn;CRAle3342",
+                ("sn;CRAle3342", "searchQuery1", "\\0"),
             new EventGridEvent(
                 "https://store2.resource.io/kv/searchQuery2",
-				"Microsoft.AppConfiguration.KeyValueModified", "2",
-                BinaryData.FromString("{\"key\":\"searchQuery1\",\"etag\":\"etagValue1\",\"syncToken\":\"sn;CRAle3342\"}")
+                "Microsoft.AppConfiguration.KeyValueModified", "2",
+                BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\":\"\\\\0\", \"etag\":\"etagValue1\",\"syncToken\":\"sn;CRAle3342\"}")
                 )
             }
         };
 
-		ConfigurationSetting FirstKeyValue => _kvCollection.First();
+        ConfigurationSetting FirstKeyValue => _kvCollection.First();
 
         [Fact]
         public void ValidatePushNotificationCreation()
         {
-			foreach (KeyValuePair<string, EventGridEvent> eventGridAndSync in _eventGridEvents)
+            foreach (KeyValuePair<(string, string, string), EventGridEvent> eventGridAndSync in _eventGridEvents)
             {
-				string syncToken = eventGridAndSync.Key;
-				EventGridEvent eventGridEvent = eventGridAndSync.Value; 
+                string syncToken = eventGridAndSync.Key.Item1;
+                EventGridEvent eventGridEvent = eventGridAndSync.Value;
 
-				Assert.True(eventGridEvent.TryCreatePushNotification(out PushNotification pushNotification));
+                Assert.True(eventGridEvent.TryCreatePushNotification(out PushNotification pushNotification));
                 Assert.NotNull(pushNotification);
                 Assert.Equal(eventGridEvent.EventType, pushNotification.EventType);
                 Assert.Equal(eventGridEvent.Subject, pushNotification.ResourceUri.OriginalString);
                 Assert.Equal(syncToken, pushNotification.SyncToken);
             }
-		}
+        }
 
         [Fact]
-		public void ProcessPushNotificationThrowsArgumentExceptions()
+        public void ValidateKeyValuePushNotificationCreation()
         {
-			var mockResponse = new Mock<Response>();
-			var mockClient = GetMockConfigurationClient();
-
-			IConfigurationRefresher refresher = null;
-
-			var config = new ConfigurationBuilder()
-				.AddAzureAppConfiguration(options =>
-				{
-					options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
-					options.Select("*");
-					options.ConfigureRefresh(refreshOptions =>
-					{
-						refreshOptions.Register("TestKey1", "label")
-							.SetCacheExpiration(TimeSpan.FromDays(30));
-					});
-					refresher = options.GetRefresher();
-				})
-				.Build();
-
-			foreach (PushNotification invalidPushNotification in _invalidPushNotificationList)
+            foreach (KeyValuePair<(string, string, string), EventGridEvent> eventGridAndSync in _eventGridEvents)
             {
-				Action action = () => refresher.ProcessPushNotification(invalidPushNotification);
-				Assert.Throws<ArgumentException>(action); 
-			}
+                string syncToken = eventGridAndSync.Key.Item1;
+                EventGridEvent eventGridEvent = eventGridAndSync.Value;
 
-			PushNotification nullPushNotification = null;
+                Assert.True(eventGridEvent.TryCreateKeyValuePushNotification(out KeyValuePushNotification keyValuePushNotification));
+                Assert.NotNull(keyValuePushNotification);
+                Assert.Equal(eventGridEvent.EventType, keyValuePushNotification.EventType);
+                Assert.Equal(eventGridEvent.Subject, keyValuePushNotification.ResourceUri.OriginalString);
+                Assert.Equal(syncToken, keyValuePushNotification.SyncToken);
+                Assert.Equal(eventGridAndSync.Key.Item2, keyValuePushNotification.Key);
+                Assert.Equal(eventGridAndSync.Key.Item3, keyValuePushNotification.Label);
+            }
+        }
 
-			Action nullAction = () => refresher.ProcessPushNotification(nullPushNotification);
-			Assert.Throws<ArgumentNullException>(nullAction);
-		}
+        [Fact]
+        public void ProcessKeyValuePushNotificationThrowsArgumentExceptions()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = GetMockConfigurationClient();
 
-		[Fact]
-		public void SyncTokenUpdatesCorrectNumberOfTimes()
-		{
-			// Arrange
-			var mockResponse = new Mock<Response>();
-			var mockClient = GetMockConfigurationClient();
+            IConfigurationRefresher refresher = null;
 
-			IConfigurationRefresher refresher = null;
-			var clientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
+                    options.Select("*");
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.RegisterUpdatesOnly()
+                            .SetCacheExpiration(TimeSpan.FromDays(30));
+                    });
+                    refresher = options.GetRefresher();
+                })
+                .Build();
 
-			var config = new ConfigurationBuilder()
-				.AddAzureAppConfiguration(options =>
-				{
-					options.ClientManager = clientManager;
-					options.Select("*");
-					options.ConfigureRefresh(refreshOptions =>
-					{
-						refreshOptions.Register("TestKey1", "label")
-							.SetCacheExpiration(TimeSpan.FromDays(30));
-					});
-					refresher = options.GetRefresher();
-				})
-				.Build();
+            foreach (KeyValuePushNotification invalidKeyValuePushNotification in _invalidKeyValuePushNotificationList)
+            {
+                Action action = () => refresher.ProcessKeyValuePushNotification(invalidKeyValuePushNotification);
+                Assert.Throws<ArgumentException>(action);
+            }
 
-			foreach (PushNotification pushNotification in _pushNotificationList)
-			{
-				refresher.ProcessPushNotification(pushNotification, TimeSpan.FromSeconds(0));
-				refresher.RefreshAsync().Wait();
-			}
+            KeyValuePushNotification nullPushNotification = null;
 
-			var validNotificationKVWatcherCount = 8;
-			var validEndpointCount = 4;
+            Action nullAction = () => refresher.ProcessKeyValuePushNotification(nullPushNotification);
+            Assert.Throws<ArgumentNullException>(nullAction);
+        }
 
-			mockClient.Verify(c => c.GetConfigurationSettingAsync(It.IsAny<ConfigurationSetting>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Exactly(validNotificationKVWatcherCount));
-			Assert.Equal(_pushNotificationList.Count, clientManager.UpdateSyncTokenCalled);
-			mockClient.Verify(c => c.UpdateSyncToken(It.IsAny<string>()), Times.Exactly(validEndpointCount));
-		}
+        [Fact]
+        public void ProcessPushNotificationThrowsArgumentExceptions()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = GetMockConfigurationClient();
 
-		[Fact]
-		public void RefreshAsyncUpdatesConfig()
-		{
-			// Arrange
-			var mockResponse = new Mock<Response>();
-			var mockClient = GetMockConfigurationClient();
+            IConfigurationRefresher refresher = null;
 
-			IConfigurationRefresher refresher = null;
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
+                    options.Select("*");
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.Register("TestKey1", "label")
+                            .SetCacheExpiration(TimeSpan.FromDays(30));
+                    });
+                    refresher = options.GetRefresher();
+                })
+                .Build();
 
-			var config = new ConfigurationBuilder()
-				.AddAzureAppConfiguration(options =>
-				{
-					options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);;
-					options.Select("*");
-					options.ConfigureRefresh(refreshOptions =>
-					{
-						refreshOptions.Register("TestKey1", "label")
-							.SetCacheExpiration(TimeSpan.FromDays(30));
-					});
-					refresher = options.GetRefresher();
-				})
-				.Build();
+            foreach (PushNotification invalidPushNotification in _invalidPushNotificationList)
+            {
+                Action action = () => refresher.ProcessPushNotification(invalidPushNotification);
+                Assert.Throws<ArgumentException>(action);
+            }
+
+            PushNotification nullPushNotification = null;
+
+            Action nullAction = () => refresher.ProcessPushNotification(nullPushNotification);
+            Assert.Throws<ArgumentNullException>(nullAction);
+        }
+
+        [Fact]
+        public void SyncTokenUpdatesCorrectNumberOfTimes()
+        {
+            // Arrange
+            var mockResponse = new Mock<Response>();
+            var mockClient = GetMockConfigurationClient();
+
+            IConfigurationRefresher refresher = null;
+            var clientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.ClientManager = clientManager;
+                    options.Select("*");
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.Register("TestKey1", "label")
+                            .SetCacheExpiration(TimeSpan.FromDays(30));
+                    });
+                    refresher = options.GetRefresher();
+                })
+                .Build();
+
+            foreach (PushNotification pushNotification in _pushNotificationList)
+            {
+                refresher.ProcessPushNotification(pushNotification, TimeSpan.FromSeconds(0));
+                refresher.RefreshAsync().Wait();
+            }
+
+            var validNotificationKVWatcherCount = 8;
+            var validEndpointCount = 4;
+
+            mockClient.Verify(c => c.GetConfigurationSettingAsync(It.IsAny<ConfigurationSetting>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Exactly(validNotificationKVWatcherCount));
+            Assert.Equal(_pushNotificationList.Count, clientManager.UpdateSyncTokenCalled);
+            mockClient.Verify(c => c.UpdateSyncToken(It.IsAny<string>()), Times.Exactly(validEndpointCount));
+        }
+
+        [Fact]
+        public void RefreshAsyncUpdatesConfig()
+        {
+            // Arrange
+            var mockResponse = new Mock<Response>();
+            var mockClient = GetMockConfigurationClient();
+
+            IConfigurationRefresher refresher = null;
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object); ;
+                    options.Select("*");
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.Register("TestKey1", "label")
+                            .SetCacheExpiration(TimeSpan.FromDays(30));
+                    });
+                    refresher = options.GetRefresher();
+                })
+                .Build();
 
 
-			Assert.Equal("TestValue1", config["TestKey1"]);
-			FirstKeyValue.Value = "newValue1";
+            Assert.Equal("TestValue1", config["TestKey1"]);
+            FirstKeyValue.Value = "newValue1";
 
-			refresher.ProcessPushNotification(_pushNotificationList.First(), TimeSpan.FromSeconds(0));
-			refresher.RefreshAsync().Wait();
+            refresher.ProcessPushNotification(_pushNotificationList.First(), TimeSpan.FromSeconds(0));
+            refresher.RefreshAsync().Wait();
 
-			Assert.Equal("newValue1", config["TestKey1"]);
-		}
+            Assert.Equal("newValue1", config["TestKey1"]);
+        }
 
-		private Mock<ConfigurationClient> GetMockConfigurationClient()
-		{
-			var mockResponse = new Mock<Response>();
-			var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
+        [Fact]
+        public void RefreshUpdatedConfigurationOnly()
+        {
+            // Arrange
+            var mockResponse = new Mock<Response>();
+            var mockClient = GetMockConfigurationClient();
 
-			Response<ConfigurationSetting> GetTestKey(string key, string label, CancellationToken cancellationToken)
-			{
-				return Response.FromValue(TestHelpers.CloneSetting(_kvCollection.FirstOrDefault(s => s.Key == key && s.Label == label)), mockResponse.Object);
-			}
+            IConfigurationRefresher refresher = null;
 
-			Response<ConfigurationSetting> GetIfChanged(ConfigurationSetting setting, bool onlyIfChanged, CancellationToken cancellationToken)
-			{
-				var newSetting = _kvCollection.FirstOrDefault(s => (s.Key == setting.Key && s.Label == setting.Label));
-				var unchanged = (newSetting.Key == setting.Key && newSetting.Label == setting.Label && newSetting.Value == setting.Value);
-				var response = new MockResponse(unchanged ? 304 : 200);
-				return Response.FromValue(newSetting, response);
-			}
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object); ;
+                    options.Select(KeyFilter.Any, LabelFilter.Null);
+                    options.Select(KeyFilter.Any, "label");
+                    options.ConfigureRefresh(refreshOptions =>
+                    {
+                        refreshOptions.RegisterUpdatesOnly()
+                            .SetCacheExpiration(TimeSpan.FromDays(30));
+                    });
+                    refresher = options.GetRefresher();
+                })
+                .Build();
 
-			// We don't actually select KV based on SettingSelector, we just return a deep copy of _kvCollection
-			mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
-				.Returns(() =>
-				{
-					return new MockAsyncPageable(_kvCollection.Select(setting => TestHelpers.CloneSetting(setting)).ToList());
-				});
+            Assert.Equal("TestValue6", config["TestKey6"]);
+            Assert.Equal("TestValue3", config["TestKey3"]);
 
-			mockClient.Setup(c => c.GetConfigurationSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-				.ReturnsAsync((Func<string, string, CancellationToken, Response<ConfigurationSetting>>)GetTestKey);
+            // Third Value
+            _kvCollection[2].Value = "newValue3";
+            // Sixth value
+            _kvCollection[5].Value = "newValue6";
+            refresher.ProcessKeyValuePushNotification(_keyValuePushNotificationList[0], TimeSpan.Zero);
+            refresher.ProcessKeyValuePushNotification(_keyValuePushNotificationList[1], TimeSpan.Zero);
+            refresher.RefreshAsync().Wait();
 
-			mockClient.Setup(c => c.GetConfigurationSettingAsync(It.IsAny<ConfigurationSetting>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-				.ReturnsAsync((Func<ConfigurationSetting, bool, CancellationToken, Response<ConfigurationSetting>>)GetIfChanged);
+            Assert.Equal("newValue6", config["TestKey6"]);
+            Assert.Equal("newValue3", config["TestKey3"]);
+        }
 
-			mockClient.Setup(c => c.UpdateSyncToken(It.IsAny<string>()));
+        private Mock<ConfigurationClient> GetMockConfigurationClient()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
 
-			return mockClient;
-		}
-	}
+            Response<ConfigurationSetting> GetTestKey(string key, string label, CancellationToken cancellationToken)
+            {
+                return Response.FromValue(TestHelpers.CloneSetting(_kvCollection.FirstOrDefault(s => s.Key == key && s.Label == label)), mockResponse.Object);
+            }
+
+            Response<ConfigurationSetting> GetIfChanged(ConfigurationSetting setting, bool onlyIfChanged, CancellationToken cancellationToken)
+            {
+                var newSetting = _kvCollection.FirstOrDefault(s => (s.Key == setting.Key && s.Label == setting.Label));
+                var unchanged = (newSetting.Key == setting.Key && newSetting.Label == setting.Label && newSetting.Value == setting.Value);
+                var response = new MockResponse(unchanged ? 304 : 200);
+                return Response.FromValue(newSetting, response);
+            }
+
+            // We don't actually select KV based on SettingSelector, we just return a deep copy of _kvCollection
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    return new MockAsyncPageable(_kvCollection.Select(setting => TestHelpers.CloneSetting(setting)).ToList());
+                });
+
+            mockClient.Setup(c => c.GetConfigurationSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Func<string, string, CancellationToken, Response<ConfigurationSetting>>)GetTestKey);
+
+            mockClient.Setup(c => c.GetConfigurationSettingAsync(It.IsAny<ConfigurationSetting>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Func<ConfigurationSetting, bool, CancellationToken, Response<ConfigurationSetting>>)GetIfChanged);
+
+            mockClient.Setup(c => c.UpdateSyncToken(It.IsAny<string>()));
+
+            return mockClient;
+        }
+    }
 
 }

--- a/tests/Tests.AzureAppConfiguration/PushRefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/PushRefreshTests.cs
@@ -72,42 +72,42 @@ namespace Tests.AzureAppConfiguration
             {
               new PushNotification  {
                                     ResourceUri = PrimaryResourceUri,
-                                    EventType = "eventType.KeyValueModified",
+                                    EventType = RefreshConstants.KeyValueModified,
                                     SyncToken = "SyncToken1;sn=001",
                                     },
               new PushNotification  {
                                     ResourceUri = PrimaryResourceUri,
-                                    EventType = "eventType.KeyValueModified",
+                                    EventType = RefreshConstants.KeyValueModified,
                                     SyncToken = "SyncToken2",
                                     },
               new PushNotification  {
                                     ResourceUri = PrimaryResourceUri,
-                                    EventType = "eventType.KeyValueDeleted",
+                                    EventType = RefreshConstants.KeyValueDeleted,
                                     SyncToken = "SyncToken1;sn=001",
                                     },
               new PushNotification  {
                                     ResourceUri = PrimaryResourceUri,
-                                    EventType = "eventType.KeyValueDeleted",
+                                    EventType = RefreshConstants.KeyValueDeleted,
                                     SyncToken = "SyncToken2",
                                     },
               new PushNotification  {
                                     ResourceUri = SecondaryResourceUri,
-                                    EventType = "eventType.KeyValueModified",
+                                    EventType = RefreshConstants.KeyValueModified,
                                     SyncToken = "SyncToken1",
                                     },
               new PushNotification  {
                                     ResourceUri = SecondaryResourceUri,
-                                    EventType = "eventType.KeyValueModified",
+                                    EventType = RefreshConstants.KeyValueModified,
                                     SyncToken = "SyncToken2",
                                     },
               new PushNotification  {
                                     ResourceUri = SecondaryResourceUri,
-                                    EventType = "eventType.KeyValueDeleted",
+                                    EventType =  RefreshConstants.KeyValueDeleted,
                                     SyncToken = "SyncToken1",
                                     },
               new PushNotification  {
                                     ResourceUri = SecondaryResourceUri,
-                                    EventType = "eventType.KeyValueDeleted",
+                                    EventType = RefreshConstants.KeyValueDeleted,
                                     SyncToken = "SyncToken2",
                                     }
             };
@@ -116,21 +116,21 @@ namespace Tests.AzureAppConfiguration
             {
               new KeyValuePushNotification  {
                                     ResourceUri = PrimaryResourceUri,
-                                    EventType = "eventType.KeyValueModified",
+                                    EventType = RefreshConstants.KeyValueModified,
                                     SyncToken = "SyncToken1;sn=001",
                                     Key = "TestKey6",
                                     Label = LabelFilter.Null
                                     },
               new KeyValuePushNotification  {
                                     ResourceUri = SecondaryResourceUri,
-                                    EventType = "eventType.KeyValueModified",
+                                    EventType = RefreshConstants.KeyValueModified,
                                     SyncToken = "SyncToken1",
                                     Key = "TestKey3",
                                     Label = "label"
                                     },
               new KeyValuePushNotification  {
                                     ResourceUri = SecondaryResourceUri,
-                                    EventType = "eventType.KeyValueModified",
+                                    EventType = RefreshConstants.KeyValueModified,
                                     SyncToken = "SyncToken1",
                                     Key = "TestKeyWithMultipleLabels",
                                     Label = "label1"
@@ -141,7 +141,7 @@ namespace Tests.AzureAppConfiguration
             {
               new PushNotification  {
                                     ResourceUri = null,
-                                    EventType = "eventType.KeyValueModified",
+                                    EventType = RefreshConstants.KeyValueModified,
                                     SyncToken = "SyncToken1;sn=001"
                                     },
               new PushNotification  {
@@ -151,12 +151,12 @@ namespace Tests.AzureAppConfiguration
                                     },
               new PushNotification  {
                                     ResourceUri = PrimaryResourceUri,
-                                    EventType = "eventType.KeyValueDeleted",
+                                    EventType = RefreshConstants.KeyValueDeleted,
                                     SyncToken = null
                                     },
               new PushNotification  {
                                     ResourceUri = null,
-                                    EventType = "eventType.KeyValueDeleted",
+                                    EventType = RefreshConstants.KeyValueDeleted,
                                     SyncToken = null
                                     },
               new PushNotification  {
@@ -170,7 +170,7 @@ namespace Tests.AzureAppConfiguration
             {
               new KeyValuePushNotification  {
                                     ResourceUri = null,
-                                    EventType = "eventType.KeyValueModified",
+                                    EventType = RefreshConstants.KeyValueModified,
                                     SyncToken = "SyncToken1;sn=001",
                                     Key = null,
                                     Label = null
@@ -184,14 +184,14 @@ namespace Tests.AzureAppConfiguration
                                     },
               new KeyValuePushNotification  {
                                     ResourceUri = PrimaryResourceUri,
-                                    EventType = "eventType.KeyValueDeleted",
+                                    EventType = RefreshConstants.KeyValueDeleted,
                                     SyncToken = null,
                                     Key = null,
                                     Label = null
                                     },
               new KeyValuePushNotification  {
                                     ResourceUri = null,
-                                    EventType = "eventType.KeyValueDeleted",
+                                    EventType = RefreshConstants.KeyValueDeleted,
                                     SyncToken = null,
                                     Key = null,
                                     Label = null
@@ -205,14 +205,14 @@ namespace Tests.AzureAppConfiguration
                                     },
               new KeyValuePushNotification  {
                                     ResourceUri = PrimaryResourceUri,
-                                    EventType = "eventType.KeyValueModified",
+                                    EventType = RefreshConstants.KeyValueModified,
                                     SyncToken = "SyncToken3;sn=003",
                                     Key = "Key1",
                                     Label = null
                                     },
               new KeyValuePushNotification  {
                                     ResourceUri = PrimaryResourceUri,
-                                    EventType = "eventType.KeyValueModified",
+                                    EventType = RefreshConstants.KeyValueModified,
                                     SyncToken = "SyncToken4;sn=004",
                                     Key = null,
                                     Label = "Label1"
@@ -225,7 +225,7 @@ namespace Tests.AzureAppConfiguration
                 ("sn;Vxujfidne", "searchQuery1", LabelFilter.Null),
             new EventGridEvent(
                 "https://store1.resource.io/kv/searchQuery1",
-                "Microsoft.AppConfiguration.KeyValueModified", "2",
+                RefreshConstants.KeyValueModified, "2",
                 BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\": null, \"etag\":\"etagValue1\",\"syncToken\":\"sn;Vxujfidne\"}")
                 )
             },
@@ -233,7 +233,7 @@ namespace Tests.AzureAppConfiguration
                 ("sn;AxRty78B", "searchQuery1", LabelFilter.Null),
             new EventGridEvent(
                 "https://store2.resource.io/kv/searchQuery1",
-                "Microsoft.AppConfiguration.KeyValueDeleted", "2",
+                RefreshConstants.KeyValueDeleted, "2",
                 BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\": null, \"etag\":\"etagValue1\",\"syncToken\":\"sn;AxRty78B\"}")
                 )
             },
@@ -241,7 +241,7 @@ namespace Tests.AzureAppConfiguration
                 ("sn;Ttylmable", "searchQuery1", LabelFilter.Null),
             new EventGridEvent(
                 "https://store1.resource.io/kv/searchQuery2",
-                "Microsoft.AppConfiguration.KeyValueDeleted", "2",
+                RefreshConstants.KeyValueDeleted, "2",
                 BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\": null, \"etag\":\"etagValue1\",\"syncToken\":\"sn;Ttylmable\"}")
                 )
             },
@@ -249,7 +249,7 @@ namespace Tests.AzureAppConfiguration
                 ("sn;CRAle3342", "searchQuery1", LabelFilter.Null),
             new EventGridEvent(
                 "https://store2.resource.io/kv/searchQuery2",
-                "Microsoft.AppConfiguration.KeyValueModified", "2",
+                RefreshConstants.KeyValueModified, "2",
                 BinaryData.FromString("{\"key\":\"searchQuery1\", \"label\": null, \"etag\":\"etagValue1\",\"syncToken\":\"sn;CRAle3342\"}")
                 )
             }


### PR DESCRIPTION
Within our solution the following scenario occurred.

Our setup is as follows:
- We provider our appconfiguration values with terraform for multiple applications. 
- There is multiple pipelines writing values to appconfiguration.
- These pipelines can not share a single sentinel key, so they can't update it whenever new values are added or old ones have changed. 

While our application is running the app configurations can be updated. After this update our application will receive a service bus message that there is a new available setting. Based on this setting our application has to do some actions. 

We need to refresh the settings between the time the service bus call is made and the key is updated/added to appconfiguration.

In this PR following has been added to make it work:
- KeyValuePushNotification
The key value notifcation a model.
- ProcessKeyValuePushNotification
When this notification is processed it will mark all the keys that have one of the registered labels or key filters as expired. The next refresh will then reload those keys that have been updated.
- RegisterRefreshOnly was added to make the user aware it is using updates instead of the cache refresh mechanism

Example: 

Configuring:
`.AddAzureAppConfiguration(options => options
                    .Connect(connStr)
                    .Select(KeyFilter.Any)
                    .Select(KeyFilter.Any, "anylabelspecifictotheapplication")
                    .ConfigureRefresh(refresh => refresh
                        .RegisterUpdatesOnly()
                        .SetCacheExpiration(TimeSpan.FromDays(1))
                    )`
Receiving the eventgrid notification and processing it:
`if (eventGridEvent.TryCreateKeyValuePushNotification(out KeyValuePushNotification keyValuePushNotification))
{
    foreach (var refresher in _refreshers)
    {
        // Prompt Configuration Refresh based on the PushNotification
        refresher.ProcessKeyValuePushNotification(keyValuePushNotification, TimeSpan.FromSeconds(0));
    }
}`

Within your application you can now do:
`IConfigurationRefresher.RefreshAsync()`

This will now have reloaded the keys that have been updated.




