### PR TITLE
Verify Srv endpoint domain by server TLS cert

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/DomainVerifier.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/DomainVerifier.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
+{
+    /// <summary>
+    /// Verify the domain name of the endpoint matches the certificate.
+    /// </summary>
+    internal static class DomainVerifier
+    {
+        private const int TlsPort = 443;
+        private const string SubjectAltNameOid = "2.5.29.17";
+        private const string CommonName = "CN=";
+        private const string MultiDomainWildcard = "*.";
+
+        public static IEnumerable<string> MatchedHosts(this IEnumerable<string> hosts, IEnumerable<string> validDomains)
+        {
+            if (validDomains == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            foreach (string host in hosts)
+            {
+                if (!string.IsNullOrEmpty(host) && IsMatch(host, validDomains))
+                {
+                    yield return host;
+                }
+            }
+        }
+
+        public static async Task<List<string>> GetValidDomainsFromTlsCert(string endpoint)
+        {
+            var validDomains = new List<string>();
+
+            X509Certificate2 cert = null;
+
+            using (var client = new TcpClient(endpoint, TlsPort))
+            using (var sslStream = new SslStream(client.GetStream(), leaveInnerStreamOpen: false)) {
+
+                // Initiate the connection, so it will download the server certificate
+                await sslStream.AuthenticateAsClientAsync(endpoint).ConfigureAwait(false);
+
+                var serverCertificate = sslStream.RemoteCertificate;
+
+                if (serverCertificate == null)
+                {
+                    return validDomains;
+                }
+
+                cert = new X509Certificate2(serverCertificate);
+            }
+
+            if (cert == null)
+            {
+                return validDomains;
+            }
+
+            // Get the Subject Alternative Name (SAN) extension
+            var sanExtension = cert.Extensions[SubjectAltNameOid];
+
+            if (sanExtension != null)
+            {
+                IEnumerable<string> formattedSanExtensions = sanExtension
+                    .Format(true)
+                    .Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+                
+                foreach (string formattedExtension in formattedSanExtensions)
+                {
+                    // Valid pattern should be "DNS Name=*.domain.com"
+                    string[] parts = formattedExtension.Split('=');
+
+                    if (parts.Length != 2)
+                    {
+                        continue;
+                    }
+                    
+                    string value = parts[1];
+
+                    // Skip non-multi domain
+                    if (!value.StartsWith(MultiDomainWildcard))
+                    {
+                        continue;
+                    }
+
+                    // .domain.com
+                    string domain = value.Substring(1);
+
+                    if (!validDomains.Contains(domain))
+                    {
+                        validDomains.Add(domain);
+                    }
+                }
+            }
+
+            // Get the Common Name (CN) from the Subject Name if Subject Alternative Name is not available
+            if (!validDomains.Any() && cert.SubjectName != null)
+            {
+                IEnumerable<string> parts = cert.SubjectName
+                    .Format(true)
+                    .Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+
+                foreach (string part in parts)
+                {
+                    // Valid pattern should be "CN=*.domain.com", skip non-multi domain
+                    if (part.StartsWith(CommonName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        string domain = part.Substring(CommonName.Length);
+
+                        if (domain.StartsWith(MultiDomainWildcard))
+                        {
+                            // .domain.com
+                            string domainName = domain.Substring(1);
+
+                            validDomains.Add(domainName);
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            return validDomains;
+        }
+        
+        private static bool IsMatch(string hostName, IEnumerable<string> validDomains)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(hostName));
+            Debug.Assert(validDomains != null);
+
+            UriHostNameType hostNameType = Uri.CheckHostName(hostName);
+
+            if (hostNameType != UriHostNameType.Dns)
+            {
+                return false;
+            }
+
+            foreach (var validDomain in validDomains)
+            {
+                if (hostName.EndsWith(validDomain, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Get the endpoint TLS certificate and use the subject alternative name of the certificate to verify the validity of endpoints that are queried from SRV DNS lookup.
