### PR TITLE
Populate feature flag telemetry metadata when feature flag telemetry is enabled

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -75,6 +75,14 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     catch (FormatException) { }
                 }
 
+                // This is used only when a test passes in a ConfigurationClientManager but no endpoint or connection string is provided.
+                ConfigurationClient client = _configClientManager.GetClients().FirstOrDefault();
+
+                if (client != null)
+                {
+                    return _configClientManager.GetEndpointForClient(client);
+                }
+
                 return null;
             }
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -75,14 +75,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     catch (FormatException) { }
                 }
 
-                // This is used only when a test passes in a ConfigurationClientManager but no endpoint or connection string is provided.
-                ConfigurationClient client = _configClientManager.GetClients().FirstOrDefault();
-
-                if (client != null)
-                {
-                    return _configClientManager.GetEndpointForClient(client);
-                }
-
                 return null;
             }
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -916,7 +916,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     continue;
                 }
 
-                IEnumerable<KeyValuePair<string, string>> kvs = await adapter.ProcessKeyValue(setting, _logger, cancellationToken).ConfigureAwait(false);
+                IEnumerable<KeyValuePair<string, string>> kvs = await adapter.ProcessKeyValue(setting, AppConfigurationEndpoint, _logger, cancellationToken).ConfigureAwait(false);
 
                 if (kvs != null)
                 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
         /// <summary> Uses the Azure Key Vault secret provider to resolve Key Vault references retrieved from Azure App Configuration. </summary>
         /// <param KeyValue ="IKeyValue">  inputs the IKeyValue </param>
         /// returns the keyname and actual value
