### PR TITLE
Fix bug with variant configuration value for feature management

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -93,10 +93,17 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                     keyValues.Add(new KeyValuePair<string, string>($"{variantsPath}:{FeatureManagementConstants.Name}", featureVariant.Name));
 
-                    foreach (KeyValuePair<string, string> kvp in new JsonFlattener().FlattenJson(featureVariant.ConfigurationValue))
+                    if (featureVariant.ConfigurationValue.ValueKind == JsonValueKind.Null)
                     {
-                        keyValues.Add(new KeyValuePair<string, string>($"{variantsPath}:{FeatureManagementConstants.ConfigurationValue}" + 
-                            (string.IsNullOrEmpty(kvp.Key) ? "" : $":{kvp.Key}"), kvp.Value));
+                        keyValues.Add(new KeyValuePair<string, string>($"{variantsPath}:{FeatureManagementConstants.ConfigurationValue}", null));
+                    }
+                    else
+                    {
+                        foreach (KeyValuePair<string, string> kvp in new JsonFlattener().FlattenJson(featureVariant.ConfigurationValue))
+                        {
+                            keyValues.Add(new KeyValuePair<string, string>($"{variantsPath}:{FeatureManagementConstants.ConfigurationValue}" +
+                                (string.IsNullOrEmpty(kvp.Key) ? "" : $":{kvp.Key}"), kvp.Value));
+                        }
                     }
 
                     if (featureVariant.ConfigurationReference != null)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -93,17 +93,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                     keyValues.Add(new KeyValuePair<string, string>($"{variantsPath}:{FeatureManagementConstants.Name}", featureVariant.Name));
 
-                    if (featureVariant.ConfigurationValue.ValueKind == JsonValueKind.Null)
+                    foreach (KeyValuePair<string, string> kvp in new JsonFlattener().FlattenJson(featureVariant.ConfigurationValue))
                     {
-                        keyValues.Add(new KeyValuePair<string, string>($"{variantsPath}:{FeatureManagementConstants.ConfigurationValue}", null));
-                    }
-                    else
-                    {
-                        foreach (KeyValuePair<string, string> kvp in new JsonFlattener().FlattenJson(featureVariant.ConfigurationValue))
-                        {
-                            keyValues.Add(new KeyValuePair<string, string>($"{variantsPath}:{FeatureManagementConstants.ConfigurationValue}" +
-                                (string.IsNullOrEmpty(kvp.Key) ? "" : $":{kvp.Key}"), kvp.Value));
-                        }
+                        keyValues.Add(new KeyValuePair<string, string>($"{variantsPath}:{FeatureManagementConstants.ConfigurationValue}" +
+                            (string.IsNullOrEmpty(kvp.Key) ? "" : $":{kvp.Key}"), kvp.Value));
                     }
 
                     if (featureVariant.ConfigurationReference != null)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -95,7 +95,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                     foreach (KeyValuePair<string, string> kvp in new JsonFlattener().FlattenJson(featureVariant.ConfigurationValue))
                     {
-                        keyValues.Add(new KeyValuePair<string, string>($"{variantsPath}:{FeatureManagementConstants.ConfigurationValue}:{kvp.Key}", kvp.Value));
+                        keyValues.Add(new KeyValuePair<string, string>($"{variantsPath}:{FeatureManagementConstants.ConfigurationValue}" + 
+                            (string.IsNullOrEmpty(kvp.Key) ? "" : $":{kvp.Key}"), kvp.Value));
                     }
 
                     if (featureVariant.ConfigurationReference != null)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -93,9 +93,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                     keyValues.Add(new KeyValuePair<string, string>($"{variantsPath}:{FeatureManagementConstants.Name}", featureVariant.Name));
 
-                    if (featureVariant.ConfigurationValue != null)
+                    foreach (KeyValuePair<string, string> kvp in new JsonFlattener().FlattenJson(featureVariant.ConfigurationValue))
                     {
-                        keyValues.Add(new KeyValuePair<string, string>($"{variantsPath}:{FeatureManagementConstants.ConfigurationValue}", featureVariant.ConfigurationValue));
+                        keyValues.Add(new KeyValuePair<string, string>($"{variantsPath}:{FeatureManagementConstants.ConfigurationValue}:{kvp.Key}", kvp.Value));
                     }
 
                     if (featureVariant.ConfigurationReference != null)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureVariant.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureVariant.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
