### PR TITLE
Add back RequirementType support

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -655,7 +655,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 }
                 else
                 {
-                    ConfigurationSettingsSnapshot snapshot;
+                    ConfigurationSnapshot snapshot;
 
                     try
                     {
@@ -666,9 +666,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                         throw new InvalidOperationException($"Could not find snapshot with name '{loadOption.SnapshotName}'.", rfe);
                     }
 
-                    if (snapshot.CompositionType != CompositionType.Key)
+                    if (snapshot.SnapshotComposition != SnapshotComposition.Key)
                     {
-                        throw new InvalidOperationException($"{nameof(snapshot.CompositionType)} for the selected snapshot with name '{snapshot.Name}' must be 'key', found '{snapshot.CompositionType}'.");
+                        throw new InvalidOperationException($"{nameof(snapshot.SnapshotComposition)} for the selected snapshot with name '{snapshot.Name}' must be 'key', found '{snapshot.SnapshotComposition}'.");
                     }
 
                     settingsEnumerable = client.GetConfigurationSettingsForSnapshotAsync(

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureConditions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureConditions.cs
@@ -10,5 +10,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
     {
         [JsonPropertyName("client_filters")]
         public List<ClientFilter> ClientFilters { get; set; } = new List<ClientFilter>();
+
+        [JsonPropertyName("requirement_type")]
+        public string RequirementType { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
@@ -9,5 +9,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         public const string ContentType = "application/vnd.microsoft.appconfig.ff+json";
         public const string SectionName = "FeatureManagement";
         public const string EnabledFor = "EnabledFor";
+        public const string RequirementType = "RequirementType";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -51,6 +51,15 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                             keyValues.Add(new KeyValuePair<string, string>($"{FeatureManagementConstants.SectionName}:{featureFlag.Id}:{FeatureManagementConstants.EnabledFor}:{i}:Parameters:{kvp.Key}", kvp.Value));
                         }
                     }
+
+                    //
+                    // process RequirementType only when filters are not empty
+                    if (featureFlag.Conditions.RequirementType != null)
+                    {
+                        keyValues.Add(new KeyValuePair<string, string>(
+                            $"{FeatureManagementConstants.SectionName}:{featureFlag.Id}:{FeatureManagementConstants.RequirementType}", 
+                            featureFlag.Conditions.RequirementType));
+                    }
                 }
             }
             else

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.3.0-beta.2" />
+    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.3.0-beta.3" />
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.7.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.18" />

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -185,21 +185,6 @@ namespace Tests.AzureAppConfiguration
                 eTag: new ETag("0a76e3d7-7ec1-4e37-883c-9ea6d0d89e63"),
                 contentType: "text");
 
-        readonly ConfigurationSetting Feature_RequirementTypeAll = ConfigurationModelFactory.ConfigurationSetting(
-            key: FeatureManagementConstants.FeatureFlagMarker + "Feature_All",
-                value: @"
-                        {
-                          ""id"": ""Feature_All"",
-                          ""enabled"": true,
-                          ""conditions"": {
-                            ""requirement_type"": ""All"",
-                            ""client_filters"": []
-                          }
-                        }
-                        ",
-                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
-                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
-
         TimeSpan CacheExpirationTime = TimeSpan.FromSeconds(1);
 
         [Fact]
@@ -1135,15 +1120,6 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("newValue1", config["TestKey1"]);
             Assert.Equal("NoUsers", config["FeatureManagement:MyFeature:EnabledFor:0:Name"]);
         }
-        Response<ConfigurationSetting> GetIfChanged(ConfigurationSetting setting, bool onlyIfChanged, CancellationToken cancellationToken)
-        {
-            return Response.FromValue(FirstKeyValue, new MockResponse(200));
-        }
-
-        Response<ConfigurationSetting> GetTestKey(string key, string label, CancellationToken cancellationToken)
-        {
-            return Response.FromValue(TestHelpers.CloneSetting(FirstKeyValue), new Mock<Response>().Object);
-        }
 
         [Fact]
         public void WithRequirementType()
