### PR TITLE
Remove MaxAttempts for CalculateBackoffTime

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
 {
     internal static class TimeSpanExtensions
     {
-        private const int MaxAttempts = 63;
+        private const int MaxSafeShiftBit = 63;
         private const double JitterRatio = 0.25;
 
         private static readonly IList<KeyValuePair<TimeSpan, TimeSpan>> StartupMaxBackoffDurationIntervals = new List<KeyValuePair<TimeSpan, TimeSpan>>
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
 
             //
             // IMPORTANT: This can overflow
-            double calculatedMilliseconds = minDuration.TotalMilliseconds * ((long)1 << Math.Min(attempts, MaxAttempts));
+            double calculatedMilliseconds = minDuration.TotalMilliseconds * (1L << Math.Min(attempts, MaxSafeShiftBit));
 
             if (calculatedMilliseconds > maxDuration.TotalMilliseconds ||
                     calculatedMilliseconds <= 0 /*overflow*/)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
 {
     internal static class TimeSpanExtensions
     {
-        private const int MaxAttempts = 63;
+        private const double ExponentialBackoffFactor = 2;
         private const double JitterRatio = 0.25;
 
         private static readonly IList<KeyValuePair<TimeSpan, TimeSpan>> StartupMaxBackoffDurationIntervals = new List<KeyValuePair<TimeSpan, TimeSpan>>
@@ -30,6 +30,21 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
         /// <returns>The calculated exponential backoff time, or <paramref name="interval"/> if it is less than <paramref name="min"/>.</returns>
         public static TimeSpan CalculateBackoffTime(this TimeSpan interval, TimeSpan min, TimeSpan max, int attempts)
         {
+            if (interval <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(interval), interval, "The time interval should not be equal to or less than 0.");
+            }
+
+            if (min <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(min), min, "The minimum backoff time should not be equal to or less than 0.");
+            }
+
+            if (max < min)
+            {
+                throw new ArgumentOutOfRangeException(nameof(max), max, "The maximum backoff time should not be less than the minimum backoff time.");
+            }
+
             if (attempts < 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(attempts), attempts, "The number of attempts should not be less than 1.");
@@ -58,6 +73,16 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
         /// </exception>
         public static TimeSpan CalculateBackoffDuration(this TimeSpan minDuration, TimeSpan maxDuration, int attempts)
         {
+            if (minDuration <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minDuration), minDuration, "The minimum backoff time should not be equal to or less than 0.");
+            }
+
+            if (maxDuration < minDuration)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxDuration), maxDuration, "The maximum backoff time should not be less than the minimum backoff time.");
+            }
+
             if (attempts < 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(attempts), attempts, "The number of attempts should not be less than 1.");
@@ -68,12 +93,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                 return minDuration;
             }
 
-            //
-            // IMPORTANT: This can overflow
-            double calculatedMilliseconds = Math.Max(1, minDuration.TotalMilliseconds) * ((long)1 << Math.Min(attempts, MaxAttempts));
+            double calculatedMilliseconds = minDuration.TotalMilliseconds * Math.Pow(ExponentialBackoffFactor, attempts);
 
-            if (calculatedMilliseconds > maxDuration.TotalMilliseconds ||
-                    calculatedMilliseconds <= 0 /*overflow*/)
+            if (calculatedMilliseconds > maxDuration.TotalMilliseconds)
             {
                 calculatedMilliseconds = maxDuration.TotalMilliseconds;
             }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/TimeSpanExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
 {
     internal static class TimeSpanExtensions
     {
-        private const int MaxSafeShiftBit = 63;
+        private const int SafeShiftLimit = 63;
         private const double JitterRatio = 0.25;
 
         private static readonly IList<KeyValuePair<TimeSpan, TimeSpan>> StartupMaxBackoffDurationIntervals = new List<KeyValuePair<TimeSpan, TimeSpan>>
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
 
             //
             // IMPORTANT: This can overflow
-            double calculatedMilliseconds = minDuration.TotalMilliseconds * (1L << Math.Min(attempts, MaxSafeShiftBit));
+            double calculatedMilliseconds = Math.Max(1, minDuration.TotalMilliseconds) * (1L << Math.Min(attempts, SafeShiftLimit));
 
             if (calculatedMilliseconds > maxDuration.TotalMilliseconds ||
                     calculatedMilliseconds <= 0 /*overflow*/)


### PR DESCRIPTION
The variable name `MaxAttempts` is misleading. This variable is used for preventing the case that the attempts is larger than the bit number of long int. For example, `1 << 65 ` will give the same result as `1 << 1`.
 I think the name `MaxSafeShiftBit` or something similar will be more informative. The name `MaxAttempts` is quite misleading because it feels like if the attempts reach the `MaxAttempts`, the retry will be ended. 
However, in the code,
```C#
//
// IMPORTANT: This can overflow
double calculatedMilliseconds = Math.Max(1, minDuration.TotalMilliseconds) * ((long)1 << Math.Min(attempts, MaxAttempts));

if (calculatedMilliseconds > maxDuration.TotalMilliseconds ||
        calculatedMilliseconds <= 0 /*overflow*/)
{
    calculatedMilliseconds = maxDuration.TotalMilliseconds;
}
```
In fact, attempts will never reach `MaxAttempts`, because `maxDuration` is usually very small.

In [Python Provider](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/appconfiguration/azure-appconfiguration-provider/azure/appconfiguration/provider/_azureappconfigurationprovider.py#L411), the implementation is the same as dotnet provider. 
The `max_attempts = 63` makes no sense in python provider to keep the same behavior since there is no overflow in [python](https://docs.python.org/3/c-api/long.html#integer-objects).

In this PR, I suggested using Math.Pow instead of << operation.
I tested the performance difference, it is only about 0.01 ms. 
Double type will not have the overflow issue. The "overflow" will return double.PositiveInfinity which is larger than any double number. We can remove the code of handling overflow.

Also, I found the [discussion](https://github.com/Azure/AppConfiguration-DotnetProvider/pull/488#discussion_r1387429187) about the exponential strategy which called out the possibility to adjust the factor.

Also, I feels `Math.Max(1, minDuration.TotalMilliseconds)` weird. I suggest adding some out range check for all TimeSpan parameters.