@@ -11,7 +12,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         public string Name { get; set; }
 
         [JsonPropertyName("configuration_value")]
-        public string ConfigurationValue { get; set; }
+        public JsonElement ConfigurationValue { get; set; }
 
         [JsonPropertyName("configuration_reference")]
         public string ConfigurationReference { get; set; }

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -188,13 +188,13 @@ namespace Tests.AzureAppConfiguration
                 eTag: new ETag("0a76e3d7-7ec1-4e37-883c-9ea6d0d89e63"),
                 contentType: "text");
 
-        private ConfigurationSetting _variantsKv = ConfigurationModelFactory.ConfigurationSetting(
-            key: FeatureManagementConstants.FeatureFlagMarker + "VariantsFeature",
+        private ConfigurationSetting _variantsKv1 = ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "VariantsFeature1",
             value: @"
                     {
-                        ""id"": ""VariantsFeature"",
+                        ""id"": ""VariantsFeature1"",
                         ""description"": """",
-                        ""display_name"": ""Variants Feature"",
+                        ""display_name"": ""Variants Feature 1"",
                         ""enabled"": true,
                         ""conditions"": {
                         ""client_filters"": [
@@ -261,6 +261,39 @@ namespace Tests.AzureAppConfiguration
 	                    }
                     }
                     ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
+
+        private ConfigurationSetting _variantsKv2 = ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "VariantsFeature2",
+            value: @"
+                            {
+                                ""id"": ""VariantsFeature2"",
+                                ""description"": """",
+                                ""display_name"": ""Variants Feature 2"",
+                                ""enabled"": false,
+                                ""conditions"": {
+                                ""client_filters"": [
+                                ]
+                                },
+                                ""variants"": [
+		                        {
+			                        ""name"": ""Medium"",
+			                        ""configuration_value"": {
+                                        ""Key1"": ""Value1"",
+                                        ""Key2"": {
+                                            ""InsideKey2"": ""Value2""
+                                        }
+                                    }
+		                        }
+	                            ],
+	                            ""allocation"": {
+		                            ""default_when_disabled"": ""Medium"",
+		                            ""default_when_enabled"": ""Medium""
+	                            }
+                            }
+                            ",
             label: default,
             contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
             eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
@@ -1266,7 +1299,8 @@ namespace Tests.AzureAppConfiguration
         {
             var featureFlags = new List<ConfigurationSetting>()
             {
-                _variantsKv
+                _variantsKv1,
+                _variantsKv2
             };
 
             var mockResponse = new Mock<Response>();
@@ -1283,32 +1317,39 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("AlwaysOn", config["FeatureManagement:VariantsFeature:EnabledFor:0:Name"]);
-            Assert.Equal("Big", config["FeatureManagement:VariantsFeature:Variants:0:Name"]);
-            Assert.Equal("600px", config["FeatureManagement:VariantsFeature:Variants:0:ConfigurationValue"]);
-            Assert.Equal("Small", config["FeatureManagement:VariantsFeature:Variants:1:Name"]);
-            Assert.Equal("ShoppingCart:Small", config["FeatureManagement:VariantsFeature:Variants:1:ConfigurationReference"]);
-            Assert.Equal("Disabled", config["FeatureManagement:VariantsFeature:Variants:1:StatusOverride"]);
-            Assert.Equal("Small", config["FeatureManagement:VariantsFeature:Allocation:DefaultWhenDisabled"]);
-            Assert.Equal("Small", config["FeatureManagement:VariantsFeature:Allocation:DefaultWhenEnabled"]);
-            Assert.Equal("Big", config["FeatureManagement:VariantsFeature:Allocation:User:0:Variant"]);
-            Assert.Equal("Marsha", config["FeatureManagement:VariantsFeature:Allocation:User:0:Users:0"]);
-            Assert.Equal("John", config["FeatureManagement:VariantsFeature:Allocation:User:0:Users:1"]);
-            Assert.Equal("Small", config["FeatureManagement:VariantsFeature:Allocation:User:1:Variant"]);
-            Assert.Equal("Alice", config["FeatureManagement:VariantsFeature:Allocation:User:1:Users:0"]);
-            Assert.Equal("Bob", config["FeatureManagement:VariantsFeature:Allocation:User:1:Users:1"]);
-            Assert.Equal("Big", config["FeatureManagement:VariantsFeature:Allocation:Group:0:Variant"]);
-            Assert.Equal("Ring1", config["FeatureManagement:VariantsFeature:Allocation:Group:0:Groups:0"]);
-            Assert.Equal("Small", config["FeatureManagement:VariantsFeature:Allocation:Group:1:Variant"]);
-            Assert.Equal("Ring2", config["FeatureManagement:VariantsFeature:Allocation:Group:1:Groups:0"]);
-            Assert.Equal("Ring3", config["FeatureManagement:VariantsFeature:Allocation:Group:1:Groups:1"]);
-            Assert.Equal("Big", config["FeatureManagement:VariantsFeature:Allocation:Percentile:0:Variant"]);
-            Assert.Equal("0", config["FeatureManagement:VariantsFeature:Allocation:Percentile:0:From"]);
-            Assert.Equal("50", config["FeatureManagement:VariantsFeature:Allocation:Percentile:0:To"]);
-            Assert.Equal("Small", config["FeatureManagement:VariantsFeature:Allocation:Percentile:1:Variant"]);
-            Assert.Equal("50", config["FeatureManagement:VariantsFeature:Allocation:Percentile:1:From"]);
-            Assert.Equal("100", config["FeatureManagement:VariantsFeature:Allocation:Percentile:1:To"]);
-            Assert.Equal("13992821", config["FeatureManagement:VariantsFeature:Allocation:Seed"]);
+            Assert.Equal("AlwaysOn", config["FeatureManagement:VariantsFeature1:EnabledFor:0:Name"]);
+            Assert.Equal("Big", config["FeatureManagement:VariantsFeature1:Variants:0:Name"]);
+            Assert.Equal("600px", config["FeatureManagement:VariantsFeature1:Variants:0:ConfigurationValue"]);
+            Assert.Equal("Small", config["FeatureManagement:VariantsFeature1:Variants:1:Name"]);
+            Assert.Equal("ShoppingCart:Small", config["FeatureManagement:VariantsFeature1:Variants:1:ConfigurationReference"]);
+            Assert.Equal("Disabled", config["FeatureManagement:VariantsFeature1:Variants:1:StatusOverride"]);
+            Assert.Equal("Small", config["FeatureManagement:VariantsFeature1:Allocation:DefaultWhenDisabled"]);
+            Assert.Equal("Small", config["FeatureManagement:VariantsFeature1:Allocation:DefaultWhenEnabled"]);
+            Assert.Equal("Big", config["FeatureManagement:VariantsFeature1:Allocation:User:0:Variant"]);
+            Assert.Equal("Marsha", config["FeatureManagement:VariantsFeature1:Allocation:User:0:Users:0"]);
+            Assert.Equal("John", config["FeatureManagement:VariantsFeature1:Allocation:User:0:Users:1"]);
+            Assert.Equal("Small", config["FeatureManagement:VariantsFeature1:Allocation:User:1:Variant"]);
+            Assert.Equal("Alice", config["FeatureManagement:VariantsFeature1:Allocation:User:1:Users:0"]);
+            Assert.Equal("Bob", config["FeatureManagement:VariantsFeature1:Allocation:User:1:Users:1"]);
+            Assert.Equal("Big", config["FeatureManagement:VariantsFeature1:Allocation:Group:0:Variant"]);
+            Assert.Equal("Ring1", config["FeatureManagement:VariantsFeature1:Allocation:Group:0:Groups:0"]);
+            Assert.Equal("Small", config["FeatureManagement:VariantsFeature1:Allocation:Group:1:Variant"]);
+            Assert.Equal("Ring2", config["FeatureManagement:VariantsFeature1:Allocation:Group:1:Groups:0"]);
+            Assert.Equal("Ring3", config["FeatureManagement:VariantsFeature1:Allocation:Group:1:Groups:1"]);
+            Assert.Equal("Big", config["FeatureManagement:VariantsFeature1:Allocation:Percentile:0:Variant"]);
+            Assert.Equal("0", config["FeatureManagement:VariantsFeature1:Allocation:Percentile:0:From"]);
+            Assert.Equal("50", config["FeatureManagement:VariantsFeature1:Allocation:Percentile:0:To"]);
+            Assert.Equal("Small", config["FeatureManagement:VariantsFeature1:Allocation:Percentile:1:Variant"]);
+            Assert.Equal("50", config["FeatureManagement:VariantsFeature1:Allocation:Percentile:1:From"]);
+            Assert.Equal("100", config["FeatureManagement:VariantsFeature1:Allocation:Percentile:1:To"]);
+            Assert.Equal("13992821", config["FeatureManagement:VariantsFeature1:Allocation:Seed"]);
+
+            Assert.Equal("Disabled", config["FeatureManagement:VariantsFeature2:Status"]);
+            Assert.Equal("Medium", config["FeatureManagement:VariantsFeature2:Variants:0:Name"]);
+            Assert.Equal("Value1", config["FeatureManagement:VariantsFeature2:Variants:0:ConfigurationValue:Key1"]);
+            Assert.Equal("Value2", config["FeatureManagement:VariantsFeature2:Variants:0:ConfigurationValue:Key2:InsideKey2"]);
+            Assert.Equal("Medium", config["FeatureManagement:VariantsFeature2:Allocation:DefaultWhenDisabled"]);
+            Assert.Equal("Medium", config["FeatureManagement:VariantsFeature2:Allocation:DefaultWhenEnabled"]);
         }
 
         [Fact]

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -1366,7 +1366,7 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("NumberVariant", config["FeatureManagement:VariantsFeature2:Variants:1:Name"]);
             Assert.Equal("100", config["FeatureManagement:VariantsFeature2:Variants:1:ConfigurationValue"]);
             Assert.Equal("NullVariant", config["FeatureManagement:VariantsFeature2:Variants:2:Name"]);
-            Assert.Null(config["FeatureManagement:VariantsFeature2:Variants:2:ConfigurationValue"]);
+            Assert.Equal("", config["FeatureManagement:VariantsFeature2:Variants:2:ConfigurationValue"]);
             Assert.True(config
                 .GetSection("FeatureManagement:VariantsFeature2:Variants:2")
                 .AsEnumerable()

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -279,18 +279,33 @@ namespace Tests.AzureAppConfiguration
                                 },
                                 ""variants"": [
 		                        {
-			                        ""name"": ""Medium"",
+			                        ""name"": ""ObjectVariant"",
 			                        ""configuration_value"": {
                                         ""Key1"": ""Value1"",
                                         ""Key2"": {
                                             ""InsideKey2"": ""Value2""
                                         }
                                     }
+		                        },
+		                        {
+			                        ""name"": ""NumberVariant"",
+			                        ""configuration_value"": 100
+		                        },
+		                        {
+			                        ""name"": ""NullVariant"",
+			                        ""configuration_value"": null
+		                        },
+		                        {
+			                        ""name"": ""MissingValueVariant""
+		                        },
+		                        {
+			                        ""name"": ""BooleanVariant"",
+			                        ""configuration_value"": true
 		                        }
 	                            ],
 	                            ""allocation"": {
-		                            ""default_when_disabled"": ""Medium"",
-		                            ""default_when_enabled"": ""Medium""
+		                            ""default_when_disabled"": ""ObjectVariant"",
+		                            ""default_when_enabled"": ""ObjectVariant""
 	                            }
                             }
                             ",