@@ -1163,9 +1139,9 @@ namespace Tests.AzureAppConfiguration
             var featureFlags = new List<ConfigurationSetting>()
             {
                 _kv2,
-                featureWithRequirementType("Feature_NoFilters", "All", emptyFilters),
-                featureWithRequirementType("Feature_RequireAll", "All", nonEmptyFilters),
-                featureWithRequirementType("Feature_RequireAny", "Any", nonEmptyFilters)
+                FeatureWithRequirementType("Feature_NoFilters", "All", emptyFilters),
+                FeatureWithRequirementType("Feature_RequireAll", "All", nonEmptyFilters),
+                FeatureWithRequirementType("Feature_RequireAny", "Any", nonEmptyFilters)
             };
 
             var mockResponse = new Mock<Response>();
@@ -1188,7 +1164,17 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("Any", config["FeatureManagement:Feature_RequireAny:RequirementType"]);
         }
 
-        private ConfigurationSetting featureWithRequirementType(string featureId, string requirementType, string clientFiltersJsonString)
+        Response<ConfigurationSetting> GetIfChanged(ConfigurationSetting setting, bool onlyIfChanged, CancellationToken cancellationToken)
+        {
+            return Response.FromValue(FirstKeyValue, new MockResponse(200));
+        }
+
+        Response<ConfigurationSetting> GetTestKey(string key, string label, CancellationToken cancellationToken)
+        {
+            return Response.FromValue(TestHelpers.CloneSetting(FirstKeyValue), new Mock<Response>().Object);
+        }
+
+        private ConfigurationSetting FeatureWithRequirementType(string featureId, string requirementType, string clientFiltersJsonString)
         {
             return ConfigurationModelFactory.ConfigurationSetting(
                 key: FeatureManagementConstants.FeatureFlagMarker + featureId,

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -185,6 +185,21 @@ namespace Tests.AzureAppConfiguration
                 eTag: new ETag("0a76e3d7-7ec1-4e37-883c-9ea6d0d89e63"),
                 contentType: "text");
 
+        readonly ConfigurationSetting Feature_RequirementTypeAll = ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "Feature_All",
+                value: @"
+                        {
+                          ""id"": ""Feature_All"",
+                          ""enabled"": true,
+                          ""conditions"": {
+                            ""requirement_type"": ""All"",
+                            ""client_filters"": []
+                          }
+                        }
+                        ",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
+
         TimeSpan CacheExpirationTime = TimeSpan.FromSeconds(1);
 
         [Fact]
@@ -1128,6 +1143,67 @@ namespace Tests.AzureAppConfiguration
         Response<ConfigurationSetting> GetTestKey(string key, string label, CancellationToken cancellationToken)
         {
             return Response.FromValue(TestHelpers.CloneSetting(FirstKeyValue), new Mock<Response>().Object);
+        }
+
+        [Fact]
+        public void WithRequirementType()
+        {
+            var emptyFilters = "[]";
+            var nonEmptyFilters = @"[
+                {
+                    ""name"": ""FilterA"",
+                    ""parameters"": {
+                        ""Foo"": ""Bar""
+                    }
+                },
+                {
+                    ""name"": ""FilterB""
+                }
+            ]";
+            var featureFlags = new List<ConfigurationSetting>()
+            {
+                _kv2,
+                featureWithRequirementType("Feature_NoFilters", "All", emptyFilters),
+                featureWithRequirementType("Feature_RequireAll", "All", nonEmptyFilters),
+                featureWithRequirementType("Feature_RequireAny", "Any", nonEmptyFilters)
+            };
+
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(new MockAsyncPageable(featureFlags));
+
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
+                    options.UseFeatureFlags();
+                })
+                .Build();
+
+            Assert.Null(config["FeatureManagement:MyFeature2:RequirementType"]);
+            Assert.Null(config["FeatureManagement:Feature_NoFilters:RequirementType"]);
+            Assert.Equal("All", config["FeatureManagement:Feature_RequireAll:RequirementType"]);
+            Assert.Equal("Any", config["FeatureManagement:Feature_RequireAny:RequirementType"]);
+        }
+
+        private ConfigurationSetting featureWithRequirementType(string featureId, string requirementType, string clientFiltersJsonString)
+        {
+            return ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + featureId,
+                value: $@"
+                        {{
+                          ""id"": ""{featureId}"",
+                          ""enabled"": true,
+                          ""conditions"": {{
+                            ""requirement_type"": ""{requirementType}"",
+                            ""client_filters"": {clientFiltersJsonString}
+                          }}
+                        }}
+                        ",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
         }
     }
 }


### PR DESCRIPTION
With the release of a new Azure.Data.AppConfiguration version, we can now support `requirement_type` in the `conditions` object. Based on #418.