-        public async Task<IEnumerable<KeyValuePair<string, string>>> ProcessKeyValue(ConfigurationSetting setting, Logger logger, CancellationToken cancellationToken)
+        public async Task<IEnumerable<KeyValuePair<string, string>>> ProcessKeyValue(ConfigurationSetting setting, Uri endpoint, Logger logger, CancellationToken cancellationToken)
         {
             KeyVaultSecretReference secretRef;
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/BytesExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/BytesExtensions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
     {
         /// <summary>
         /// Converts a byte array to Base64URL string and removes trailing '=' characters.
+        /// Base64 description: https://datatracker.ietf.org/doc/html/rfc4648.html#section-4
         /// </summary>
         public static string ToBase64Url(this byte[] bytes)
         {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/BytesExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/BytesExtensions.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
 {
     internal static class BytesExtensions
     {
+        /// <summary>
+        /// Converts a byte array to Base64URL string and removes trailing '=' characters.
+        /// </summary>
         public static string ToBase64Url(this byte[] bytes)
         {
             string bytesBase64 = Convert.ToBase64String(bytes);

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/BytesExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/BytesExtensions.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System.Text;
+using System;
+
+namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
+{
+    internal static class BytesExtensions
+    {
+        public static string ToBase64Url(this byte[] bytes)
+        {
+            string featureFlagIdBase64 = Convert.ToBase64String(bytes);
+
+            int indexOfEquals = featureFlagIdBase64.IndexOf("=");
+
+            int stringBuilderCapacity = indexOfEquals != -1 ? indexOfEquals : featureFlagIdBase64.Length;
+
+            StringBuilder featureFlagIdBuilder = new StringBuilder(stringBuilderCapacity);
+
+            for (int i = 0; i < stringBuilderCapacity; i++)
+            {
+                if (featureFlagIdBase64[i] == '+')
+                {
+                    featureFlagIdBuilder.Append('-');
+                }
+                else if (featureFlagIdBase64[i] == '/')
+                {
+                    featureFlagIdBuilder.Append('_');
+                }
+                else
+                {
+                    featureFlagIdBuilder.Append(featureFlagIdBase64[i]);
+                }
+            }
+
+            return featureFlagIdBuilder.ToString();
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/BytesExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/BytesExtensions.cs
@@ -14,10 +14,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
 
             int indexOfEquals = bytesBase64.IndexOf("=");
 
+            // Remove all instances of "=" at the end of the string that were added as padding
             int stringBuilderCapacity = indexOfEquals != -1 ? indexOfEquals : bytesBase64.Length;
 
             StringBuilder stringBuilder = new StringBuilder(stringBuilderCapacity);
 
+            // Construct Base64URL string by replacing characters in Base64 conversion that are not URL safe
             for (int i = 0; i < stringBuilderCapacity; i++)
             {
                 if (bytesBase64[i] == '+')

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/BytesExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/BytesExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
     internal static class BytesExtensions
     {
         /// <summary>
-        /// Converts a byte array to Base64URL string and removes trailing '=' characters.
+        /// Converts a byte array to Base64URL string with optional padding ('=') characters removed.
         /// Base64 description: https://datatracker.ietf.org/doc/html/rfc4648.html#section-4
         /// </summary>
         public static string ToBase64Url(this byte[] bytes)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/BytesExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/BytesExtensions.cs
@@ -10,31 +10,31 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
     {
         public static string ToBase64Url(this byte[] bytes)
         {
-            string featureFlagIdBase64 = Convert.ToBase64String(bytes);
+            string bytesBase64 = Convert.ToBase64String(bytes);
 
-            int indexOfEquals = featureFlagIdBase64.IndexOf("=");
+            int indexOfEquals = bytesBase64.IndexOf("=");
 
-            int stringBuilderCapacity = indexOfEquals != -1 ? indexOfEquals : featureFlagIdBase64.Length;
+            int stringBuilderCapacity = indexOfEquals != -1 ? indexOfEquals : bytesBase64.Length;
 
-            StringBuilder featureFlagIdBuilder = new StringBuilder(stringBuilderCapacity);
+            StringBuilder stringBuilder = new StringBuilder(stringBuilderCapacity);
 
             for (int i = 0; i < stringBuilderCapacity; i++)
             {
-                if (featureFlagIdBase64[i] == '+')
+                if (bytesBase64[i] == '+')
                 {
-                    featureFlagIdBuilder.Append('-');
+                    stringBuilder.Append('-');
                 }
-                else if (featureFlagIdBase64[i] == '/')
+                else if (bytesBase64[i] == '/')
                 {
-                    featureFlagIdBuilder.Append('_');
+                    stringBuilder.Append('_');
                 }
                 else
                 {
-                    featureFlagIdBuilder.Append(featureFlagIdBase64[i]);
+                    stringBuilder.Append(bytesBase64[i]);
                 }
             }
 
-            return featureFlagIdBuilder.ToString();
+            return stringBuilder.ToString();
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
@@ -33,5 +33,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         public const string Seed = "Seed";
         public const string ETag = "ETag";
         public const string FeatureFlagId = "FeatureFlagId";
+        public const string FeatureFlagReference = "FeatureFlagReference";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
@@ -31,5 +31,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         public const string From = "From";
         public const string To = "To";
         public const string Seed = "Seed";
+        public const string ETag = "ETag";
+        public const string FeatureFlagId = "FeatureFlagId";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -214,12 +214,27 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                         featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{setting.Key}\n{(string.IsNullOrWhiteSpace(setting.Label) ? null : setting.Label)}"));
                     }
 
-                    string featureFlagId = Convert.ToBase64String(featureFlagIdHash)
-                        .TrimEnd('=')
-                        .Replace('+', '-')
-                        .Replace('/', '_');
+                    string featureFlagIdBase64 = Convert.ToBase64String(featureFlagIdHash);
 
-                    keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.FeatureFlagId}", featureFlagId));
+                    StringBuilder featureFlagIdBuilder = new StringBuilder(featureFlagIdBase64[featureFlagIdBase64.Length - 1] == '=' ? featureFlagIdBase64.Length - 1 : featureFlagIdBase64.Length);
+
+                    for (int i = 0; i < featureFlagIdBuilder.Capacity; i++)
+                    {
+                        if (featureFlagIdBase64[i] == '+')
+                        {
+                            featureFlagIdBuilder.Append('-');
+                        }
+                        else if (featureFlagIdBase64[i] == '/')
+                        {
+                            featureFlagIdBuilder.Append('_');
+                        }
+                        else
+                        {
+                            featureFlagIdBuilder.Append(featureFlagIdBase64[i]);
+                        }
+                    }
+
+                    keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.FeatureFlagId}", featureFlagIdBuilder.ToString()));
 
                     if (endpoint != null)
                     {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                     using (HashAlgorithm hashAlgorithm = SHA256.Create())
                     {
-                        featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{setting.Key}\n{setting.Label}"));
+                        featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{setting.Key}\n{(string.IsNullOrWhiteSpace(setting.Label) ? null : setting.Label)}"));
                     }
 
                     string featureFlagId = Convert.ToBase64String(featureFlagIdHash)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -201,27 +201,27 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                 if (telemetry.Enabled)
                 {
                     keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Enabled}", telemetry.Enabled.ToString()));
+
+                    byte[] featureFlagIdHash;
+
+                    using (HashAlgorithm hashAlgorithm = SHA256.Create())
+                    {
+                        featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{setting.Key}\n{setting.Label}"));
+                    }
+
+                    string featureFlagId = WebUtility.UrlEncode(Convert.ToBase64String(featureFlagIdHash));
+
+                    keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.FeatureFlagId}", featureFlagId));
+
+                    if (endpoint != null)
+                    {
+                        string featureFlagReference = $"{endpoint.AbsoluteUri}kv/{setting.Key}{(setting.Label != null ? $"?label={setting.Label}" : "")}";
+
+                        keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.FeatureFlagReference}", featureFlagReference));
+                    }
+
+                    keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.ETag}", setting.ETag.ToString()));
                 }
-
-                byte[] featureFlagIdHash;
-
-                using (HashAlgorithm hashAlgorithm = SHA256.Create())
-                {
-                    featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{setting.Key}\n{setting.Label}"));
-                }
-
-                string featureFlagId = WebUtility.UrlEncode(Convert.ToBase64String(featureFlagIdHash));
-
-                keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.FeatureFlagId}", featureFlagId));
-
-                if (endpoint != null)
-                {
-                    string featureFlagReference = $"{endpoint.AbsoluteUri}kv/{setting.Key}{(setting.Label != null ? $"?label={setting.Label}" : "")}";
-
-                    keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.FeatureFlagReference}", featureFlagReference));
-                }
-
-                keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.ETag}", setting.ETag.ToString()));
 
                 if (telemetry.Metadata != null)
                 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -200,6 +200,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                     keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Enabled}", telemetry.Enabled.ToString()));
                 }
 
+                string featureFlagId = $"{setting.Key}\n{setting.Label}";
+
+                keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.FeatureFlagId}", featureFlagId));
+
+                keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.ETag}", setting.ETag.ToString()));
+
                 if (telemetry.Metadata != null)
                 {
                     foreach (KeyValuePair<string, string> kvp in telemetry.Metadata)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -208,14 +208,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                         }
                     }
 