@@ -1345,11 +1360,29 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("13992821", config["FeatureManagement:VariantsFeature1:Allocation:Seed"]);
 
             Assert.Equal("Disabled", config["FeatureManagement:VariantsFeature2:Status"]);
-            Assert.Equal("Medium", config["FeatureManagement:VariantsFeature2:Variants:0:Name"]);
+            Assert.Equal("ObjectVariant", config["FeatureManagement:VariantsFeature2:Variants:0:Name"]);
             Assert.Equal("Value1", config["FeatureManagement:VariantsFeature2:Variants:0:ConfigurationValue:Key1"]);
             Assert.Equal("Value2", config["FeatureManagement:VariantsFeature2:Variants:0:ConfigurationValue:Key2:InsideKey2"]);
-            Assert.Equal("Medium", config["FeatureManagement:VariantsFeature2:Allocation:DefaultWhenDisabled"]);
-            Assert.Equal("Medium", config["FeatureManagement:VariantsFeature2:Allocation:DefaultWhenEnabled"]);
+            Assert.Equal("NumberVariant", config["FeatureManagement:VariantsFeature2:Variants:1:Name"]);
+            Assert.Equal("100", config["FeatureManagement:VariantsFeature2:Variants:1:ConfigurationValue"]);
+            Assert.Equal("NullVariant", config["FeatureManagement:VariantsFeature2:Variants:2:Name"]);
+            Assert.Null(config["FeatureManagement:VariantsFeature2:Variants:2:ConfigurationValue"]);
+            Assert.True(config
+                .GetSection("FeatureManagement:VariantsFeature2:Variants:2")
+                .AsEnumerable()
+                .ToDictionary(x => x.Key, x => x.Value)
+                .ContainsKey("FeatureManagement:VariantsFeature2:Variants:2:ConfigurationValue"));
+            Assert.Equal("MissingValueVariant", config["FeatureManagement:VariantsFeature2:Variants:3:Name"]);
+            Assert.Null(config["FeatureManagement:VariantsFeature2:Variants:3:ConfigurationValue"]);
+            Assert.False(config
+                .GetSection("FeatureManagement:VariantsFeature2:Variants:3")
+                .AsEnumerable()
+                .ToDictionary(x => x.Key, x => x.Value)
+                .ContainsKey("FeatureManagement:VariantsFeature2:Variants:3:ConfigurationValue"));
+            Assert.Equal("BooleanVariant", config["FeatureManagement:VariantsFeature2:Variants:4:Name"]);
+            Assert.Equal("True", config["FeatureManagement:VariantsFeature2:Variants:4:ConfigurationValue"]);
+            Assert.Equal("ObjectVariant", config["FeatureManagement:VariantsFeature2:Allocation:DefaultWhenDisabled"]);
+            Assert.Equal("ObjectVariant", config["FeatureManagement:VariantsFeature2:Allocation:DefaultWhenEnabled"]);
         }
 
         [Fact]


### PR DESCRIPTION
Currently, the provider incorrectly expects the `string` type for a variant's configuration value within a feature flag. This PR allows the provider to correctly handle all possible values for `configuration_value`.

Expected allowed values:

```JSON
{
	"id": "ExampleFlag",
	"description": "",
	"enabled": true,
	"conditions": {
		"client_filters": []
	},
	"variants": [
		{
			"name": "NumberValue",
			"configuration_value": 1
		},
		{
			"name": "StringValue",
			"configuration_value": "1"
		},
		{
			"name": "ObjectValue",
			"configuration_value": {
                                "Key1": "Value1"
                        }
		},
		{
			"name": "ArrayValue",
			"configuration_value": ["1"]
		},
		{
			"name": "BooleanValue",
			"configuration_value": true
		},
		{
			"name": "NullValue",
			"configuration_value": null
		}
	]
}
```

Currently allowed values:

```JSON
{
	"id": "ExampleFlag",
	"description": "",
	"enabled": true,
	"conditions": {
		"client_filters": []
	},
	"variants": [
		{
			"name": "StringValue",
			"configuration_value": "1"
		},
		{
			"name": "NullValue",
			"configuration_value": null
		}
	]
}
```