-                    byte[] featureFlagIdHash;
-
-                    using (HashAlgorithm hashAlgorithm = SHA256.Create())
-                    {
-                        featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{setting.Key}\n{(string.IsNullOrWhiteSpace(setting.Label) ? null : setting.Label)}"));
-                    }
-
-                    string featureFlagId = featureFlagIdHash.ToBase64Url();
+                    string featureFlagId = CalculateFeatureFlagId(setting.Key, setting.Label);
 
                     keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.FeatureFlagId}", featureFlagId));
 
@@ -251,6 +244,20 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         public bool NeedsRefresh()
         {
             return false;
+        }
+
+        private static string CalculateFeatureFlagId(string key, string label)
+        {
+            byte[] featureFlagIdHash;
+
+            // Convert the value consisting of key, newline character, and label to a byte array using UTF8 encoding to hash it using SHA 256
+            using (HashAlgorithm hashAlgorithm = SHA256.Create())
+            {
+                featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{key}\n{(string.IsNullOrWhiteSpace(label) ? null : label)}"));
+            }
+
+            // Convert the hashed byte array to Base64Url
+            return featureFlagIdHash.ToBase64Url();
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -198,6 +198,14 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                 string telemetryPath = $"{featureFlagPath}:{FeatureManagementConstants.Telemetry}";
 
+                if (telemetry.Metadata != null)
+                {
+                    foreach (KeyValuePair<string, string> kvp in telemetry.Metadata)
+                    {
+                        keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{kvp.Key}", kvp.Value));
+                    }
+                }
+
                 if (telemetry.Enabled)
                 {
                     keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Enabled}", telemetry.Enabled.ToString()));
@@ -221,14 +229,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                     }
 
                     keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.ETag}", setting.ETag.ToString()));
-                }
-
-                if (telemetry.Metadata != null)
-                {
-                    foreach (KeyValuePair<string, string> kvp in telemetry.Metadata)
-                    {
-                        keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{kvp.Key}", kvp.Value));
-                    }
                 }
             }
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -216,7 +216,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                     string featureFlagIdBase64 = Convert.ToBase64String(featureFlagIdHash);
 
-                    StringBuilder featureFlagIdBuilder = new StringBuilder(featureFlagIdBase64[featureFlagIdBase64.Length - 1] == '=' ? featureFlagIdBase64.Length - 1 : featureFlagIdBase64.Length);
+                    int indexOfEquals = featureFlagIdBase64.IndexOf("=");
+
+                    StringBuilder featureFlagIdBuilder = new StringBuilder(indexOfEquals != -1 ? indexOfEquals : featureFlagIdBase64.Length);
 
                     for (int i = 0; i < featureFlagIdBuilder.Capacity; i++)
                     {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -5,7 +5,6 @@ using Azure.Data.AppConfiguration;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -215,7 +214,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                         featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{setting.Key}\n{setting.Label}"));
                     }
 
-                    string featureFlagId = WebUtility.UrlEncode(Convert.ToBase64String(featureFlagIdHash));
+                    string featureFlagId = Convert.ToBase64String(featureFlagIdHash)
+                        .TrimEnd('=')
+                        .Replace('+', '-')
+                        .Replace('/', '_');
 
                     keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.FeatureFlagId}", featureFlagId));
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -208,8 +208,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                 if (telemetry.Enabled)
                 {
-                    keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Enabled}", telemetry.Enabled.ToString()));
-
                     byte[] featureFlagIdHash;
 
                     using (HashAlgorithm hashAlgorithm = SHA256.Create())
@@ -229,6 +227,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                     }
 
                     keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.ETag}", setting.ETag.ToString()));
+
+                    keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Enabled}", telemetry.Enabled.ToString()));
                 }
             }
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -212,11 +212,14 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                 string featureFlagId = WebUtility.UrlEncode(Convert.ToBase64String(featureFlagIdHash));
 
-                string featureFlagReference = $"{endpoint.AbsoluteUri}kv/{setting.Key}{(setting.Label != null ? $"?label={setting.Label}" : "")}";
-
                 keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.FeatureFlagId}", featureFlagId));
 
-                keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.FeatureFlagReference}", featureFlagReference));
+                if (endpoint != null)
+                {
+                    string featureFlagReference = $"{endpoint.AbsoluteUri}kv/{setting.Key}{(setting.Label != null ? $"?label={setting.Label}" : "")}";
+
+                    keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.FeatureFlagReference}", featureFlagReference));
+                }
 
                 keyValues.Add(new KeyValuePair<string, string>($"{telemetryPath}:{FeatureManagementConstants.Metadata}:{FeatureManagementConstants.ETag}", setting.ETag.ToString()));
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -218,9 +218,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                     int indexOfEquals = featureFlagIdBase64.IndexOf("=");
 
-                    StringBuilder featureFlagIdBuilder = new StringBuilder(indexOfEquals != -1 ? indexOfEquals : featureFlagIdBase64.Length);
+                    int stringBuilderCapacity = indexOfEquals != -1 ? indexOfEquals : featureFlagIdBase64.Length;
 
-                    for (int i = 0; i < featureFlagIdBuilder.Capacity; i++)
+                    StringBuilder featureFlagIdBuilder = new StringBuilder(stringBuilderCapacity);
+
+                    for (int i = 0; i < stringBuilderCapacity; i++)
                     {
                         if (featureFlagIdBase64[i] == '+')
                         {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IConfigurationRefresher.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 //
 using Azure;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 //
 using Azure.Data.AppConfiguration;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,7 +11,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     internal interface IKeyValueAdapter
     {
-        Task<IEnumerable<KeyValuePair<string, string>>> ProcessKeyValue(ConfigurationSetting setting, Logger logger, CancellationToken cancellationToken);
+        Task<IEnumerable<KeyValuePair<string, string>>> ProcessKeyValue(ConfigurationSetting setting, Uri endpoint, Logger logger, CancellationToken cancellationToken);
 
         bool CanProcess(ConfigurationSetting setting);
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             KeyVaultConstants.ContentType
         };
 
-        public Task<IEnumerable<KeyValuePair<string, string>>> ProcessKeyValue(ConfigurationSetting setting, Logger logger, CancellationToken cancellationToken)
+        public Task<IEnumerable<KeyValuePair<string, string>>> ProcessKeyValue(ConfigurationSetting setting, Uri endpoint, Logger logger, CancellationToken cancellationToken)
         {
             if (setting == null)
             {

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -6,6 +6,7 @@ using Azure.Core.Diagnostics;
 using Azure.Core.Testing;
 using Azure.Data.AppConfiguration;
 using Azure.Data.AppConfiguration.Tests;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement;
@@ -1333,6 +1334,7 @@ namespace Tests.AzureAppConfiguration
                 .AddAzureAppConfiguration(options =>
                 {
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
+                    options.Connect(TestHelpers.PrimaryConfigStoreEndpoint, new DefaultAzureCredential());
                     options.UseFeatureFlags();
                 })
                 .Build();

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -14,6 +14,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -1337,6 +1340,19 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("True", config["FeatureManagement:TelemetryFeature:Telemetry:Enabled"]);
             Assert.Equal("Tag1Value", config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:Tags.Tag1"]);
             Assert.Equal("Tag2Value", config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:Tags.Tag2"]);
+            Assert.Equal("c3c231fd-39a0-4cb6-3237-4614474b92c1", config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:ETag"]);
+
+            byte[] featureFlagIdHash;
+
+            using (HashAlgorithm hashAlgorithm = SHA256.Create())
+            {
+                featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature\n"));
+            }
+
+            string featureFlagId = WebUtility.UrlEncode(Convert.ToBase64String(featureFlagIdHash));
+
+            Assert.Equal(featureFlagId, config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:FeatureFlagId"]);
+            Assert.Equal($"https://azure.azconfig.io/kv/{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature", config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:FeatureFlagReference"]);
         }
 
 

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -1351,7 +1351,10 @@ namespace Tests.AzureAppConfiguration
                 featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature\nlabel"));
             }
 
-            string featureFlagId = WebUtility.UrlEncode(Convert.ToBase64String(featureFlagIdHash));
+            string featureFlagId = Convert.ToBase64String(featureFlagIdHash)
+                .TrimEnd('=')
+                .Replace('+', '-')
+                .Replace('/', '_');
 
             Assert.Equal(featureFlagId, config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:FeatureFlagId"]);
             Assert.Equal($"{TestHelpers.PrimaryConfigStoreEndpoint}kv/{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature?label=label", config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:FeatureFlagReference"]);

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -291,7 +291,7 @@ namespace Tests.AzureAppConfiguration
                         }
                     }
                     ",
-            label: default,
+            label: "label",
             contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
             eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
 
@@ -1346,13 +1346,13 @@ namespace Tests.AzureAppConfiguration
 
             using (HashAlgorithm hashAlgorithm = SHA256.Create())
             {
-                featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature\n"));
+                featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature\nlabel"));
             }
 
             string featureFlagId = WebUtility.UrlEncode(Convert.ToBase64String(featureFlagIdHash));
 
             Assert.Equal(featureFlagId, config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:FeatureFlagId"]);
-            Assert.Equal($"https://azure.azconfig.io/kv/{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature", config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:FeatureFlagReference"]);
+            Assert.Equal($"{TestHelpers.PrimaryConfigStoreEndpoint}kv/{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature?label=label", config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:FeatureFlagReference"]);
         }
 
 

--- a/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
@@ -422,7 +422,7 @@ namespace Tests.AzureAppConfiguration
             var mockKeyValueAdapter = new Mock<IKeyValueAdapter>(MockBehavior.Strict);
             mockKeyValueAdapter.Setup(adapter => adapter.CanProcess(_kv))
                 .Returns(true);
-            mockKeyValueAdapter.Setup(adapter => adapter.ProcessKeyValue(_kv, It.IsAny<Logger>(), It.IsAny<CancellationToken>()))
+            mockKeyValueAdapter.Setup(adapter => adapter.ProcessKeyValue(_kv, It.IsAny<Uri>(), It.IsAny<Logger>(), It.IsAny<CancellationToken>()))
                 .Throws(new KeyVaultReferenceException("Key vault error", null));
             mockKeyValueAdapter.Setup(adapter => adapter.InvalidateCache(null));
 


### PR DESCRIPTION
Adding 3 values to feature flag telemetry metadata when a flag has telemetry enabled: `ETag`, `FeatureFlagId`, and `FeatureFlagReference`.