### PR TITLE
Use Microsoft feature flag schema and remove use of reflection for json parsing

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -1222,7 +1222,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     if (featureManagementVersion != null)
                     {
                         // If the version is less than 3.2.0, log the schema version warning
-                        if (featureManagementVersion.Major < 3 || (featureManagementVersion.Major == 3 && featureManagementVersion.Minor <= 1))
+                        if (featureManagementVersion < new Version(3, 2, 0))
                         {
                             _logger.LogWarning(LogHelper.BuildFeatureManagementMicrosoftSchemaVersionWarningMessage());
                         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -1192,9 +1192,23 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
                 if (_requestTracingEnabled && _requestTracingOptions != null)
                 {
-                    _requestTracingOptions.FeatureManagementVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.FeatureManagementAssemblyName);
+                    Version featureManagementVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.FeatureManagementAssemblyName);
 
-                    _requestTracingOptions.FeatureManagementAspNetCoreVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.FeatureManagementAspNetCoreAssemblyName);
+                    Version featureManagementAspNetCoreVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.FeatureManagementAspNetCoreAssemblyName);
+
+                    if (featureManagementVersion != null)
+                    {
+                        // If the version is less than 3.2.0, log the schema version warning
+                        if (featureManagementVersion.Major <= 3 && featureManagementVersion.Minor <= 1)
+                        {
+                            _logger.LogWarning(LogHelper.BuildFeatureManagementMicrosoftSchemaVersionWarningMessage());
+                        }
+                    }
+
+                    // Return the version using only the first 3 fields and remove additional characters
+                    _requestTracingOptions.FeatureManagementVersion = featureManagementVersion?.ToString(3).Trim('{', '}');
+
+                    _requestTracingOptions.FeatureManagementAspNetCoreVersion = featureManagementAspNetCoreVersion?.ToString(3).Trim('{', '}');
                 }
             }
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -556,6 +556,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             // Reset old filter tracing in order to track the filter types present in the current response from server.
             _options.FeatureFilterTracing.ResetFeatureFilterTracing();
 
+            foreach (IKeyValueAdapter adapter in _options.Adapters)
+            {
+                adapter.ResetState();
+            }
+
             foreach (KeyValuePair<string, ConfigurationSetting> kvp in data)
             {
                 IEnumerable<KeyValuePair<string, string>> keyValuePairs = null;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -388,7 +388,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                             // Invalidate the cached Key Vault secret (if any) for this ConfigurationSetting
                             foreach (IKeyValueAdapter adapter in _options.Adapters)
                             {
-                                adapter.ProcessProviderRefresh(change.Current);
+                                adapter.OnConfigurationRefresh(change.Current);
                             }
                         }
                     }
@@ -399,7 +399,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                         // Invalidate all the cached KeyVault secrets
                         foreach (IKeyValueAdapter adapter in _options.Adapters)
                         {
-                            adapter.ProcessProviderRefresh();
+                            adapter.OnConfigurationRefresh();
                         }
 
                         // Update the next refresh time for all refresh registered settings and feature flags
@@ -734,7 +734,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 // Invalidate all the cached KeyVault secrets
                 foreach (IKeyValueAdapter adapter in _options.Adapters)
                 {
-                    adapter.ProcessProviderRefresh();
+                    adapter.OnConfigurationRefresh();
                 }
 
                 Dictionary<string, ConfigurationSetting> mappedData = await MapConfigurationSettings(data).ConfigureAwait(false);
@@ -912,6 +912,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         {
             // Set the application data for the configuration provider
             Data = data;
+
+            foreach (IKeyValueAdapter adapter in _options.Adapters)
+            {
+                adapter.OnConfigurationUpdated();
+            }
 
             // Notify that the configuration has been updated
             OnReload();

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -1222,7 +1222,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     if (featureManagementVersion != null)
                     {
                         // If the version is less than 3.2.0, log the schema version warning
-                        if (featureManagementVersion.Major <= 3 && featureManagementVersion.Minor <= 1)
+                        if (featureManagementVersion.Major < 3 || (featureManagementVersion.Major == 3 && featureManagementVersion.Minor <= 1))
                         {
                             _logger.LogWarning(LogHelper.BuildFeatureManagementMicrosoftSchemaVersionWarningMessage());
                         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -1211,27 +1211,26 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         {
             if (!_isFeatureManagementVersionInspected)
             {
+                const string FeatureManagementMinimumVersion = "3.2.0";
+
                 _isFeatureManagementVersionInspected = true;
 
                 if (_requestTracingEnabled && _requestTracingOptions != null)
                 {
-                    Version featureManagementVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.FeatureManagementAssemblyName);
-
-                    Version featureManagementAspNetCoreVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.FeatureManagementAspNetCoreAssemblyName);
+                    string featureManagementVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.FeatureManagementAssemblyName);
 
                     if (featureManagementVersion != null)
                     {
                         // If the version is less than 3.2.0, log the schema version warning
-                        if (featureManagementVersion < new Version(3, 2, 0))
+                        if (Version.Parse(featureManagementVersion) < Version.Parse(FeatureManagementMinimumVersion))
                         {
                             _logger.LogWarning(LogHelper.BuildFeatureManagementMicrosoftSchemaVersionWarningMessage());
                         }
                     }
 
-                    // Return the version using only the first 3 fields and remove additional characters
-                    _requestTracingOptions.FeatureManagementVersion = featureManagementVersion?.ToString(3).Trim('{', '}');
+                    _requestTracingOptions.FeatureManagementVersion = featureManagementVersion;
 
-                    _requestTracingOptions.FeatureManagementAspNetCoreVersion = featureManagementAspNetCoreVersion?.ToString(3).Trim('{', '}');
+                    _requestTracingOptions.FeatureManagementAspNetCoreVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.FeatureManagementAspNetCoreAssemblyName);
                 }
             }
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -388,7 +388,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                             // Invalidate the cached Key Vault secret (if any) for this ConfigurationSetting
                             foreach (IKeyValueAdapter adapter in _options.Adapters)
                             {
-                                adapter.OnConfigurationRefresh(change.Current);
+                                adapter.OnChangeDetected(change.Current);
                             }
                         }
                     }
@@ -399,7 +399,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                         // Invalidate all the cached KeyVault secrets
                         foreach (IKeyValueAdapter adapter in _options.Adapters)
                         {
-                            adapter.OnConfigurationRefresh();
+                            adapter.OnChangeDetected();
                         }
 
                         // Update the next refresh time for all refresh registered settings and feature flags
@@ -734,7 +734,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 // Invalidate all the cached KeyVault secrets
                 foreach (IKeyValueAdapter adapter in _options.Adapters)
                 {
-                    adapter.OnConfigurationRefresh();
+                    adapter.OnChangeDetected();
                 }
 
                 Dictionary<string, ConfigurationSetting> mappedData = await MapConfigurationSettings(data).ConfigureAwait(false);
@@ -915,7 +915,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
             foreach (IKeyValueAdapter adapter in _options.Adapters)
             {
-                adapter.OnConfigurationUpdated();
+                adapter.OnConfigUpdated();
             }
 
             // Notify that the configuration has been updated

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -388,7 +388,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                             // Invalidate the cached Key Vault secret (if any) for this ConfigurationSetting
                             foreach (IKeyValueAdapter adapter in _options.Adapters)
                             {
-                                adapter.InvalidateCache(change.Current);
+                                adapter.ProcessProviderRefresh(change.Current);
                             }
                         }
                     }
@@ -399,7 +399,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                         // Invalidate all the cached KeyVault secrets
                         foreach (IKeyValueAdapter adapter in _options.Adapters)
                         {
-                            adapter.InvalidateCache();
+                            adapter.ProcessProviderRefresh();
                         }
 
                         // Update the next refresh time for all refresh registered settings and feature flags
@@ -556,11 +556,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
             // Reset old filter tracing in order to track the filter types present in the current response from server.
             _options.FeatureFilterTracing.ResetFeatureFilterTracing();
-
-            foreach (IKeyValueAdapter adapter in _options.Adapters)
-            {
-                adapter.ResetState();
-            }
 
             foreach (KeyValuePair<string, ConfigurationSetting> kvp in data)
             {
@@ -739,7 +734,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 // Invalidate all the cached KeyVault secrets
                 foreach (IKeyValueAdapter adapter in _options.Adapters)
                 {
-                    adapter.InvalidateCache();
+                    adapter.ProcessProviderRefresh();
                 }
 
                 Dictionary<string, ConfigurationSetting> mappedData = await MapConfigurationSettings(data).ConfigureAwait(false);

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -1219,13 +1219,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 {
                     string featureManagementVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.FeatureManagementAssemblyName);
 
-                    if (featureManagementVersion != null)
+                    // If the version is less than 3.2.0, log the schema version warning
+                    if (featureManagementVersion != null && Version.Parse(featureManagementVersion) < Version.Parse(FeatureManagementMinimumVersion))
                     {
-                        // If the version is less than 3.2.0, log the schema version warning
-                        if (Version.Parse(featureManagementVersion) < Version.Parse(FeatureManagementMinimumVersion))
-                        {
-                            _logger.LogWarning(LogHelper.BuildFeatureManagementMicrosoftSchemaVersionWarningMessage());
-                        }
+                        _logger.LogWarning(LogHelper.BuildFeatureManagementMicrosoftSchemaVersionWarningMessage());
                     }
 
                     _requestTracingOptions.FeatureManagementVersion = featureManagementVersion;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
             return string.Equals(contentType, KeyVaultConstants.ContentType);
         }
 
-        public void ProcessProviderRefresh(ConfigurationSetting setting = null)
+        public void OnConfigurationRefresh(ConfigurationSetting setting = null)
         {
             if (setting == null)
             {
@@ -96,6 +96,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
             {
                 _secretProvider.RemoveSecretFromCache(setting.Key);
             }
+        }
+
+        public void OnConfigurationUpdated()
+        {
+            return;
         }
 
         public bool NeedsRefresh()

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
             return string.Equals(contentType, KeyVaultConstants.ContentType);
         }
 
-        public void OnConfigurationRefresh(ConfigurationSetting setting = null)
+        public void OnChangeDetected(ConfigurationSetting setting = null)
         {
             if (setting == null)
             {
@@ -98,7 +98,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
             }
         }
 
-        public void OnConfigurationUpdated()
+        public void OnConfigUpdated()
         {
             return;
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
@@ -107,10 +107,5 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
         {
             return _secretProvider.ShouldRefreshKeyVaultSecrets();
         }
-
-        public void ResetState()
-        {
-            return;
-        }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
@@ -102,5 +102,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
         {
             return _secretProvider.ShouldRefreshKeyVaultSecrets();
         }
+
+        public void ResetState()
+        {
+            return;
+        }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureKeyVaultReference/AzureKeyVaultKeyValueAdapter.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault
             return string.Equals(contentType, KeyVaultConstants.ContentType);
         }
 
-        public void InvalidateCache(ConfigurationSetting setting = null)
+        public void ProcessProviderRefresh(ConfigurationSetting setting = null)
         {
             if (setting == null)
             {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/ErrorMessages.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/ErrorMessages.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public const string RefreshIntervalTooShort = "The refresh interval cannot be less than {0} milliseconds.";
         public const string SecretRefreshIntervalTooShort = "The secret refresh interval cannot be less than {0} milliseconds.";
         public const string FeatureFlagInvalidJsonProperty = "Invalid property '{0}' for feature flag. Key: '{1}'. Found type: '{2}'. Expected type: '{3}'.";
-        public const string FeatureFlagInvalidFormat = "Invalid json format for feature flag. Key: '{0}'";
+        public const string FeatureFlagInvalidFormat = "Invalid json format for feature flag. Key: '{0}'.";
         public const string InvalidKeyVaultReference = "Invalid Key Vault reference.";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/ErrorMessages.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/ErrorMessages.cs
@@ -7,5 +7,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     {
         public const string RefreshIntervalTooShort = "The refresh interval cannot be less than {0} milliseconds.";
         public const string SecretRefreshIntervalTooShort = "The secret refresh interval cannot be less than {0} milliseconds.";
+        public const string FeatureFlagInvalidJsonProperty = "Invalid property '{0}' for feature flag. Key: '{1}'. Found type: '{2}'. Expected type: '{3}'.";
+        public const string FeatureFlagInvalidFormat = "Invalid json format for feature flag. Key: '{0}'";
+        public const string InvalidKeyVaultReference = "Invalid Key Vault reference.";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
@@ -34,6 +34,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public const string FailingOverToEndpoint = "Failing over to endpoint";
         public const string FeatureManagementMicrosoftSchemaVersionWarning = "Your application may be using an older version of " + 
             "Microsoft.FeatureManagement that isn't compatible with this version of the App Configuration .NET provider. Please update " +
-            "to the latest version of the Microsoft.FeatureManagement package.";
+            "the Microsoft.FeatureManagement package to version 3.2.0 or later.";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
@@ -32,5 +32,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public const string RefreshSkippedNoClientAvailable = "Refresh skipped because no endpoint is accessible.";
         public const string RefreshFailedToGetSettingsFromEndpoint = "Failed to get configuration settings from endpoint";
         public const string FailingOverToEndpoint = "Failing over to endpoint";
+        public const string FeatureManagementMicrosoftSchemaVersionWarning = "Your application may be using an older version of " + 
+            "Microsoft.FeatureManagement that isn't compatible with this version of the App Configuration .NET provider. Please update " +
+            "to the latest version of the Microsoft.FeatureManagement package.";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/LoggingConstants.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public const string RefreshFailedToGetSettingsFromEndpoint = "Failed to get configuration settings from endpoint";
         public const string FailingOverToEndpoint = "Failing over to endpoint";
         public const string FeatureManagementMicrosoftSchemaVersionWarning = "Your application may be using an older version of " + 
-            "Microsoft.FeatureManagement that isn't compatible with this version of the App Configuration .NET provider. Please update " +
+            "Microsoft.FeatureManagement library that isn't compatible with Microsoft.Extensions.Configuration.AzureAppConfiguration. Please update " +
             "the Microsoft.FeatureManagement package to version 3.2.0 or later.";
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/ClientFilter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/ClientFilter.cs
@@ -2,16 +2,13 @@
 // Licensed under the MIT license.
 //
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
     internal class ClientFilter
     {
-        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonPropertyName("parameters")]
         public JsonElement Parameters { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureAllocation.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureAllocation.cs
@@ -2,28 +2,21 @@
 // Licensed under the MIT license.
 //
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
     internal class FeatureAllocation
     {
-        [JsonPropertyName("default_when_disabled")]
         public string DefaultWhenDisabled { get; set; }
 
-        [JsonPropertyName("default_when_enabled")]
         public string DefaultWhenEnabled { get; set; }
 
-        [JsonPropertyName("user")]
         public IEnumerable<FeatureUserAllocation> User { get; set; }
 
-        [JsonPropertyName("group")]
         public IEnumerable<FeatureGroupAllocation> Group { get; set; }
 
-        [JsonPropertyName("percentile")]
         public IEnumerable<FeaturePercentileAllocation> Percentile { get; set; }
 
-        [JsonPropertyName("seed")]
         public string Seed { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureConditions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureConditions.cs
@@ -2,16 +2,13 @@
 // Licensed under the MIT license.
 //
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
     internal class FeatureConditions
     {
-        [JsonPropertyName("client_filters")]
         public List<ClientFilter> ClientFilters { get; set; } = new List<ClientFilter>();
 
-        [JsonPropertyName("requirement_type")]
         public string RequirementType { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlag.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureFlag.cs
@@ -2,28 +2,21 @@
 // Licensed under the MIT license.
 //
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
     internal class FeatureFlag
     {
-        [JsonPropertyName("id")]
         public string Id { get; set; }
 
-        [JsonPropertyName("enabled")]
         public bool Enabled { get; set; }
 
-        [JsonPropertyName("conditions")]
         public FeatureConditions Conditions { get; set; }
 
-        [JsonPropertyName("variants")]
         public IEnumerable<FeatureVariant> Variants { get; set; }
 
-        [JsonPropertyName("allocation")]
         public FeatureAllocation Allocation { get; set; }
 
-        [JsonPropertyName("telemetry")]
         public FeatureTelemetry Telemetry { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureGroupAllocation.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureGroupAllocation.cs
@@ -2,16 +2,13 @@
 // Licensed under the MIT license.
 //
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
     internal class FeatureGroupAllocation
     {
-        [JsonPropertyName("variant")]
         public string Variant { get; set; }
 
-        [JsonPropertyName("groups")]
         public IEnumerable<string> Groups { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
@@ -39,13 +39,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         public const string To = "to";
         public const string Seed = "seed";
 
-        // Feature flag status values
-        public const string Conditional = "Conditional";
-        public const string Disabled = "Disabled";
-
-        // Default filters
-        public const string AlwaysOnFilter = "AlwaysOn";
-
         // Telemetry metadata keys
         public const string ETag = "ETag";
         public const string FeatureFlagId = "FeatureFlagId";

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         public const string From = "from";
         public const string To = "to";
         public const string Seed = "seed";
-        public const string Status = "status";
 
         // Feature flag status values
         public const string Conditional = "Conditional";

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
@@ -7,36 +7,50 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
     {
         public const string FeatureFlagMarker = ".appconfig.featureflag/";
         public const string ContentType = "application/vnd.microsoft.appconfig.ff+json";
-        public const string SectionName = "FeatureManagement";
-        public const string EnabledFor = "EnabledFor";
-        public const string Variants = "Variants";
-        public const string Allocation = "Allocation";
-        public const string User = "User";
-        public const string Group = "Group";
-        public const string Percentile = "Percentile";
-        public const string Telemetry = "Telemetry";
-        public const string Enabled = "Enabled";
-        public const string Metadata = "Metadata";
-        public const string RequirementType = "RequirementType";
-        public const string Name = "Name";
-        public const string Parameters = "Parameters";
-        public const string Variant = "Variant";
-        public const string ConfigurationValue = "ConfigurationValue";
-        public const string ConfigurationReference = "ConfigurationReference";
-        public const string StatusOverride = "StatusOverride";
-        public const string DefaultWhenDisabled = "DefaultWhenDisabled";
-        public const string DefaultWhenEnabled = "DefaultWhenEnabled";
-        public const string Users = "Users";
-        public const string Groups = "Groups";
-        public const string From = "From";
-        public const string To = "To";
-        public const string Seed = "Seed";
+
+        // Feature management section keys
+        public const string FeatureManagementSectionName = "feature_management";
+        public const string FeatureFlagsSectionName = "feature_flags";
+
+        // Feature flag properties
+        public const string Id = "id";
+        public const string Enabled = "enabled";
+        public const string Conditions = "conditions";
+        public const string ClientFilters = "client_filters";
+        public const string Variants = "variants";
+        public const string Allocation = "allocation";
+        public const string User = "user";
+        public const string Group = "group";
+        public const string Percentile = "percentile";
+        public const string Telemetry = "telemetry";
+        public const string Metadata = "metadata";
+        public const string RequirementType = "requirement_type";
+        public const string Name = "name";
+        public const string Parameters = "parameters";
+        public const string Variant = "variant";
+        public const string ConfigurationValue = "configuration_value";
+        public const string ConfigurationReference = "configuration_reference";
+        public const string StatusOverride = "status_override";
+        public const string DefaultWhenDisabled = "default_when_disabled";
+        public const string DefaultWhenEnabled = "default_when_enabled";
+        public const string Users = "users";
+        public const string Groups = "groups";
+        public const string From = "from";
+        public const string To = "to";
+        public const string Seed = "seed";
+        public const string Status = "status";
+
+        // Feature flag status values
+        public const string Conditional = "Conditional";
+        public const string Disabled = "Disabled";
+
+        // Default filters
+        public const string AlwaysOnFilter = "AlwaysOn";
+
+        // Telemetry keys
         public const string ETag = "ETag";
         public const string FeatureFlagId = "FeatureFlagId";
         public const string FeatureFlagReference = "FeatureFlagReference";
-        public const string Status = "Status";
-        public const string AlwaysOnFilter = "AlwaysOn";
-        public const string Conditional = "Conditional";
-        public const string Disabled = "Disabled";
+
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
@@ -19,9 +19,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         public const string ClientFilters = "client_filters";
         public const string Variants = "variants";
         public const string Allocation = "allocation";
-        public const string User = "user";
-        public const string Group = "group";
-        public const string Percentile = "percentile";
+        public const string UserAllocation = "user";
+        public const string GroupAllocation = "group";
+        public const string PercentileAllocation = "percentile";
         public const string Telemetry = "telemetry";
         public const string Metadata = "metadata";
         public const string RequirementType = "requirement_type";

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         // Default filters
         public const string AlwaysOnFilter = "AlwaysOn";
 
-        // Telemetry keys
+        // Telemetry metadata keys
         public const string ETag = "ETag";
         public const string FeatureFlagId = "FeatureFlagId";
         public const string FeatureFlagReference = "FeatureFlagReference";

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementConstants.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
     internal class FeatureManagementConstants
@@ -43,6 +44,5 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         public const string ETag = "ETag";
         public const string FeatureFlagId = "FeatureFlagId";
         public const string FeatureFlagReference = "FeatureFlagReference";
-
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -172,9 +172,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                     {
                         keyValues.Add(new KeyValuePair<string, string>($"{allocationPath}:{FeatureManagementConstants.PercentileAllocation}:{i}:{FeatureManagementConstants.Variant}", percentileAllocation.Variant));
 
-                        keyValues.Add(new KeyValuePair<string, string>($"{allocationPath}:{FeatureManagementConstants.PercentileAllocation}:{i}:{FeatureManagementConstants.From}", percentileAllocation.From.ToString()));
+                        keyValues.Add(new KeyValuePair<string, string>($"{allocationPath}:{FeatureManagementConstants.PercentileAllocation}:{i}:{FeatureManagementConstants.From}", percentileAllocation.From?.ToString()));
 
-                        keyValues.Add(new KeyValuePair<string, string>($"{allocationPath}:{FeatureManagementConstants.PercentileAllocation}:{i}:{FeatureManagementConstants.To}", percentileAllocation.To.ToString()));
+                        keyValues.Add(new KeyValuePair<string, string>($"{allocationPath}:{FeatureManagementConstants.PercentileAllocation}:{i}:{FeatureManagementConstants.To}", percentileAllocation.To?.ToString()));
 
                         i++;
                     }
@@ -741,7 +741,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                                     {
                                         FeaturePercentileAllocation featurePercentileAllocation = ParseFeaturePercentileAllocation(ref reader, settingKey);
 
-                                        if (featurePercentileAllocation.Variant != null)
+                                        if (featurePercentileAllocation.Variant != null ||
+                                            featurePercentileAllocation.From != null ||
+                                            featurePercentileAllocation.To != null)
                                         {
                                             percentileAllocations.Add(featurePercentileAllocation);
                                         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -46,11 +46,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
             if (featureFlag.Enabled)
             {
                 //if (featureFlag.Conditions?.ClientFilters == null)
-                if (featureFlag.Conditions?.ClientFilters == null || !featureFlag.Conditions.ClientFilters.Any()) // workaround since we are not yet setting client filters to null
-                {
-                     keyValues.Add(new KeyValuePair<string, string>($"{featureFlagPath}:{FeatureManagementConstants.Conditions}:{FeatureManagementConstants.ClientFilters}:{0}:{FeatureManagementConstants.Name}", FeatureManagementConstants.AlwaysOnFilter));
-                }
-                else
+                if (featureFlag.Conditions?.ClientFilters != null && featureFlag.Conditions.ClientFilters.Any()) // workaround since we are not yet setting client filters to null
                 {
                     //
                     // Conditionally on based on feature filters

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -734,7 +734,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                                     {
                                         FeaturePercentileAllocation featurePercentileAllocation = ParseFeaturePercentileAllocation(ref reader, settingKey);
 
-                                        if (featurePercentileAllocation.Variant != null) //TODO condition for this?
+                                        if (featurePercentileAllocation.Variant != null)
                                         {
                                             percentileAllocations.Add(featurePercentileAllocation);
                                         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
             }
             else
             {
-                keyValues.Add(new KeyValuePair<string, string>($"{featureFlagPath}:{FeatureManagementConstants.Status}", FeatureManagementConstants.Disabled));
+                //keyValues.Add(new KeyValuePair<string, string>($"{featureFlagPath}:{FeatureManagementConstants.Status}", FeatureManagementConstants.Disabled));
             }
 
             if (featureFlag.Variants != null)
@@ -370,7 +370,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                             {
                                 if (reader.Read() && reader.TokenType == JsonTokenType.StartArray)
                                 {
-                                    featureFlag.Variants = new List<FeatureVariant>();
+                                    List<FeatureVariant> variants = new List<FeatureVariant>();
 
                                     while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
                                     {
@@ -380,10 +380,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                                             if (featureVariant.Name != null)
                                             {
-                                                featureFlag.Variants.Append(featureVariant);
+                                                variants.Add(featureVariant);
                                             }
                                         }
                                     }
+
+                                    featureFlag.Variants = variants;
                                 }
                                 else if (reader.TokenType != JsonTokenType.Null)
                                 {
@@ -632,7 +634,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                         {
                             if (reader.Read() && reader.TokenType == JsonTokenType.StartArray)
                             {
-                                featureAllocation.User = new List<FeatureUserAllocation>();
+                                List<FeatureUserAllocation> userAllocations = new List<FeatureUserAllocation>();
 
                                 int i = 0;
 
@@ -646,7 +648,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                                             (featureUserAllocation.Users != null &&
                                             featureUserAllocation.Users.Any()))
                                         {
-                                            featureAllocation.User.Append(featureUserAllocation);
+                                            userAllocations.Add(featureUserAllocation);
                                         }
                                     }
                                     else if (reader.TokenType != JsonTokenType.Null)
@@ -660,6 +662,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                                     i++;
                                 }
+
+                                featureAllocation.User = userAllocations;
                             }
                             else if (reader.TokenType != JsonTokenType.Null)
                             {
@@ -677,7 +681,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                         {
                             if (reader.Read() && reader.TokenType == JsonTokenType.StartArray)
                             {
-                                featureAllocation.Group = new List<FeatureGroupAllocation>();
+                                List<FeatureGroupAllocation> groupAllocations = new List<FeatureGroupAllocation>();
 
                                 int i = 0;
 
@@ -691,7 +695,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                                             (featureGroupAllocation.Groups != null &&
                                             featureGroupAllocation.Groups.Any()))
                                         {
-                                            featureAllocation.Group.Append(featureGroupAllocation);
+                                            groupAllocations.Add(featureGroupAllocation);
                                         }
                                     }
                                     else if (reader.TokenType != JsonTokenType.Null)
@@ -705,6 +709,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                                     i++;
                                 }
+
+                                featureAllocation.Group = groupAllocations;
                             }
                             else if (reader.TokenType != JsonTokenType.Null)
                             {
@@ -722,7 +728,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                         {
                             if (reader.Read() && reader.TokenType == JsonTokenType.StartArray)
                             {
-                                featureAllocation.Percentile = new List<FeaturePercentileAllocation>();
+                                List<FeaturePercentileAllocation> percentileAllocations = new List<FeaturePercentileAllocation>();
 
                                 int i = 0;
 
@@ -734,7 +740,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                                         if (featurePercentileAllocation.Variant != null) //TODO condition for this?
                                         {
-                                            featureAllocation.Percentile.Append(featurePercentileAllocation);
+                                            percentileAllocations.Add(featurePercentileAllocation);
                                         }
                                     }
                                     else if (reader.TokenType != JsonTokenType.Null)
@@ -748,6 +754,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                                     i++;
                                 }
+
+                                featureAllocation.Percentile = percentileAllocations;
                             }
                             else if (reader.TokenType != JsonTokenType.Null)
                             {
@@ -756,6 +764,24 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                                     settingKey,
                                     reader.TokenType.ToString(),
                                     JsonTokenType.StartArray.ToString());
+                            }
+
+                            break;
+                        }
+
+                    case FeatureManagementConstants.Seed:
+                        {
+                            if (reader.Read() && reader.TokenType == JsonTokenType.String)
+                            {
+                                featureAllocation.Seed = reader.GetString();
+                            }
+                            else if (reader.TokenType != JsonTokenType.Null)
+                            {
+                                throw CreateFeatureFlagFormatException(
+                                    FeatureManagementConstants.Seed,
+                                    settingKey,
+                                    reader.TokenType.ToString(),
+                                    JsonTokenType.String.ToString());
                             }
 
                             break;
@@ -808,7 +834,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                         {
                             if (reader.Read() && reader.TokenType == JsonTokenType.StartArray)
                             {
-                                featureUserAllocation.Users = new List<string>();
+                                List<string> users = new List<string>();
 
                                 int i = 0;
 
@@ -816,7 +842,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                                 {
                                     if (reader.TokenType == JsonTokenType.String)
                                     {
-                                        featureUserAllocation.Users.Append(reader.GetString());
+                                        users.Add(reader.GetString());
                                     }
                                     else if (reader.TokenType != JsonTokenType.Null)
                                     {
@@ -829,6 +855,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                                     i++;
                                 }
+
+                                featureUserAllocation.Users = users;
                             }
                             else if (reader.TokenType != JsonTokenType.Null)
                             {
@@ -889,7 +917,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                         {
                             if (reader.Read() && reader.TokenType == JsonTokenType.StartArray)
                             {
-                                featureGroupAllocation.Groups = new List<string>();
+                                List<string> groups = new List<string>();
 
                                 int i = 0;
 
@@ -897,7 +925,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                                 {
                                     if (reader.TokenType == JsonTokenType.String)
                                     {
-                                        featureGroupAllocation.Groups.Append(reader.GetString());
+                                        groups.Add(reader.GetString());
                                     }
                                     else if (reader.TokenType != JsonTokenType.Null)
                                     {
@@ -910,6 +938,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                                     i++;
                                 }
+
+                                featureGroupAllocation.Groups = groups;
                             }
                             else if (reader.TokenType != JsonTokenType.Null)
                             {
@@ -1077,6 +1107,25 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                             break;
                         }
 
+
+                    case FeatureManagementConstants.StatusOverride:
+                        {
+                            if (reader.Read() && reader.TokenType == JsonTokenType.String)
+                            {
+                                featureVariant.StatusOverride = reader.GetString();
+                            }
+                            else if (reader.TokenType != JsonTokenType.Null)
+                            {
+                                throw CreateFeatureFlagFormatException(
+                                    FeatureManagementConstants.StatusOverride,
+                                    settingKey,
+                                    reader.TokenType.ToString(),
+                                    JsonTokenType.String.ToString());
+                            }
+
+                            break;
+                        }
+
                     default:
                         reader.Skip();
 
@@ -1118,7 +1167,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                                     FeatureManagementConstants.Enabled,
                                     settingKey,
                                     reader.TokenType.ToString(),
-                                    JsonTokenType.String.ToString());
+                                    $"{JsonTokenType.True}' or '{JsonTokenType.False}");
                             }
 
                             break;
@@ -1126,21 +1175,40 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                     case FeatureManagementConstants.Metadata:
                         {
-                            if (reader.Read() && (reader.TokenType == JsonTokenType.False || reader.TokenType == JsonTokenType.True))
+                            if (reader.Read() && reader.TokenType == JsonTokenType.StartObject)
                             {
-                                featureTelemetry.Enabled = reader.GetBoolean();
-                            }
-                            else if (reader.TokenType == JsonTokenType.String && bool.TryParse(reader.GetString(), out bool enabled))
-                            {
-                                featureTelemetry.Enabled = enabled;
+                                featureTelemetry.Metadata = new Dictionary<string, string>();
+
+                                while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+                                {
+                                    if (reader.TokenType != JsonTokenType.PropertyName)
+                                    {
+                                        continue;
+                                    }
+
+                                    string metadataPropertyName = reader.GetString();
+
+                                    if (reader.Read() && reader.TokenType == JsonTokenType.String)
+                                    {
+                                        featureTelemetry.Metadata[metadataPropertyName] = reader.GetString();
+                                    }
+                                    else if (reader.TokenType != JsonTokenType.Null)
+                                    {
+                                        throw CreateFeatureFlagFormatException(
+                                            FeatureManagementConstants.Metadata,
+                                            settingKey,
+                                            reader.TokenType.ToString(),
+                                            JsonTokenType.String.ToString());
+                                    }
+                                }
                             }
                             else if (reader.TokenType != JsonTokenType.Null)
                             {
                                 throw CreateFeatureFlagFormatException(
-                                    FeatureManagementConstants.Enabled,
+                                    FeatureManagementConstants.Metadata,
                                     settingKey,
                                     reader.TokenType.ToString(),
-                                    $"{JsonTokenType.True}' or '{JsonTokenType.False}");
+                                    JsonTokenType.StartObject.ToString());
                             }
 
                             break;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
             return false;
         }
 
-        public void ResetState()
+        public void ProcessProviderRefresh(ConfigurationSetting setting = null)
         {
             _featureFlagIndex = 0;
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
     internal class FeatureManagementKeyValueAdapter : IKeyValueAdapter
     {
         private FeatureFilterTracing _featureFilterTracing;
+        private int _featureFlagIndex = 0;
 
         public FeatureManagementKeyValueAdapter(FeatureFilterTracing featureFilterTracing)
         {
@@ -37,8 +38,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
             var keyValues = new List<KeyValuePair<string, string>>();
 
-            // TODO how to get index of this flag?
-            string featureFlagPath = $"{FeatureManagementConstants.FeatureManagementSectionName}:{FeatureManagementConstants.FeatureManagementSectionName}:{_featureFlagIndex}";
+            string featureFlagPath = $"{FeatureManagementConstants.FeatureManagementSectionName}:{FeatureManagementConstants.FeatureFlagsSectionName}:{_featureFlagIndex}";
+
+            _featureFlagIndex++;
 
             keyValues.Add(new KeyValuePair<string, string>($"{featureFlagPath}:{FeatureManagementConstants.Id}", featureFlag.Id));
 
@@ -248,6 +250,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
         public bool NeedsRefresh()
         {
             return false;
+        }
+
+        public void ResetState()
+        {
+            _featureFlagIndex = 0;
+
+            return;
         }
 
         private static string CalculateFeatureFlagId(string key, string label)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -172,9 +172,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                     {
                         keyValues.Add(new KeyValuePair<string, string>($"{allocationPath}:{FeatureManagementConstants.PercentileAllocation}:{i}:{FeatureManagementConstants.Variant}", percentileAllocation.Variant));
 
-                        keyValues.Add(new KeyValuePair<string, string>($"{allocationPath}:{FeatureManagementConstants.PercentileAllocation}:{i}:{FeatureManagementConstants.From}", percentileAllocation.From?.ToString()));
+                        keyValues.Add(new KeyValuePair<string, string>($"{allocationPath}:{FeatureManagementConstants.PercentileAllocation}:{i}:{FeatureManagementConstants.From}", percentileAllocation.From.ToString()));
 
-                        keyValues.Add(new KeyValuePair<string, string>($"{allocationPath}:{FeatureManagementConstants.PercentileAllocation}:{i}:{FeatureManagementConstants.To}", percentileAllocation.To?.ToString()));
+                        keyValues.Add(new KeyValuePair<string, string>($"{allocationPath}:{FeatureManagementConstants.PercentileAllocation}:{i}:{FeatureManagementConstants.To}", percentileAllocation.To.ToString()));
 
                         i++;
                     }
@@ -741,12 +741,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                                     {
                                         FeaturePercentileAllocation featurePercentileAllocation = ParseFeaturePercentileAllocation(ref reader, settingKey);
 
-                                        if (featurePercentileAllocation.Variant != null ||
-                                            featurePercentileAllocation.From != null ||
-                                            featurePercentileAllocation.To != null)
-                                        {
-                                            percentileAllocations.Add(featurePercentileAllocation);
-                                        }
+                                        percentileAllocations.Add(featurePercentileAllocation);
                                     }
                                     else if (reader.TokenType != JsonTokenType.Null)
                                     {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -1195,7 +1195,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                                     else if (reader.TokenType != JsonTokenType.Null)
                                     {
                                         throw CreateFeatureFlagFormatException(
-                                            FeatureManagementConstants.Metadata,
+                                            metadataPropertyName,
                                             settingKey,
                                             reader.TokenType.ToString(),
                                             JsonTokenType.String.ToString());

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -45,11 +45,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
             if (featureFlag.Enabled)
             {
-                //if (featureFlag.Conditions?.ClientFilters == null)
                 if (featureFlag.Conditions?.ClientFilters != null && featureFlag.Conditions.ClientFilters.Any()) // workaround since we are not yet setting client filters to null
                 {
                     //
-                    // Conditionally on based on feature filters
+                    // Conditionally based on feature filters
                     for (int i = 0; i < featureFlag.Conditions.ClientFilters.Count; i++)
                     {
                         ClientFilter clientFilter = featureFlag.Conditions.ClientFilters[i];
@@ -260,7 +259,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
         private FeatureFlag ParseFeatureFlag(string settingKey, string settingValue)
         {
-            FeatureFlag featureFlag = new FeatureFlag();
+            var featureFlag = new FeatureFlag();
 
             var reader = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes(settingValue));
 
@@ -366,6 +365,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                                     while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
                                     {
+                                        int i = 0;
+
                                         if (reader.TokenType == JsonTokenType.StartObject)
                                         {
                                             FeatureVariant featureVariant = ParseFeatureVariant(ref reader, settingKey);
@@ -375,6 +376,16 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                                                 variants.Add(featureVariant);
                                             }
                                         }
+                                        else if (reader.TokenType != JsonTokenType.Null)
+                                        {
+                                            throw CreateFeatureFlagFormatException(
+                                                $"{FeatureManagementConstants.Variants}[{i}]",
+                                                settingKey,
+                                                reader.TokenType.ToString(),
+                                                JsonTokenType.StartObject.ToString());
+                                        }
+
+                                        i++;
                                     }
 
                                     featureFlag.Variants = variants;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -240,7 +240,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
             return false;
         }
 
-        public void ProcessProviderRefresh(ConfigurationSetting setting = null)
+        public void OnConfigurationRefresh(ConfigurationSetting setting = null)
+        {
+            return;
+        }
+
+        public void OnConfigurationUpdated()
         {
             _featureFlagIndex = 0;
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -634,6 +634,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                             {
                                 featureAllocation.User = new List<FeatureUserAllocation>();
 
+                                int i = 0;
+
                                 while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
                                 {
                                     if (reader.TokenType == JsonTokenType.StartObject)
@@ -647,6 +649,16 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                                             featureAllocation.User.Append(featureUserAllocation);
                                         }
                                     }
+                                    else if (reader.TokenType != JsonTokenType.Null)
+                                    {
+                                        throw CreateFeatureFlagFormatException(
+                                            $"{FeatureManagementConstants.UserAllocation}[{i}]",
+                                            settingKey,
+                                            reader.TokenType.ToString(),
+                                            JsonTokenType.StartObject.ToString());
+                                    }
+
+                                    i++;
                                 }
                             }
                             else if (reader.TokenType != JsonTokenType.Null)
@@ -667,6 +679,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                             {
                                 featureAllocation.Group = new List<FeatureGroupAllocation>();
 
+                                int i = 0;
+
                                 while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
                                 {
                                     if (reader.TokenType == JsonTokenType.StartObject)
@@ -680,6 +694,16 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                                             featureAllocation.Group.Append(featureGroupAllocation);
                                         }
                                     }
+                                    else if (reader.TokenType != JsonTokenType.Null)
+                                    {
+                                        throw CreateFeatureFlagFormatException(
+                                            $"{FeatureManagementConstants.GroupAllocation}[{i}]",
+                                            settingKey,
+                                            reader.TokenType.ToString(),
+                                            JsonTokenType.StartObject.ToString());
+                                    }
+
+                                    i++;
                                 }
                             }
                             else if (reader.TokenType != JsonTokenType.Null)
@@ -700,18 +724,29 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                             {
                                 featureAllocation.Percentile = new List<FeaturePercentileAllocation>();
 
+                                int i = 0;
+
                                 while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
                                 {
                                     if (reader.TokenType == JsonTokenType.StartObject)
                                     {
                                         FeaturePercentileAllocation featurePercentileAllocation = ParseFeaturePercentileAllocation(ref reader, settingKey);
 
-                                        if (featurePercentileAllocation.Variant != null ||
-                                            ())
+                                        if (featurePercentileAllocation.Variant != null) //TODO condition for this?
                                         {
                                             featureAllocation.Percentile.Append(featurePercentileAllocation);
                                         }
                                     }
+                                    else if (reader.TokenType != JsonTokenType.Null)
+                                    {
+                                        throw CreateFeatureFlagFormatException(
+                                            $"{FeatureManagementConstants.PercentileAllocation}[{i}]",
+                                            settingKey,
+                                            reader.TokenType.ToString(),
+                                            JsonTokenType.StartObject.ToString());
+                                    }
+
+                                    i++;
                                 }
                             }
                             else if (reader.TokenType != JsonTokenType.Null)
@@ -775,21 +810,33 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                             {
                                 featureUserAllocation.Users = new List<string>();
 
+                                int i = 0;
+
                                 while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
                                 {
                                     if (reader.TokenType == JsonTokenType.String)
                                     {
                                         featureUserAllocation.Users.Append(reader.GetString());
                                     }
+                                    else if (reader.TokenType != JsonTokenType.Null)
+                                    {
+                                        throw CreateFeatureFlagFormatException(
+                                            $"{FeatureManagementConstants.Users}[{i}]",
+                                            settingKey,
+                                            reader.TokenType.ToString(),
+                                            JsonTokenType.String.ToString());
+                                    }
+
+                                    i++;
                                 }
                             }
                             else if (reader.TokenType != JsonTokenType.Null)
                             {
                                 throw CreateFeatureFlagFormatException(
-                                    FeatureManagementConstants.Variant,
+                                    FeatureManagementConstants.Users,
                                     settingKey,
                                     reader.TokenType.ToString(),
-                                    JsonTokenType.String.ToString());
+                                    JsonTokenType.StartArray.ToString());
                             }
 
                             break;
@@ -803,6 +850,170 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
             }
 
             return featureUserAllocation;
+        }
+
+        private FeatureGroupAllocation ParseFeatureGroupAllocation(ref Utf8JsonReader reader, string settingKey)
+        {
+            var featureGroupAllocation = new FeatureGroupAllocation();
+
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    continue;
+                }
+
+                string groupAllocationPropertyName = reader.GetString();
+
+                switch (groupAllocationPropertyName)
+                {
+                    case FeatureManagementConstants.Variant:
+                        {
+                            if (reader.Read() && reader.TokenType == JsonTokenType.String)
+                            {
+                                featureGroupAllocation.Variant = reader.GetString();
+                            }
+                            else if (reader.TokenType != JsonTokenType.Null)
+                            {
+                                throw CreateFeatureFlagFormatException(
+                                    FeatureManagementConstants.Variant,
+                                    settingKey,
+                                    reader.TokenType.ToString(),
+                                    JsonTokenType.String.ToString());
+                            }
+
+                            break;
+                        }
+
+                    case FeatureManagementConstants.Groups:
+                        {
+                            if (reader.Read() && reader.TokenType == JsonTokenType.StartArray)
+                            {
+                                featureGroupAllocation.Groups = new List<string>();
+
+                                int i = 0;
+
+                                while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                                {
+                                    if (reader.TokenType == JsonTokenType.String)
+                                    {
+                                        featureGroupAllocation.Groups.Append(reader.GetString());
+                                    }
+                                    else if (reader.TokenType != JsonTokenType.Null)
+                                    {
+                                        throw CreateFeatureFlagFormatException(
+                                            $"{FeatureManagementConstants.Groups}[{i}]",
+                                            settingKey,
+                                            reader.TokenType.ToString(),
+                                            JsonTokenType.String.ToString());
+                                    }
+
+                                    i++;
+                                }
+                            }
+                            else if (reader.TokenType != JsonTokenType.Null)
+                            {
+                                throw CreateFeatureFlagFormatException(
+                                    FeatureManagementConstants.Groups,
+                                    settingKey,
+                                    reader.TokenType.ToString(),
+                                    JsonTokenType.StartArray.ToString());
+                            }
+
+                            break;
+                        }
+
+                    default:
+                        reader.Skip();
+
+                        break;
+                }
+            }
+
+            return featureGroupAllocation;
+        }
+
+        private FeaturePercentileAllocation ParseFeaturePercentileAllocation(ref Utf8JsonReader reader, string settingKey)
+        {
+            var featurePercentileAllocation = new FeaturePercentileAllocation();
+
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    continue;
+                }
+
+                string percentileAllocationPropertyName = reader.GetString();
+
+                switch (percentileAllocationPropertyName)
+                {
+                    case FeatureManagementConstants.Variant:
+                        {
+                            if (reader.Read() && reader.TokenType == JsonTokenType.String)
+                            {
+                                featurePercentileAllocation.Variant = reader.GetString();
+                            }
+                            else if (reader.TokenType != JsonTokenType.Null)
+                            {
+                                throw CreateFeatureFlagFormatException(
+                                    FeatureManagementConstants.Variant,
+                                    settingKey,
+                                    reader.TokenType.ToString(),
+                                    JsonTokenType.String.ToString());
+                            }
+
+                            break;
+                        }
+
+                    case FeatureManagementConstants.From:
+                        {
+                            if (reader.Read() && 
+                                ((reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out int from)) || 
+                                (reader.TokenType == JsonTokenType.String && int.TryParse(reader.GetString(), out from))))
+                            {
+                                featurePercentileAllocation.From = from;
+                            }
+                            else if (reader.TokenType != JsonTokenType.Null)
+                            {
+                                throw CreateFeatureFlagFormatException(
+                                    FeatureManagementConstants.From,
+                                    settingKey,
+                                    reader.TokenType.ToString(),
+                                    JsonTokenType.Number.ToString());
+                            }
+
+                            break;
+                        }
+
+                    case FeatureManagementConstants.To:
+                        {
+                            if (reader.Read() &&
+                                ((reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out int to)) ||
+                                (reader.TokenType == JsonTokenType.String && int.TryParse(reader.GetString(), out to))))
+                            {
+                                featurePercentileAllocation.To = to;
+                            }
+                            else if (reader.TokenType != JsonTokenType.Null)
+                            {
+                                throw CreateFeatureFlagFormatException(
+                                    FeatureManagementConstants.To,
+                                    settingKey,
+                                    reader.TokenType.ToString(),
+                                    JsonTokenType.Number.ToString());
+                            }
+
+                            break;
+                        }
+
+                    default:
+                        reader.Skip();
+
+                        break;
+                }
+            }
+
+            return featurePercentileAllocation;
         }
 
         private FeatureVariant ParseFeatureVariant(ref Utf8JsonReader reader, string settingKey)

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -37,16 +37,19 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
             var keyValues = new List<KeyValuePair<string, string>>();
 
-            string featureFlagPath = $"{FeatureManagementConstants.SectionName}:{featureFlag.Id}";
+            // TODO how to get index of this flag?
+            string featureFlagPath = $"{FeatureManagementConstants.FeatureManagementSectionName}:{FeatureManagementConstants.FeatureManagementSectionName}:{_featureFlagIndex}";
+
+            keyValues.Add(new KeyValuePair<string, string>($"{featureFlagPath}:{FeatureManagementConstants.Id}", featureFlag.Id));
+
+            keyValues.Add(new KeyValuePair<string, string>($"{featureFlagPath}:{FeatureManagementConstants.Enabled}", featureFlag.Enabled.ToString()));
 
             if (featureFlag.Enabled)
             {
-                keyValues.Add(new KeyValuePair<string, string>($"{featureFlagPath}:{FeatureManagementConstants.Status}", FeatureManagementConstants.Conditional));
-
                 //if (featureFlag.Conditions?.ClientFilters == null)
                 if (featureFlag.Conditions?.ClientFilters == null || !featureFlag.Conditions.ClientFilters.Any()) // workaround since we are not yet setting client filters to null
                 {
-                     keyValues.Add(new KeyValuePair<string, string>($"{featureFlagPath}:{FeatureManagementConstants.EnabledFor}:{0}:{FeatureManagementConstants.Name}", FeatureManagementConstants.AlwaysOnFilter));
+                     keyValues.Add(new KeyValuePair<string, string>($"{featureFlagPath}:{FeatureManagementConstants.Conditions}:{FeatureManagementConstants.ClientFilters}:{0}:{FeatureManagementConstants.Name}", FeatureManagementConstants.AlwaysOnFilter));
                 }
                 else
                 {
@@ -58,7 +61,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
 
                         _featureFilterTracing.UpdateFeatureFilterTracing(clientFilter.Name);
 
-                        string clientFiltersPath = $"{featureFlagPath}:{FeatureManagementConstants.EnabledFor}:{i}";
+                        string clientFiltersPath = $"{featureFlagPath}:{FeatureManagementConstants.Conditions}:{FeatureManagementConstants.ClientFilters}:{i}";
 
                         keyValues.Add(new KeyValuePair<string, string>($"{clientFiltersPath}:{FeatureManagementConstants.Name}", clientFilter.Name));
 
@@ -73,7 +76,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                     if (featureFlag.Conditions.RequirementType != null)
                     {
                         keyValues.Add(new KeyValuePair<string, string>(
-                            $"{featureFlagPath}:{FeatureManagementConstants.RequirementType}", 
+                            $"{featureFlagPath}:{FeatureManagementConstants.Conditions}:{FeatureManagementConstants.RequirementType}", 
                             featureFlag.Conditions.RequirementType));
                     }
                 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -76,10 +76,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
                     }
                 }
             }
-            else
-            {
-                //keyValues.Add(new KeyValuePair<string, string>($"{featureFlagPath}:{FeatureManagementConstants.Status}", FeatureManagementConstants.Disabled));
-            }
 
             if (featureFlag.Variants != null)
             {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureManagementKeyValueAdapter.cs
@@ -240,12 +240,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
             return false;
         }
 
-        public void OnConfigurationRefresh(ConfigurationSetting setting = null)
+        public void OnChangeDetected(ConfigurationSetting setting = null)
         {
             return;
         }
 
-        public void OnConfigurationUpdated()
+        public void OnConfigUpdated()
         {
             _featureFlagIndex = 0;
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeaturePercentileAllocation.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeaturePercentileAllocation.cs
@@ -2,19 +2,15 @@
 // Licensed under the MIT license.
 //
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
     internal class FeaturePercentileAllocation
     {
-        [JsonPropertyName("variant")]
         public string Variant { get; set; }
 
-        [JsonPropertyName("from")]
         public double From { get; set; }
 
-        [JsonPropertyName("to")]
         public double To { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeaturePercentileAllocation.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeaturePercentileAllocation.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
     {
         public string Variant { get; set; }
 
-        public double From { get; set; }
+        public double? From { get; set; }
 
-        public double To { get; set; }
+        public double? To { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeaturePercentileAllocation.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeaturePercentileAllocation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
-using System.Collections.Generic;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
@@ -9,8 +8,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
     {
         public string Variant { get; set; }
 
-        public double? From { get; set; }
+        public double From { get; set; }
 
-        public double? To { get; set; }
+        public double To { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureTelemetry.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureTelemetry.cs
@@ -3,16 +3,13 @@
 //
 
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
     internal class FeatureTelemetry
     {
-        [JsonPropertyName("enabled")]
         public bool Enabled { get; set; }
 
-        [JsonPropertyName("metadata")]
         public IReadOnlyDictionary<string, string> Metadata { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureTelemetry.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureTelemetry.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManage
     {
         public bool Enabled { get; set; }
 
-        public IReadOnlyDictionary<string, string> Metadata { get; set; }
+        public IDictionary<string, string> Metadata { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureUserAllocation.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureUserAllocation.cs
@@ -2,16 +2,13 @@
 // Licensed under the MIT license.
 //
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
     internal class FeatureUserAllocation
     {
-        [JsonPropertyName("variant")]
         public string Variant { get; set; }
 
-        [JsonPropertyName("users")]
         public IEnumerable<string> Users { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureVariant.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/FeatureManagement/FeatureVariant.cs
@@ -2,22 +2,17 @@
 // Licensed under the MIT license.
 //
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement
 {
     internal class FeatureVariant
     {
-        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonPropertyName("configuration_value")]
         public JsonElement ConfigurationValue { get; set; }
 
-        [JsonPropertyName("configuration_reference")]
         public string ConfigurationReference { get; set; }
 
-        [JsonPropertyName("status_override")]
         public string StatusOverride { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
@@ -15,10 +15,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         bool CanProcess(ConfigurationSetting setting);
 
-        void InvalidateCache(ConfigurationSetting setting = null);
+        void ProcessProviderRefresh(ConfigurationSetting setting = null);
 
         bool NeedsRefresh();
-
-        void ResetState();
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
@@ -15,7 +15,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         bool CanProcess(ConfigurationSetting setting);
 
-        void ProcessProviderRefresh(ConfigurationSetting setting = null);
+        void OnConfigurationRefresh(ConfigurationSetting setting = null);
+
+        void OnConfigurationUpdated();
 
         bool NeedsRefresh();
     }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         void InvalidateCache(ConfigurationSetting setting = null);
 
         bool NeedsRefresh();
+
+        void ResetState();
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/IKeyValueAdapter.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         bool CanProcess(ConfigurationSetting setting);
 
-        void OnConfigurationRefresh(ConfigurationSetting setting = null);
+        void OnChangeDetected(ConfigurationSetting setting = null);
 
-        void OnConfigurationUpdated();
+        void OnConfigUpdated();
 
         bool NeedsRefresh();
     }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
@@ -99,5 +99,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         {
             return false;
         }
+
+        public void ResetState()
+        {
+            return;
+        }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
@@ -90,12 +90,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return false;
         }
 
-        public void OnConfigurationRefresh(ConfigurationSetting setting = null)
+        public void OnChangeDetected(ConfigurationSetting setting = null)
         {
             return;
         }
 
-        public void OnConfigurationUpdated()
+        public void OnConfigUpdated()
         {
             return;
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
@@ -104,10 +104,5 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         {
             return false;
         }
-
-        public void ResetState()
-        {
-            return;
-        }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
@@ -90,7 +90,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return false;
         }
 
-        public void ProcessProviderRefresh(ConfigurationSetting setting = null)
+        public void OnConfigurationRefresh(ConfigurationSetting setting = null)
+        {
+            return;
+        }
+
+        public void OnConfigurationUpdated()
         {
             return;
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return false;
         }
 
-        public void InvalidateCache(ConfigurationSetting setting = null)
+        public void ProcessProviderRefresh(ConfigurationSetting setting = null)
         {
             return;
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/LogHelper.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/LogHelper.cs
@@ -89,5 +89,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         {
             return $"{LoggingConstants.FallbackClientLookupError}\n{exceptionMessage}";
         }
+
+        public static string BuildFeatureManagementMicrosoftSchemaVersionWarningMessage()
+        {
+            return LoggingConstants.FeatureManagementMicrosoftSchemaVersionWarning;
+        }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -75,11 +75,12 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return false;
         }
 
-        public static Version GetAssemblyVersion(string assemblyName)
+        public static string GetAssemblyVersion(string assemblyName)
         {
             if (!string.IsNullOrEmpty(assemblyName))
             {
-                return AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(assembly => assembly.GetName().Name == assemblyName)?.GetName().Version;
+                // Return the version using only the first 3 fields and remove additional characters
+                return AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(assembly => assembly.GetName().Name == assemblyName)?.GetName().Version?.ToString(3).Trim('{', '}');
             }
 
             return null;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using System.Security;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Security;
 using System.Text;
 using System.Threading.Tasks;
@@ -75,12 +76,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return false;
         }
 
-        public static string GetAssemblyVersion(string assemblyName)
+        public static Version GetAssemblyVersion(string assemblyName)
         {
             if (!string.IsNullOrEmpty(assemblyName))
             {
-                // Return the version using only the first 3 fields and remove additional characters
-                return AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(assembly => assembly.GetName().Name == assemblyName)?.GetName().Version?.ToString(3).Trim('{', '}');
+                return AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(assembly => assembly.GetName().Name == assemblyName)?.GetName().Version;
             }
 
             return null;

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -193,7 +193,7 @@ namespace Tests.AzureAppConfiguration
             eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"))
         };
 
-    List<ConfigurationSetting> _validFormatFeatureFlagCollection = new List<ConfigurationSetting>
+        List<ConfigurationSetting> _validFormatFeatureFlagCollection = new List<ConfigurationSetting>
         {
             ConfigurationModelFactory.ConfigurationSetting(
             key: FeatureManagementConstants.FeatureFlagMarker + "AdditionalProperty",
@@ -320,7 +320,7 @@ namespace Tests.AzureAppConfiguration
             eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"))
         };
 
-    List<ConfigurationSetting> _featureFlagCollection = new List<ConfigurationSetting>
+        List<ConfigurationSetting> _featureFlagCollection = new List<ConfigurationSetting>
         {
             ConfigurationModelFactory.ConfigurationSetting(
                 key: FeatureManagementConstants.FeatureFlagMarker + "App1_Feature1",
@@ -1300,7 +1300,7 @@ namespace Tests.AzureAppConfiguration
                 .Returns(() =>
                 {
                     return new MockAsyncPageable(_featureFlagCollection.Where(s =>
-                        (s.Key.StartsWith(FeatureManagementConstants.FeatureFlagMarker + prefix1) && s.Label == label1) || 
+                        (s.Key.StartsWith(FeatureManagementConstants.FeatureFlagMarker + prefix1) && s.Label == label1) ||
                         (s.Key.StartsWith(FeatureManagementConstants.FeatureFlagMarker + prefix2) && s.Label == label2)).ToList());
                 });
 

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -187,86 +187,88 @@ namespace Tests.AzureAppConfiguration
                 eTag: new ETag("0a76e3d7-7ec1-4e37-883c-9ea6d0d89e63"),
                 contentType: "text");
 
-        private ConfigurationSetting _variantsKv1 = ConfigurationModelFactory.ConfigurationSetting(
-            key: FeatureManagementConstants.FeatureFlagMarker + "VariantsFeature1",
-            value: @"
-                    {
-                        ""id"": ""VariantsFeature1"",
-                        ""description"": """",
-                        ""display_name"": ""Variants Feature 1"",
-                        ""enabled"": true,
-                        ""conditions"": {
-                        ""client_filters"": [
-                        ]
-                        },
-                        ""variants"": [
-		                {
-			                ""name"": ""Big"",
-			                ""configuration_value"": ""600px""
-		                },
-		                {
-			                ""name"": ""Small"",
-			                ""configuration_reference"": ""ShoppingCart:Small"",
-			                ""status_override"": ""Disabled""
-		                }
-	                    ],
-	                    ""allocation"": {
-		                    ""seed"": ""13992821"",
-		                    ""default_when_disabled"": ""Small"",
-		                    ""default_when_enabled"": ""Small"",
-		                    ""user"": [
-			                    {
-				                    ""variant"": ""Big"",
-				                    ""users"": [
-					                    ""Marsha"",
-                                        ""John""
-				                    ]
-			                    },
-                                {
-                                    ""variant"": ""Small"",
-                                    ""users"": [
-                                        ""Alice"",
-                                        ""Bob""
-                                    ]
-                                }   
-		                    ],
-		                    ""group"": [
-			                    {
-				                    ""variant"": ""Big"",
-				                    ""groups"": [
-					                    ""Ring1""
-				                    ]
-			                    },
-                                {
-                                    ""variant"": ""Small"",
-                                    ""groups"": [
-                                        ""Ring2"",
-                                        ""Ring3""
-                                    ]
-                                }
-		                    ],
-		                    ""percentile"": [
-			                    {
-				                    ""variant"": ""Big"",
-				                    ""from"": 0,
-				                    ""to"": 50
-			                    },
-                                {
-                                    ""variant"": ""Small"",
-                                    ""from"": 50,
-                                    ""to"": 100
-                                }
-		                    ]
-	                    }
-                    }
-                    ",
-            label: default,
-            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
-            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
+        List<ConfigurationSetting> _variantFeatureFlagCollection = new List<ConfigurationSetting>
+        {
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "VariantsFeature1",
+                value: @"
+                        {
+                            ""id"": ""VariantsFeature1"",
+                            ""description"": """",
+                            ""display_name"": ""Variants Feature 1"",
+                            ""enabled"": true,
+                            ""conditions"": {
+                            ""client_filters"": [
+                            ]
+                            },
+                            ""variants"": [
+		                    {
+			                    ""name"": ""Big"",
+			                    ""configuration_value"": ""600px""
+		                    },
+		                    {
+			                    ""name"": ""Small"",
+			                    ""configuration_reference"": ""ShoppingCart:Small"",
+			                    ""status_override"": ""Disabled""
+		                    }
+	                        ],
+	                        ""allocation"": {
+		                        ""seed"": ""13992821"",
+		                        ""default_when_disabled"": ""Small"",
+		                        ""default_when_enabled"": ""Small"",
+		                        ""user"": [
+			                        {
+				                        ""variant"": ""Big"",
+				                        ""users"": [
+					                        ""Marsha"",
+                                            ""John""
+				                        ]
+			                        },
+                                    {
+                                        ""variant"": ""Small"",
+                                        ""users"": [
+                                            ""Alice"",
+                                            ""Bob""
+                                        ]
+                                    }   
+		                        ],
+		                        ""group"": [
+			                        {
+				                        ""variant"": ""Big"",
+				                        ""groups"": [
+					                        ""Ring1""
+				                        ]
+			                        },
+                                    {
+                                        ""variant"": ""Small"",
+                                        ""groups"": [
+                                            ""Ring2"",
+                                            ""Ring3""
+                                        ]
+                                    }
+		                        ],
+		                        ""percentile"": [
+			                        {
+				                        ""variant"": ""Big"",
+				                        ""from"": 0,
+				                        ""to"": 50
+			                        },
+                                    {
+                                        ""variant"": ""Small"",
+                                        ""from"": 50,
+                                        ""to"": 100
+                                    }
+		                        ]
+	                        }
+                        }
+                        ",
+                label: default,
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
 
-        private ConfigurationSetting _variantsKv2 = ConfigurationModelFactory.ConfigurationSetting(
-            key: FeatureManagementConstants.FeatureFlagMarker + "VariantsFeature2",
-            value: @"
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "VariantsFeature2",
+                value: @"
                             {
                                 ""id"": ""VariantsFeature2"",
                                 ""description"": """",
@@ -308,34 +310,120 @@ namespace Tests.AzureAppConfiguration
 	                            }
                             }
                             ",
-            label: default,
-            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
-            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
+                label: default,
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
 
-        private ConfigurationSetting _telemetryKv = ConfigurationModelFactory.ConfigurationSetting(
-            key: FeatureManagementConstants.FeatureFlagMarker + "TelemetryFeature",
-            value: @"
-                    {
-                        ""id"": ""TelemetryFeature"",
-                        ""description"": """",
-                        ""display_name"": ""Telemetry Feature"",
-                        ""enabled"": true,
-                        ""conditions"": {
-                        ""client_filters"": [
-                        ]
-                        },
-                        ""telemetry"": {
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "VariantsFeature3",
+                value: @"
+                            {
+                                ""id"": ""VariantsFeature3"",
+                                ""description"": """",
+                                ""display_name"": ""Variants Feature 3"",
+                                ""enabled"": true,
+                                ""conditions"": {
+                                ""client_filters"": [
+                                ]
+                                },
+                                ""variants"": [
+		                        {
+			                        ""name"": ""NumberVariant"",
+			                        ""configuration_value"": 1
+		                        },
+		                        {
+			                        ""name"": ""NumberVariant"",
+			                        ""configuration_value"": 2
+		                        },
+		                        {
+			                        ""name"": ""OtherVariant"",
+			                        ""configuration_value"": ""Other""
+		                        }
+	                            ],
+                                ""allocation"": {
+                                    ""default_when_enabled"": ""OtherVariant"",
+                                    ""default_when_enabled"": ""NumberVariant""
+                                }
+                            }
+                            ",
+                label: default,
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "VariantsFeature4",
+                value: @"
+                            {
+                                ""id"": ""VariantsFeature4"",
+                                ""description"": """",
+                                ""display_name"": ""Variants Feature 4"",
+                                ""enabled"": true,
+                                ""conditions"": {
+                                ""client_filters"": [
+                                ]
+                                },
+                                ""variants"": null,
+	                            ""allocation"": null
+                            }
+                            ",
+                label: default,
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"))
+        };
+
+        List<ConfigurationSetting> _telemetryFeatureFlagCollection = new List<ConfigurationSetting>
+        {
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "TelemetryFeature1",
+                value: @"
+                        {
+                            ""id"": ""TelemetryFeature1"",
+                            ""description"": """",
+                            ""display_name"": ""Telemetry Feature 1"",
                             ""enabled"": true,
-                            ""metadata"": {
-		                        ""Tags.Tag1"": ""Tag1Value"",
-		                        ""Tags.Tag2"": ""Tag2Value""
-	                        }
+                            ""conditions"": {
+                            ""client_filters"": [
+                            ]
+                            },
+                            ""telemetry"": {
+                                ""enabled"": true,
+                                ""metadata"": {
+		                            ""Tags.Tag1"": ""Tag1Value"",
+		                            ""Tags.Tag2"": ""Tag2Value""
+	                            }
+                            }
                         }
-                    }
-                    ",
-            label: "label",
-            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
-            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
+                        ",
+                label: "label",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+                key: FeatureManagementConstants.FeatureFlagMarker + "TelemetryFeature2",
+                value: @"
+                        {
+                            ""id"": ""TelemetryFeature2"",
+                            ""description"": """",
+                            ""display_name"": ""Telemetry Feature 2"",
+                            ""enabled"": true,
+                            ""conditions"": {
+                            ""client_filters"": [
+                            ]
+                            },
+                            ""telemetry"": {
+                                ""enabled"": false,
+                                ""enabled"": true,
+                                ""metadata"": {
+		                            ""Tags.Tag1"": ""Tag1Value"",
+		                            ""Tags.Tag1"": ""Tag2Value""
+	                            }
+                            }
+                        }
+                        ",
+                label: "label",
+                contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+                eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"))
+        };
 
         TimeSpan RefreshInterval = TimeSpan.FromSeconds(1);
 
@@ -360,6 +448,8 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
+            Assert.Equal("Beta", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
             Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
             Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
             Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
@@ -394,6 +484,8 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
+            Assert.Equal("Beta", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
             Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
             Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
             Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
@@ -435,6 +527,8 @@ namespace Tests.AzureAppConfiguration
             Thread.Sleep(RefreshInterval);
             refresher.RefreshAsync().Wait();
 
+            Assert.Equal("Beta", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
             Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
             Assert.Equal("Chrome", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
             Assert.Equal("Edge", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
@@ -465,6 +559,8 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
+            Assert.Equal("Beta", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
             Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
             Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
             Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
@@ -506,6 +602,8 @@ namespace Tests.AzureAppConfiguration
             Thread.Sleep(cacheExpirationInterval);
             refresher.RefreshAsync().Wait();
 
+            Assert.Equal("Beta", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
             Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
             Assert.Equal("Chrome", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
             Assert.Equal("Edge", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
@@ -534,6 +632,8 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
+            Assert.Equal("Beta", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
             Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
             Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
             Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
@@ -573,6 +673,8 @@ namespace Tests.AzureAppConfiguration
 
             refresher.RefreshAsync().Wait();
 
+            Assert.Equal("Beta", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
             Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
             Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
             Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
@@ -601,6 +703,8 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
+            Assert.Equal("Beta", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
             Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
             Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
             Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
@@ -640,6 +744,8 @@ namespace Tests.AzureAppConfiguration
 
             refresher.RefreshAsync().Wait();
 
+            Assert.Equal("Beta", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
             Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
             Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
             Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
@@ -1479,17 +1585,11 @@ namespace Tests.AzureAppConfiguration
         [Fact]
         public void WithVariants()
         {
-            var featureFlags = new List<ConfigurationSetting>()
-            {
-                _variantsKv1,
-                _variantsKv2
-            };
-
             var mockResponse = new Mock<Response>();
             var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
 
             mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
-                .Returns(new MockAsyncPageable(featureFlags));
+                .Returns(new MockAsyncPageable(_variantFeatureFlagCollection));
 
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
@@ -1552,21 +1652,29 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("True", config["feature_management:feature_flags:1:variants:4:configuration_value"]);
             Assert.Equal("ObjectVariant", config["feature_management:feature_flags:1:allocation:default_when_disabled"]);
             Assert.Equal("ObjectVariant", config["feature_management:feature_flags:1:allocation:default_when_enabled"]);
+
+            Assert.Equal("VariantsFeature3", config["feature_management:feature_flags:2:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:2:enabled"]);
+            Assert.Equal("NumberVariant", config["feature_management:feature_flags:2:allocation:default_when_enabled"]);
+            Assert.Equal("1", config["feature_management:feature_flags:2:variants:0:configuration_value"]);
+            Assert.Equal("2", config["feature_management:feature_flags:2:variants:1:configuration_value"]);
+            Assert.Equal("Other", config["feature_management:feature_flags:2:variants:2:configuration_value"]);
+            Assert.Equal("NumberVariant", config["feature_management:feature_flags:2:allocation:default_when_enabled"]);
+
+            Assert.Equal("VariantsFeature4", config["feature_management:feature_flags:3:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:3:enabled"]);
+            Assert.Null(config["feature_management:feature_flags:3:variants"]);
+            Assert.Null(config["feature_management:feature_flags:3:allocation"]);
         }
 
         [Fact]
         public void WithTelemetry()
         {
-            var featureFlags = new List<ConfigurationSetting>()
-            {
-                _telemetryKv
-            };
-
             var mockResponse = new Mock<Response>();
             var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
 
             mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
-                .Returns(new MockAsyncPageable(featureFlags));
+                .Returns(new MockAsyncPageable(_telemetryFeatureFlagCollection));
 
             var config = new ConfigurationBuilder()
                 .AddAzureAppConfiguration(options =>
@@ -1578,7 +1686,7 @@ namespace Tests.AzureAppConfiguration
                 .Build();
 
             Assert.Equal("True", config["feature_management:feature_flags:0:telemetry:enabled"]);
-            Assert.Equal("TelemetryFeature", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("TelemetryFeature1", config["feature_management:feature_flags:0:id"]);
             Assert.Equal("Tag1Value", config["feature_management:feature_flags:0:telemetry:metadata:Tags.Tag1"]);
             Assert.Equal("Tag2Value", config["feature_management:feature_flags:0:telemetry:metadata:Tags.Tag2"]);
             Assert.Equal("c3c231fd-39a0-4cb6-3237-4614474b92c1", config["feature_management:feature_flags:0:telemetry:metadata:ETag"]);
@@ -1587,7 +1695,7 @@ namespace Tests.AzureAppConfiguration
 
             using (HashAlgorithm hashAlgorithm = SHA256.Create())
             {
-                featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature\nlabel"));
+                featureFlagIdHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes($"{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature1\nlabel"));
             }
 
             string featureFlagId = Convert.ToBase64String(featureFlagIdHash)
@@ -1596,7 +1704,11 @@ namespace Tests.AzureAppConfiguration
                 .Replace('/', '_');
 
             Assert.Equal(featureFlagId, config["feature_management:feature_flags:0:telemetry:metadata:FeatureFlagId"]);
-            Assert.Equal($"{TestHelpers.PrimaryConfigStoreEndpoint}kv/{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature?label=label", config["feature_management:feature_flags:0:telemetry:metadata:FeatureFlagReference"]);
+            Assert.Equal($"{TestHelpers.PrimaryConfigStoreEndpoint}kv/{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature1?label=label", config["feature_management:feature_flags:0:telemetry:metadata:FeatureFlagReference"]);
+
+            Assert.Equal("True", config["feature_management:feature_flags:1:telemetry:enabled"]);
+            Assert.Equal("TelemetryFeature2", config["feature_management:feature_flags:1:id"]);
+            Assert.Equal("Tag2Value", config["feature_management:feature_flags:1:telemetry:metadata:Tags.Tag1"]);
         }
 
 

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -1741,7 +1741,7 @@ namespace Tests.AzureAppConfiguration
                 CreateFeatureFlag("Feature9", groupJsonString: @"[{""variant"": false}]"),
                 CreateFeatureFlag("Feature10", groupJsonString: @"[{""groups"": 10}]"),
                 CreateFeatureFlag("Feature11", percentileJsonString: @"[{""variant"": []}]"),
-                CreateFeatureFlag("Feature12", percentileJsonString: @"[{""from"": ""12""}]"),
+                CreateFeatureFlag("Feature12", percentileJsonString: @"[{""from"": true}]"),
                 CreateFeatureFlag("Feature13", percentileJsonString: @"[{""to"": {}}]"),
                 CreateFeatureFlag("Feature14", telemetryEnabled: "14"),
                 CreateFeatureFlag("Feature15", telemetryMetadataJsonString: @"{""key"": 15}"),

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -15,7 +15,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
-using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -88,7 +88,239 @@ namespace Tests.AzureAppConfiguration
             contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
             eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"));
 
-        List<ConfigurationSetting> _featureFlagCollection = new List<ConfigurationSetting>
+        List<ConfigurationSetting> _nullOrMissingConditionsFeatureFlagCollection = new List<ConfigurationSetting>
+        {
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "NullParameters",
+            value: @"
+                            {
+                              ""id"": ""NullParameters"",
+                              ""description"": """",
+                              ""display_name"": ""Null Parameters"",
+                              ""enabled"": true,
+                              ""conditions"": {
+                                ""client_filters"": [
+                                  {
+                                    ""name"": ""Filter"",
+                                    ""parameters"": null
+                                  }
+                                ]
+                              }
+                            }
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "NullConditions",
+            value: @"
+                            {
+                              ""id"": ""NullConditions"",
+                              ""description"": """",
+                              ""display_name"": ""Null Conditions"",
+                              ""enabled"": true,
+                              ""conditions"": null
+                            }
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "NullClientFilters",
+            value: @"
+                            {
+                              ""id"": ""NullClientFilters"",
+                              ""description"": """",
+                              ""display_name"": ""Null Client Filters"",
+                              ""enabled"": true,
+                              ""conditions"": {
+                                ""client_filters"": null
+                              }
+                            }
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "NoConditions",
+            value: @"
+                            {
+                              ""id"": ""NoConditions"",
+                              ""description"": """",
+                              ""display_name"": ""No Conditions"",
+                              ""enabled"": true
+                            }
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "EmptyConditions",
+            value: @"
+                            {
+                              ""id"": ""EmptyConditions"",
+                              ""description"": """",
+                              ""display_name"": ""Empty Conditions"",
+                              ""conditions"": {},
+                              ""enabled"": true
+                            }
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "EmptyClientFilter",
+            value: @"
+                            {
+                              ""id"": ""EmptyClientFilter"",
+                              ""description"": """",
+                              ""display_name"": ""Empty Client Filter"",
+                              ""conditions"": {
+                                ""client_filters"": [
+                                    {}
+                                ]
+                              },
+                              ""enabled"": true
+                            }
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"))
+        };
+
+    List<ConfigurationSetting> _validFormatFeatureFlagCollection = new List<ConfigurationSetting>
+        {
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "AdditionalProperty",
+            value: @"
+                            {
+                              ""id"": ""AdditionalProperty"",
+                              ""description"": ""Should not throw an exception, additional properties are skipped."",
+                              ""ignored_object"": {
+                                ""id"": false
+                              },
+                              ""enabled"": true,
+                              ""conditions"": {}
+                            }
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "DuplicateProperty",
+            value: @"
+                            {
+                              ""id"": ""DuplicateProperty"",
+                              ""description"": ""Should not throw an exception, last of duplicate properties will win."",
+                              ""enabled"": false,
+                              ""enabled"": true,
+                              ""conditions"": {}
+                            }
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "AllowNullRequirementType",
+            value: @"
+                            {
+                              ""id"": ""AllowNullRequirementType"",
+                              ""description"": ""Should not throw an exception, requirement type is allowed as null."",
+                              ""enabled"": true,
+                              ""conditions"": {
+                                ""requirement_type"": null
+                              }
+                            }
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"))
+        };
+
+        List<ConfigurationSetting> _invalidFormatFeatureFlagCollection = new List<ConfigurationSetting>
+        {
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "MissingClosingBracket1",
+            value: @"
+                            {
+                              ""id"": ""MissingClosingBracket1"",
+                              ""description"": ""Should throw an exception, invalid end of json."",
+                              ""enabled"": true,
+                              ""conditions"": {}
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "MissingClosingBracket2",
+            value: @"
+                            {
+                              ""id"": ""MissingClosingBracket2"",
+                              ""description"": ""Should throw an exception, invalid end of conditions object."",
+                              ""conditions"": {,
+                              ""enabled"": true
+                            }
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "MissingClosingBracket3",
+            value: @"
+                            {
+                              ""id"": ""MissingClosingBracket3"",
+                              ""description"": ""Should throw an exception, no closing bracket on client filters array."",
+                              ""conditions"": {
+                                ""client_filters"": [
+                              },
+                              ""enabled"": true
+                            }
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "MissingOpeningBracket1",
+            value: @"
+                            {
+                              ""id"": ""MissingOpeningBracket1"",
+                              ""description"": ""Should throw an exception, no opening bracket on conditions object."",
+                              ""conditions"": },
+                              ""enabled"": true
+                            }
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1")),
+
+            ConfigurationModelFactory.ConfigurationSetting(
+            key: FeatureManagementConstants.FeatureFlagMarker + "MissingOpeningBracket2",
+            value: @"
+                            {
+                              ""id"": ""MissingOpeningBracket2"",
+                              ""description"": ""Should throw an exception, no opening bracket on client filters array."",
+                              ""conditions"": {
+                                ""client_filters"": ]
+                              },
+                              ""enabled"": true
+                            }
+                            ",
+            label: default,
+            contentType: FeatureManagementConstants.ContentType + ";charset=utf-8",
+            eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"))
+        };
+
+    List<ConfigurationSetting> _featureFlagCollection = new List<ConfigurationSetting>
         {
             ConfigurationModelFactory.ConfigurationSetting(
                 key: FeatureManagementConstants.FeatureFlagMarker + "App1_Feature1",
@@ -832,6 +1064,111 @@ namespace Tests.AzureAppConfiguration
             // Verify that the feature flag that did not match the specified label was not loaded
             Assert.Null(config["feature_management:feature_flags:3"]);
             Assert.Null(config["feature_management:feature_flags:4"]);
+        }
+
+        [Fact]
+        public void TestNullAndMissingValuesForConditions()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
+            var cacheExpiration = TimeSpan.FromSeconds(1);
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(new MockAsyncPageable(_nullOrMissingConditionsFeatureFlagCollection));
+
+            var testClient = mockClient.Object;
+
+            // Makes sure that adapter properly processes values and doesn't throw an exception
+            var config = new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(testClient);
+                    options.UseFeatureFlags(ff =>
+                    {
+                        ff.CacheExpirationInterval = cacheExpiration;
+                        ff.Select(KeyFilter.Any);
+                    });
+                })
+                .Build();
+
+            Assert.Equal("Filter", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Null(config["feature_management:feature_flags:0:conditions:client_filters:0:parameters"]);
+            Assert.Null(config["feature_management:feature_flags:1:conditions"]);
+            Assert.Null(config["feature_management:feature_flags:2:conditions"]);
+            Assert.Null(config["feature_management:feature_flags:3:conditions"]);
+            Assert.Null(config["feature_management:feature_flags:4:conditions"]);
+            Assert.Null(config["feature_management:feature_flags:5:conditions"]);
+        }
+
+        [Fact]
+        public void InvalidFeatureFlagFormatsThrowFormatException()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
+            var cacheExpiration = TimeSpan.FromSeconds(1);
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns((Func<SettingSelector, CancellationToken, MockAsyncPageable>)GetTestKeys);
+
+            MockAsyncPageable GetTestKeys(SettingSelector selector, CancellationToken ct)
+            {
+                var copy = new List<ConfigurationSetting>();
+                var newSetting = _invalidFormatFeatureFlagCollection.FirstOrDefault(s => s.Key == selector.KeyFilter);
+                if (newSetting != null)
+                    copy.Add(TestHelpers.CloneSetting(newSetting));
+                return new MockAsyncPageable(copy);
+            };
+
+            var testClient = mockClient.Object;
+
+            foreach (ConfigurationSetting setting in _invalidFormatFeatureFlagCollection)
+            {
+                void action() => new ConfigurationBuilder()
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.Select("_");
+                    options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(testClient);
+                    options.UseFeatureFlags(ff =>
+                    {
+                        ff.CacheExpirationInterval = cacheExpiration;
+                        ff.Select(setting.Key.Substring(FeatureManagementConstants.FeatureFlagMarker.Length));
+                    });
+                })
+                .Build();
+
+                // Each of the feature flags should throw an exception
+                Assert.Throws<FormatException>(action);
+            }
+        }
+
+        [Fact]
+        public void AlternateValidFeatureFlagFormats()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
+            var cacheExpiration = TimeSpan.FromSeconds(1);
+
+            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
+                .Returns(new MockAsyncPageable(_validFormatFeatureFlagCollection));
+
+            var testClient = mockClient.Object;
+
+            var config = new ConfigurationBuilder()
+            .AddAzureAppConfiguration(options =>
+            {
+                options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(testClient);
+                options.UseFeatureFlags(ff =>
+                {
+                    ff.CacheExpirationInterval = cacheExpiration;
+                    ff.Select(KeyFilter.Any);
+                });
+            })
+            .Build();
+
+            // None of the feature flags should throw an exception, and the flag should be loaded like normal
+            Assert.Equal("True", config[$"feature_management:feature_flags:0:enabled"]);
+            Assert.Equal("True", config[$"feature_management:feature_flags:1:enabled"]);
+            Assert.Equal("True", config[$"feature_management:feature_flags:2:enabled"]);
         }
 
         [Fact]

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -394,16 +394,16 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
-            Assert.Equal("Firefox", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
-            Assert.Equal("Safari", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
-            Assert.Equal("RollOut", config["FeatureManagement:Beta:EnabledFor:1:Name"]);
-            Assert.Equal("20", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Percentage"]);
-            Assert.Equal("US", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Region"]);
-            Assert.Equal("SuperUsers", config["FeatureManagement:Beta:EnabledFor:2:Name"]);
-            Assert.Equal("TimeWindow", config["FeatureManagement:Beta:EnabledFor:3:Name"]);
-            Assert.Equal("/Date(1578643200000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:Start"]);
-            Assert.Equal("/Date(1578686400000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:End"]);
+            Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
+            Assert.Equal("RollOut", config["feature_management:feature_flags:0:conditions:client_filters:1:name"]);
+            Assert.Equal("20", config["feature_management:feature_flags:0:conditions:client_filters:1:parameters:Percentage"]);
+            Assert.Equal("US", config["feature_management:feature_flags:0:conditions:client_filters:1:parameters:Region"]);
+            Assert.Equal("SuperUsers", config["feature_management:feature_flags:0:conditions:client_filters:2:name"]);
+            Assert.Equal("TimeWindow", config["feature_management:feature_flags:0:conditions:client_filters:3:name"]);
+            Assert.Equal("/Date(1578643200000)/", config["feature_management:feature_flags:0:conditions:client_filters:3:parameters:Start"]);
+            Assert.Equal("/Date(1578686400000)/", config["feature_management:feature_flags:0:conditions:client_filters:3:parameters:End"]);
 
             featureFlags[0] = ConfigurationModelFactory.ConfigurationSetting(
                 key: FeatureManagementConstants.FeatureFlagMarker + "myFeature",
@@ -435,10 +435,10 @@ namespace Tests.AzureAppConfiguration
             Thread.Sleep(RefreshInterval);
             refresher.RefreshAsync().Wait();
 
-            Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
-            Assert.Equal("Chrome", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
-            Assert.Equal("Edge", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
-            Assert.Equal("SuperUsers", config["FeatureManagement:MyFeature2:EnabledFor:0:Name"]);
+            Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("Chrome", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Edge", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
+            Assert.Equal("SuperUsers", config["feature_management:feature_flags:1:conditions:client_filters:0:name"]);
         }
 
         [Fact]
@@ -534,16 +534,16 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
-            Assert.Equal("Firefox", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
-            Assert.Equal("Safari", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
-            Assert.Equal("RollOut", config["FeatureManagement:Beta:EnabledFor:1:Name"]);
-            Assert.Equal("20", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Percentage"]);
-            Assert.Equal("US", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Region"]);
-            Assert.Equal("SuperUsers", config["FeatureManagement:Beta:EnabledFor:2:Name"]);
-            Assert.Equal("TimeWindow", config["FeatureManagement:Beta:EnabledFor:3:Name"]);
-            Assert.Equal("/Date(1578643200000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:Start"]);
-            Assert.Equal("/Date(1578686400000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:End"]);
+            Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
+            Assert.Equal("RollOut", config["feature_management:feature_flags:0:conditions:client_filters:1:name"]);
+            Assert.Equal("20", config["feature_management:feature_flags:0:conditions:client_filters:1:parameters:Percentage"]);
+            Assert.Equal("US", config["feature_management:feature_flags:0:conditions:client_filters:1:parameters:Region"]);
+            Assert.Equal("SuperUsers", config["feature_management:feature_flags:0:conditions:client_filters:2:name"]);
+            Assert.Equal("TimeWindow", config["feature_management:feature_flags:0:conditions:client_filters:3:name"]);
+            Assert.Equal("/Date(1578643200000)/", config["feature_management:feature_flags:0:conditions:client_filters:3:parameters:Start"]);
+            Assert.Equal("/Date(1578686400000)/", config["feature_management:feature_flags:0:conditions:client_filters:3:parameters:End"]);
 
             featureFlags[0] = ConfigurationModelFactory.ConfigurationSetting(
                 key: FeatureManagementConstants.FeatureFlagMarker + "myFeature",
@@ -573,10 +573,10 @@ namespace Tests.AzureAppConfiguration
 
             refresher.RefreshAsync().Wait();
 
-            Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
-            Assert.Equal("Firefox", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
-            Assert.Equal("Safari", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
-            Assert.Null(config["FeatureManagement:MyFeature2:EnabledFor:0:Name"]);
+            Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
+            Assert.Null(config["feature_management:feature_flags:1:conditions:client_filters:0:name"]);
         }
 
         [Fact]
@@ -1155,11 +1155,16 @@ namespace Tests.AzureAppConfiguration
 
             // The refresh interval time for feature flags was overwritten by second call to UseFeatureFlags.
             // Sleeping for refreshInterval1 time should not update feature flags.
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App1_Feature1:EnabledFor:0:Name"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App1_Feature2:Status"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App2_Feature1:Status"]);
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App2_Feature2:EnabledFor:0:Name"]);
-            Assert.Equal("AlwaysOn", config["FeatureManagement:Feature1:EnabledFor:0:Name"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
+            Assert.Equal("App1_Feature1", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:1:enabled"]);
+            Assert.Equal("App1_Feature2", config["feature_management:feature_flags:1:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:2:enabled"]);
+            Assert.Equal("Feature1", config["feature_management:feature_flags:2:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:3:enabled"]);
+            Assert.Equal("App2_Feature1", config["feature_management:feature_flags:3:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:4:enabled"]);
+            Assert.Equal("App2_Feature2", config["feature_management:feature_flags:4:id"]);
         }
 
         [Fact]

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -858,7 +858,7 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("AlwaysOn", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
             Assert.Equal("False", config["feature_management:feature_flags:1:enabled"]);
 
             // Verify that the feature flag that did not start with the specified prefix was not loaded
@@ -901,13 +901,13 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("AlwaysOn", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
             Assert.Equal("App1_Feature1", config["feature_management:feature_flags:0:id"]);
             Assert.Equal("False", config["feature_management:feature_flags:1:enabled"]);
             Assert.Equal("App1_Feature2", config["feature_management:feature_flags:1:id"]);
             Assert.Equal("False", config["feature_management:feature_flags:2:enabled"]);
             Assert.Equal("App2_Feature1", config["feature_management:feature_flags:2:id"]);
-            Assert.Equal("AlwaysOn", config["feature_management:feature_flags:3:conditions:client_filters:0:name"]);
+            Assert.Equal("True", config["feature_management:feature_flags:3:enabled"]);
             Assert.Equal("App2_Feature2", config["feature_management:feature_flags:3:id"]);
 
             // Verify that the feature flag that did not start with the specified prefix was not loaded

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -309,7 +309,7 @@ namespace Tests.AzureAppConfiguration
                 value: @"
                             {
                                 ""id"": ""VariantsFeature3"",
-                                ""enabled"": true,
+                                ""enabled"": ""true"",
                                 ""variants"": [
 		                        {
 			                        ""name"": ""NumberVariant"",
@@ -358,7 +358,7 @@ namespace Tests.AzureAppConfiguration
                             ""id"": ""TelemetryFeature1"",
                             ""enabled"": true,
                             ""telemetry"": {
-                                ""enabled"": true,
+                                ""enabled"": ""true"",
                                 ""metadata"": {
 		                            ""Tags.Tag1"": ""Tag1Value"",
 		                            ""Tags.Tag2"": ""Tag2Value""

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -361,16 +361,16 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
-            Assert.Equal("Firefox", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
-            Assert.Equal("Safari", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
-            Assert.Equal("RollOut", config["FeatureManagement:Beta:EnabledFor:1:Name"]);
-            Assert.Equal("20", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Percentage"]);
-            Assert.Equal("US", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Region"]);
-            Assert.Equal("SuperUsers", config["FeatureManagement:Beta:EnabledFor:2:Name"]);
-            Assert.Equal("TimeWindow", config["FeatureManagement:Beta:EnabledFor:3:Name"]);
-            Assert.Equal("/Date(1578643200000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:Start"]);
-            Assert.Equal("/Date(1578686400000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:End"]);
+            Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
+            Assert.Equal("RollOut", config["feature_management:feature_flags:0:conditions:client_filters:1:name"]);
+            Assert.Equal("20", config["feature_management:feature_flags:0:conditions:client_filters:1:parameters:Percentage"]);
+            Assert.Equal("US", config["feature_management:feature_flags:0:conditions:client_filters:1:parameters:Region"]);
+            Assert.Equal("SuperUsers", config["feature_management:feature_flags:0:conditions:client_filters:2:name"]);
+            Assert.Equal("TimeWindow", config["feature_management:feature_flags:0:conditions:client_filters:3:name"]);
+            Assert.Equal("/Date(1578643200000)/", config["feature_management:feature_flags:0:conditions:client_filters:3:parameters:Start"]);
+            Assert.Equal("/Date(1578686400000)/", config["feature_management:feature_flags:0:conditions:client_filters:3:parameters:End"]);
         }
 
         [Fact]
@@ -396,16 +396,16 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
-            Assert.Equal("Firefox", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
-            Assert.Equal("Safari", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
-            Assert.Equal("RollOut", config["FeatureManagement:Beta:EnabledFor:1:Name"]);
-            Assert.Equal("20", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Percentage"]);
-            Assert.Equal("US", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Region"]);
-            Assert.Equal("SuperUsers", config["FeatureManagement:Beta:EnabledFor:2:Name"]);
-            Assert.Equal("TimeWindow", config["FeatureManagement:Beta:EnabledFor:3:Name"]);
-            Assert.Equal("/Date(1578643200000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:Start"]);
-            Assert.Equal("/Date(1578686400000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:End"]);
+            Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
+            Assert.Equal("RollOut", config["feature_management:feature_flags:0:conditions:client_filters:1:name"]);
+            Assert.Equal("20", config["feature_management:feature_flags:0:conditions:client_filters:1:parameters:Percentage"]);
+            Assert.Equal("US", config["feature_management:feature_flags:0:conditions:client_filters:1:parameters:Region"]);
+            Assert.Equal("SuperUsers", config["feature_management:feature_flags:0:conditions:client_filters:2:name"]);
+            Assert.Equal("TimeWindow", config["feature_management:feature_flags:0:conditions:client_filters:3:name"]);
+            Assert.Equal("/Date(1578643200000)/", config["feature_management:feature_flags:0:conditions:client_filters:3:parameters:Start"]);
+            Assert.Equal("/Date(1578686400000)/", config["feature_management:feature_flags:0:conditions:client_filters:3:parameters:End"]);
 
             featureFlags[0] = ConfigurationModelFactory.ConfigurationSetting(
                 key: FeatureManagementConstants.FeatureFlagMarker + "myFeature",
@@ -437,10 +437,10 @@ namespace Tests.AzureAppConfiguration
             Thread.Sleep(cacheExpirationTimeSpan);
             refresher.RefreshAsync().Wait();
 
-            Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
-            Assert.Equal("Chrome", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
-            Assert.Equal("Edge", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
-            Assert.Equal("SuperUsers", config["FeatureManagement:MyFeature2:EnabledFor:0:Name"]);
+            Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("Chrome", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Edge", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
+            Assert.Equal("SuperUsers", config["feature_management:feature_flags:1:conditions:client_filters:0:name"]);
         }
 
 
@@ -466,16 +466,16 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
-            Assert.Equal("Firefox", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
-            Assert.Equal("Safari", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
-            Assert.Equal("RollOut", config["FeatureManagement:Beta:EnabledFor:1:Name"]);
-            Assert.Equal("20", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Percentage"]);
-            Assert.Equal("US", config["FeatureManagement:Beta:EnabledFor:1:Parameters:Region"]);
-            Assert.Equal("SuperUsers", config["FeatureManagement:Beta:EnabledFor:2:Name"]);
-            Assert.Equal("TimeWindow", config["FeatureManagement:Beta:EnabledFor:3:Name"]);
-            Assert.Equal("/Date(1578643200000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:Start"]);
-            Assert.Equal("/Date(1578686400000)/", config["FeatureManagement:Beta:EnabledFor:3:Parameters:End"]);
+            Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
+            Assert.Equal("RollOut", config["feature_management:feature_flags:0:conditions:client_filters:1:name"]);
+            Assert.Equal("20", config["feature_management:feature_flags:0:conditions:client_filters:1:parameters:Percentage"]);
+            Assert.Equal("US", config["feature_management:feature_flags:0:conditions:client_filters:1:parameters:Region"]);
+            Assert.Equal("SuperUsers", config["feature_management:feature_flags:0:conditions:client_filters:2:name"]);
+            Assert.Equal("TimeWindow", config["feature_management:feature_flags:0:conditions:client_filters:3:name"]);
+            Assert.Equal("/Date(1578643200000)/", config["feature_management:feature_flags:0:conditions:client_filters:3:parameters:Start"]);
+            Assert.Equal("/Date(1578686400000)/", config["feature_management:feature_flags:0:conditions:client_filters:3:parameters:End"]);
 
             featureFlags[0] = ConfigurationModelFactory.ConfigurationSetting(
                 key: FeatureManagementConstants.FeatureFlagMarker + "myFeature",
@@ -505,10 +505,10 @@ namespace Tests.AzureAppConfiguration
 
             refresher.RefreshAsync().Wait();
 
-            Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
-            Assert.Equal("Firefox", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
-            Assert.Equal("Safari", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
-            Assert.Null(config["FeatureManagement:MyFeature2:EnabledFor:0:Name"]);
+            Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
+            Assert.Null(config["feature_management:feature_flags:1:conditions:client_filters:0:name"]);
         }
 
         [Fact]
@@ -619,15 +619,15 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App1_Feature1:EnabledFor:0:Name"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App1_Feature2:Status"]);
+            Assert.Equal("AlwaysOn", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("False", config["feature_management:feature_flags:1:enabled"]);
 
             // Verify that the feature flag that did not start with the specified prefix was not loaded
-            Assert.Null(config["FeatureManagement:Feature1"]);
+            Assert.Null(config["feature_management:feature_flags:2"]);
 
             // Verify that the feature flag that did not match the specified label was not loaded
-            Assert.Null(config["FeatureManagement:App2_Feature1"]);
-            Assert.Null(config["FeatureManagement:App2_Feature2"]);
+            Assert.Null(config["feature_management:feature_flags:3"]);
+            Assert.Null(config["feature_management:feature_flags:4"]);
         }
 
         [Fact]
@@ -662,13 +662,17 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App1_Feature1:EnabledFor:0:Name"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App1_Feature2:Status"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App2_Feature1:Status"]);
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App2_Feature2:EnabledFor:0:Name"]);
+            Assert.Equal("AlwaysOn", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("App1_Feature1", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:1:enabled"]);
+            Assert.Equal("App1_Feature2", config["feature_management:feature_flags:1:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:2:enabled"]);
+            Assert.Equal("App2_Feature1", config["feature_management:feature_flags:2:id"]);
+            Assert.Equal("AlwaysOn", config["feature_management:feature_flags:3:conditions:client_filters:0:name"]);
+            Assert.Equal("App2_Feature2", config["feature_management:feature_flags:3:id"]);
 
             // Verify that the feature flag that did not start with the specified prefix was not loaded
-            Assert.Null(config["FeatureManagement:Feature1"]);
+            Assert.Null(config["feature_management:feature_flags:4"]);
         }
 
         [Fact]
@@ -703,7 +707,8 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
             // label: App1_Label has higher precedence
-            Assert.Equal("AlwaysOn", config["FeatureManagement:Feature1:EnabledFor:0:Name"]);
+            Assert.Equal("Feature1", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
         }
 
         [Fact]
@@ -775,13 +780,17 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App1_Feature1:EnabledFor:0:Name"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App1_Feature2:Status"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App2_Feature1:Status"]);
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App2_Feature2:EnabledFor:0:Name"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
+            Assert.Equal("App1_Feature1", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:1:enabled"]);
+            Assert.Equal("App1_Feature2", config["feature_management:feature_flags:1:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:2:enabled"]);
+            Assert.Equal("App2_Feature1", config["feature_management:feature_flags:2:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:3:enabled"]);
+            Assert.Equal("App2_Feature2", config["feature_management:feature_flags:3:id"]);
 
-            // Verify that the feature flag that did not start with the specified prefix was not loaded
-            Assert.Null(config["FeatureManagement:Feature1"]);
+            // Verify that the feature flag Feature1 did not start with the specified prefix was not loaded
+            Assert.Null(config["feature_management:feature_flags:4"]);
         }
 
         [Fact]
@@ -819,13 +828,18 @@ namespace Tests.AzureAppConfiguration
                 .Build();
 
             // Loaded from prefix1 and label1
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App1_Feature1:EnabledFor:0:Name"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App1_Feature2:Status"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
+            Assert.Equal("App1_Feature1", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:1:enabled"]);
+            Assert.Equal("App1_Feature2", config["feature_management:feature_flags:1:id"]);
 
             // Loaded from label2
-            Assert.Equal("Disabled", config["FeatureManagement:App2_Feature1:Status"]);
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App2_Feature2:EnabledFor:0:Name"]);
-            Assert.Equal("AlwaysOn", config["FeatureManagement:Feature1:EnabledFor:0:Name"]);
+            Assert.Equal("False", config["feature_management:feature_flags:2:enabled"]);
+            Assert.Equal("App2_Feature1", config["feature_management:feature_flags:2:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:3:enabled"]);
+            Assert.Equal("App2_Feature2", config["feature_management:feature_flags:3:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:4:enabled"]);
+            Assert.Equal("Feature1", config["feature_management:feature_flags:4:id"]);
         }
 
         [Fact]
@@ -869,10 +883,14 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App1_Feature1:EnabledFor:0:Name"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App1_Feature2:Status"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App2_Feature1:Status"]);
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App2_Feature2:EnabledFor:0:Name"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
+            Assert.Equal("App1_Feature1", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:1:enabled"]);
+            Assert.Equal("App1_Feature2", config["feature_management:feature_flags:1:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:2:enabled"]);
+            Assert.Equal("App2_Feature1", config["feature_management:feature_flags:2:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:3:enabled"]);
+            Assert.Equal("App2_Feature2", config["feature_management:feature_flags:3:id"]);
 
             // update the value of App1_Feature1 feature flag with label1
             featureFlagCollection[0] = ConfigurationModelFactory.ConfigurationSetting(
@@ -917,15 +935,18 @@ namespace Tests.AzureAppConfiguration
             Thread.Sleep(cacheExpiration1);
             refresher.RefreshAsync().Wait();
 
-            Assert.Equal("Browser", config["FeatureManagement:App1_Feature1:EnabledFor:0:Name"]);
-            Assert.Equal("Chrome", config["FeatureManagement:App1_Feature1:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
-            Assert.Equal("Edge", config["FeatureManagement:App1_Feature1:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App1_Feature2:Status"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App2_Feature1:Status"]);
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App2_Feature2:EnabledFor:0:Name"]);
+            Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("Chrome", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Edge", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
+            Assert.Equal("False", config["feature_management:feature_flags:1:enabled"]);
+            Assert.Equal("App1_Feature2", config["feature_management:feature_flags:1:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:2:enabled"]);
+            Assert.Equal("App2_Feature1", config["feature_management:feature_flags:2:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:3:enabled"]);
+            Assert.Equal("App2_Feature2", config["feature_management:feature_flags:3:id"]);
 
             // even though App2_Feature3 feature flag has been added, its value should not be loaded in config because label2 cache has not expired
-            Assert.Null(config["FeatureManagement:App2_Feature3"]);
+            Assert.Null(config["feature_management:feature_flags:4"]);
         }
 
         [Fact]
@@ -962,11 +983,16 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App1_Feature1:EnabledFor:0:Name"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App1_Feature2:Status"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App2_Feature1:Status"]);
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App2_Feature2:EnabledFor:0:Name"]);
-            Assert.Equal("AlwaysOn", config["FeatureManagement:Feature1:EnabledFor:0:Name"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
+            Assert.Equal("App1_Feature1", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:1:enabled"]);
+            Assert.Equal("App1_Feature2", config["feature_management:feature_flags:1:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:2:enabled"]);
+            Assert.Equal("Feature1", config["feature_management:feature_flags:2:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:3:enabled"]);
+            Assert.Equal("App2_Feature1", config["feature_management:feature_flags:3:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:4:enabled"]);
+            Assert.Equal("App2_Feature2", config["feature_management:feature_flags:4:id"]);
 
             // update the value of App1_Feature1 feature flag with label1
             featureFlagCollection[0] = ConfigurationModelFactory.ConfigurationSetting(
@@ -996,11 +1022,16 @@ namespace Tests.AzureAppConfiguration
 
             // The cache expiration time for feature flags was overwritten by second call to UseFeatureFlags.
             // Sleeping for cacheExpiration1 time should not update feature flags.
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App1_Feature1:EnabledFor:0:Name"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App1_Feature2:Status"]);
-            Assert.Equal("Disabled", config["FeatureManagement:App2_Feature1:Status"]);
-            Assert.Equal("AlwaysOn", config["FeatureManagement:App2_Feature2:EnabledFor:0:Name"]);
-            Assert.Equal("AlwaysOn", config["FeatureManagement:Feature1:EnabledFor:0:Name"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
+            Assert.Equal("App1_Feature1", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:1:enabled"]);
+            Assert.Equal("App1_Feature2", config["feature_management:feature_flags:1:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:2:enabled"]);
+            Assert.Equal("Feature1", config["feature_management:feature_flags:2:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:3:enabled"]);
+            Assert.Equal("App2_Feature1", config["feature_management:feature_flags:3:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:4:enabled"]);
+            Assert.Equal("App2_Feature2", config["feature_management:feature_flags:4:id"]);
         }
 
         [Fact]
@@ -1035,7 +1066,8 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("Disabled", config["FeatureManagement:Feature1:Status"]);
+            Assert.Equal("False", config["feature_management:feature_flags:0:enabled"]);
+            Assert.Equal("Feature1", config["feature_management:feature_flags:0:id"]);
 
             // update the value of Feature1 feature flag with App1_Label
             featureFlagCollection[2] = ConfigurationModelFactory.ConfigurationSetting(
@@ -1064,9 +1096,9 @@ namespace Tests.AzureAppConfiguration
             Thread.Sleep(cacheExpiration);
             refresher.RefreshAsync().Wait();
 
-            Assert.Equal("Browser", config["FeatureManagement:Feature1:EnabledFor:0:Name"]);
-            Assert.Equal("Chrome", config["FeatureManagement:Feature1:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
-            Assert.Equal("Edge", config["FeatureManagement:Feature1:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
+            Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("Chrome", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Edge", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
         }
 
         [Fact]
@@ -1106,7 +1138,8 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("SuperUsers", config["FeatureManagement:MyFeature2:EnabledFor:0:Name"]);
+            Assert.Equal("SuperUsers", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("MyFeature2", config["feature_management:feature_flags:0:id"]);
 
             featureFlags[0] = ConfigurationModelFactory.ConfigurationSetting(
             key: FeatureManagementConstants.FeatureFlagMarker + "myFeature1",
@@ -1131,7 +1164,8 @@ namespace Tests.AzureAppConfiguration
 
             Thread.Sleep(CacheExpirationTime);
             refresher.TryRefreshAsync().Wait();
-            Assert.Equal("AllUsers", config["FeatureManagement:MyFeature:EnabledFor:0:Name"]);
+            Assert.Equal("AllUsers", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("MyFeature", config["feature_management:feature_flags:0:id"]);
             Assert.Contains(LogHelper.BuildFeatureFlagReadMessage("myFeature1", null, TestHelpers.PrimaryConfigStoreEndpoint.ToString().TrimEnd('/')), verboseInvocation);
             Assert.Contains(LogHelper.BuildFeatureFlagUpdatedMessage("myFeature1"), informationalInvocation);
 
@@ -1139,7 +1173,7 @@ namespace Tests.AzureAppConfiguration
             Thread.Sleep(CacheExpirationTime);
             refresher.TryRefreshAsync().Wait();
 
-            Assert.Null(config["FeatureManagement:MyFeature:EnabledFor:0:Name"]);
+            Assert.Null(config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
             Assert.Contains(LogHelper.BuildFeatureFlagReadMessage("myFeature1", null, TestHelpers.PrimaryConfigStoreEndpoint.ToString().TrimEnd('/')), verboseInvocation);
             Assert.Contains(LogHelper.BuildFeatureFlagUpdatedMessage("myFeature1"), informationalInvocation);
         }
@@ -1187,12 +1221,12 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("SuperUsers", config["FeatureManagement:MyFeature2:EnabledFor:0:Name"]);
+            Assert.Equal("SuperUsers", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
             FirstKeyValue.Value = "newValue1";
 
             Thread.Sleep(CacheExpirationTime);
             refresher.TryRefreshAsync().Wait();
-            Assert.Equal("SuperUsers", config["FeatureManagement:MyFeature2:EnabledFor:0:Name"]);
+            Assert.Equal("SuperUsers", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
             Assert.Contains(LogHelper.BuildFeatureFlagsUnchangedMessage(TestHelpers.PrimaryConfigStoreEndpoint.ToString().TrimEnd('/')), verboseInvocation);
         }
 
@@ -1278,7 +1312,8 @@ namespace Tests.AzureAppConfiguration
                 .Build();
 
             Assert.Equal("TestValue1", config["TestKey1"]);
-            Assert.Equal("NoUsers", config["FeatureManagement:MyFeature:EnabledFor:0:Name"]);
+            Assert.Equal("NoUsers", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("MyFeature", config["feature_management:feature_flags:0:id"]);
 
             FirstKeyValue.Value = "newValue1";
             featureFlags[0] = ConfigurationModelFactory.ConfigurationSetting(
@@ -1306,7 +1341,7 @@ namespace Tests.AzureAppConfiguration
             refresher.TryRefreshAsync().Wait();
 
             Assert.Equal("newValue1", config["TestKey1"]);
-            Assert.Equal("NoUsers", config["FeatureManagement:MyFeature:EnabledFor:0:Name"]);
+            Assert.Equal("NoUsers", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
         }
 
         [Fact]
@@ -1332,78 +1367,59 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("AlwaysOn", config["FeatureManagement:VariantsFeature1:EnabledFor:0:Name"]);
-            Assert.Equal("Big", config["FeatureManagement:VariantsFeature1:Variants:0:Name"]);
-            Assert.Equal("600px", config["FeatureManagement:VariantsFeature1:Variants:0:ConfigurationValue"]);
-            Assert.Equal("Small", config["FeatureManagement:VariantsFeature1:Variants:1:Name"]);
-            Assert.Equal("ShoppingCart:Small", config["FeatureManagement:VariantsFeature1:Variants:1:ConfigurationReference"]);
-            Assert.Equal("Disabled", config["FeatureManagement:VariantsFeature1:Variants:1:StatusOverride"]);
-            Assert.Equal("Small", config["FeatureManagement:VariantsFeature1:Allocation:DefaultWhenDisabled"]);
-            Assert.Equal("Small", config["FeatureManagement:VariantsFeature1:Allocation:DefaultWhenEnabled"]);
-            Assert.Equal("Big", config["FeatureManagement:VariantsFeature1:Allocation:User:0:Variant"]);
-            Assert.Equal("Marsha", config["FeatureManagement:VariantsFeature1:Allocation:User:0:Users:0"]);
-            Assert.Equal("John", config["FeatureManagement:VariantsFeature1:Allocation:User:0:Users:1"]);
-            Assert.Equal("Small", config["FeatureManagement:VariantsFeature1:Allocation:User:1:Variant"]);
-            Assert.Equal("Alice", config["FeatureManagement:VariantsFeature1:Allocation:User:1:Users:0"]);
-            Assert.Equal("Bob", config["FeatureManagement:VariantsFeature1:Allocation:User:1:Users:1"]);
-            Assert.Equal("Big", config["FeatureManagement:VariantsFeature1:Allocation:Group:0:Variant"]);
-            Assert.Equal("Ring1", config["FeatureManagement:VariantsFeature1:Allocation:Group:0:Groups:0"]);
-            Assert.Equal("Small", config["FeatureManagement:VariantsFeature1:Allocation:Group:1:Variant"]);
-            Assert.Equal("Ring2", config["FeatureManagement:VariantsFeature1:Allocation:Group:1:Groups:0"]);
-            Assert.Equal("Ring3", config["FeatureManagement:VariantsFeature1:Allocation:Group:1:Groups:1"]);
-            Assert.Equal("Big", config["FeatureManagement:VariantsFeature1:Allocation:Percentile:0:Variant"]);
-            Assert.Equal("0", config["FeatureManagement:VariantsFeature1:Allocation:Percentile:0:From"]);
-            Assert.Equal("50", config["FeatureManagement:VariantsFeature1:Allocation:Percentile:0:To"]);
-            Assert.Equal("Small", config["FeatureManagement:VariantsFeature1:Allocation:Percentile:1:Variant"]);
-            Assert.Equal("50", config["FeatureManagement:VariantsFeature1:Allocation:Percentile:1:From"]);
-            Assert.Equal("100", config["FeatureManagement:VariantsFeature1:Allocation:Percentile:1:To"]);
-            Assert.Equal("13992821", config["FeatureManagement:VariantsFeature1:Allocation:Seed"]);
+            Assert.Equal("VariantsFeature1", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:enabled"]);
+            Assert.Equal("Big", config["feature_management:feature_flags:0:variants:0:name"]);
+            Assert.Equal("600px", config["feature_management:feature_flags:0:variants:0:configuration_value"]);
+            Assert.Equal("Small", config["feature_management:feature_flags:0:variants:1:name"]);
+            Assert.Equal("ShoppingCart:Small", config["feature_management:feature_flags:0:variants:1:configuration_reference"]);
+            Assert.Equal("Disabled", config["feature_management:feature_flags:0:variants:1:status_override"]);
+            Assert.Equal("Small", config["feature_management:feature_flags:0:allocation:default_when_disabled"]);
+            Assert.Equal("Small", config["feature_management:feature_flags:0:allocation:default_when_enabled"]);
+            Assert.Equal("Big", config["feature_management:feature_flags:0:allocation:user:0:variant"]);
+            Assert.Equal("Marsha", config["feature_management:feature_flags:0:allocation:user:0:users:0"]);
+            Assert.Equal("John", config["feature_management:feature_flags:0:allocation:user:0:users:1"]);
+            Assert.Equal("Small", config["feature_management:feature_flags:0:allocation:user:1:variant"]);
+            Assert.Equal("Alice", config["feature_management:feature_flags:0:allocation:user:1:users:0"]);
+            Assert.Equal("Bob", config["feature_management:feature_flags:0:allocation:user:1:users:1"]);
+            Assert.Equal("Big", config["feature_management:feature_flags:0:allocation:group:0:variant"]);
+            Assert.Equal("Ring1", config["feature_management:feature_flags:0:allocation:group:0:groups:0"]);
+            Assert.Equal("Small", config["feature_management:feature_flags:0:allocation:group:1:variant"]);
+            Assert.Equal("Ring2", config["feature_management:feature_flags:0:allocation:group:1:groups:0"]);
+            Assert.Equal("Ring3", config["feature_management:feature_flags:0:allocation:group:1:groups:1"]);
+            Assert.Equal("Big", config["feature_management:feature_flags:0:allocation:percentile:0:variant"]);
+            Assert.Equal("0", config["feature_management:feature_flags:0:allocation:percentile:0:from"]);
+            Assert.Equal("50", config["feature_management:feature_flags:0:allocation:percentile:0:to"]);
+            Assert.Equal("Small", config["feature_management:feature_flags:0:allocation:percentile:1:variant"]);
+            Assert.Equal("50", config["feature_management:feature_flags:0:allocation:percentile:1:from"]);
+            Assert.Equal("100", config["feature_management:feature_flags:0:allocation:percentile:1:to"]);
+            Assert.Equal("13992821", config["feature_management:feature_flags:0:allocation:seed"]);
 
-            Assert.Equal("Disabled", config["FeatureManagement:VariantsFeature2:Status"]);
-            Assert.Equal("ObjectVariant", config["FeatureManagement:VariantsFeature2:Variants:0:Name"]);
-            Assert.Equal("Value1", config["FeatureManagement:VariantsFeature2:Variants:0:ConfigurationValue:Key1"]);
-            Assert.Equal("Value2", config["FeatureManagement:VariantsFeature2:Variants:0:ConfigurationValue:Key2:InsideKey2"]);
-            Assert.Equal("NumberVariant", config["FeatureManagement:VariantsFeature2:Variants:1:Name"]);
-            Assert.Equal("100", config["FeatureManagement:VariantsFeature2:Variants:1:ConfigurationValue"]);
-            Assert.Equal("NullVariant", config["FeatureManagement:VariantsFeature2:Variants:2:Name"]);
-            Assert.Equal("", config["FeatureManagement:VariantsFeature2:Variants:2:ConfigurationValue"]);
+            Assert.Equal("VariantsFeature2", config["feature_management:feature_flags:1:id"]);
+            Assert.Equal("False", config["feature_management:feature_flags:1:enabled"]);
+            Assert.Equal("ObjectVariant", config["feature_management:feature_flags:1:variants:0:name"]);
+            Assert.Equal("Value1", config["feature_management:feature_flags:1:variants:0:configuration_value:Key1"]);
+            Assert.Equal("Value2", config["feature_management:feature_flags:1:variants:0:configuration_value:Key2:InsideKey2"]);
+            Assert.Equal("NumberVariant", config["feature_management:feature_flags:1:variants:1:name"]);
+            Assert.Equal("100", config["feature_management:feature_flags:1:variants:1:configuration_value"]);
+            Assert.Equal("NullVariant", config["feature_management:feature_flags:1:variants:2:name"]);
+            Assert.Equal("", config["feature_management:feature_flags:1:variants:2:configuration_value"]);
             Assert.True(config
-                .GetSection("FeatureManagement:VariantsFeature2:Variants:2")
+                .GetSection("feature_management:feature_flags:1:variants:2")
                 .AsEnumerable()
                 .ToDictionary(x => x.Key, x => x.Value)
-                .ContainsKey("FeatureManagement:VariantsFeature2:Variants:2:ConfigurationValue"));
-            Assert.Equal("MissingValueVariant", config["FeatureManagement:VariantsFeature2:Variants:3:Name"]);
-            Assert.Null(config["FeatureManagement:VariantsFeature2:Variants:3:ConfigurationValue"]);
+                .ContainsKey("feature_management:feature_flags:1:variants:2:configuration_value"));
+            Assert.Equal("MissingValueVariant", config["feature_management:feature_flags:1:variants:3:name"]);
+            Assert.Null(config["feature_management:feature_flags:1:variants:3:configuration_value"]);
             Assert.False(config
-                .GetSection("FeatureManagement:VariantsFeature2:Variants:3")
+                .GetSection("feature_management:feature_flags:1:variants:3")
                 .AsEnumerable()
                 .ToDictionary(x => x.Key, x => x.Value)
-                .ContainsKey("FeatureManagement:VariantsFeature2:Variants:3:ConfigurationValue"));
-            Assert.Equal("BooleanVariant", config["FeatureManagement:VariantsFeature2:Variants:4:Name"]);
-            Assert.Equal("True", config["FeatureManagement:VariantsFeature2:Variants:4:ConfigurationValue"]);
-            Assert.Equal("ObjectVariant", config["FeatureManagement:VariantsFeature2:Allocation:DefaultWhenDisabled"]);
-            Assert.Equal("ObjectVariant", config["FeatureManagement:VariantsFeature2:Allocation:DefaultWhenEnabled"]);
-        }
-
-        [Fact]
-        public void WithStatus()
-        {
-            var mockResponse = new Mock<Response>();
-            var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
-
-            mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
-                .Returns(new MockAsyncPageable(_featureFlagCollection));
-
-            var config = new ConfigurationBuilder()
-                .AddAzureAppConfiguration(options =>
-                {
-                    options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
-                    options.UseFeatureFlags();
-                })
-                .Build();
-
-            Assert.Equal("Disabled", config["FeatureManagement:App1_Feature2:Status"]);
-            Assert.Equal("Conditional", config["FeatureManagement:Feature1:Status"]);
+                .ContainsKey("feature_management:feature_flags:1:variants:3:configuration_value"));
+            Assert.Equal("BooleanVariant", config["feature_management:feature_flags:1:variants:4:name"]);
+            Assert.Equal("True", config["feature_management:feature_flags:1:variants:4:configuration_value"]);
+            Assert.Equal("ObjectVariant", config["feature_management:feature_flags:1:allocation:default_when_disabled"]);
+            Assert.Equal("ObjectVariant", config["feature_management:feature_flags:1:allocation:default_when_enabled"]);
         }
 
         [Fact]
@@ -1429,10 +1445,11 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Equal("True", config["FeatureManagement:TelemetryFeature:Telemetry:Enabled"]);
-            Assert.Equal("Tag1Value", config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:Tags.Tag1"]);
-            Assert.Equal("Tag2Value", config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:Tags.Tag2"]);
-            Assert.Equal("c3c231fd-39a0-4cb6-3237-4614474b92c1", config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:ETag"]);
+            Assert.Equal("True", config["feature_management:feature_flags:0:telemetry:enabled"]);
+            Assert.Equal("TelemetryFeature", config["feature_management:feature_flags:0:id"]);
+            Assert.Equal("Tag1Value", config["feature_management:feature_flags:0:telemetry:metadata:Tags.Tag1"]);
+            Assert.Equal("Tag2Value", config["feature_management:feature_flags:0:telemetry:metadata:Tags.Tag2"]);
+            Assert.Equal("c3c231fd-39a0-4cb6-3237-4614474b92c1", config["feature_management:feature_flags:0:telemetry:metadata:ETag"]);
 
             byte[] featureFlagIdHash;
 
@@ -1446,8 +1463,8 @@ namespace Tests.AzureAppConfiguration
                 .Replace('+', '-')
                 .Replace('/', '_');
 
-            Assert.Equal(featureFlagId, config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:FeatureFlagId"]);
-            Assert.Equal($"{TestHelpers.PrimaryConfigStoreEndpoint}kv/{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature?label=label", config["FeatureManagement:TelemetryFeature:Telemetry:Metadata:FeatureFlagReference"]);
+            Assert.Equal(featureFlagId, config["feature_management:feature_flags:0:telemetry:metadata:FeatureFlagId"]);
+            Assert.Equal($"{TestHelpers.PrimaryConfigStoreEndpoint}kv/{FeatureManagementConstants.FeatureFlagMarker}TelemetryFeature?label=label", config["feature_management:feature_flags:0:telemetry:metadata:FeatureFlagReference"]);
         }
 
 
@@ -1488,10 +1505,14 @@ namespace Tests.AzureAppConfiguration
                 })
                 .Build();
 
-            Assert.Null(config["FeatureManagement:MyFeature2:RequirementType"]);
-            Assert.Null(config["FeatureManagement:Feature_NoFilters:RequirementType"]);
-            Assert.Equal("All", config["FeatureManagement:Feature_RequireAll:RequirementType"]);
-            Assert.Equal("Any", config["FeatureManagement:Feature_RequireAny:RequirementType"]);
+            Assert.Null(config["feature_management:feature_flags:0:requirement_type"]);
+            Assert.Equal("MyFeature2", config["feature_management:feature_flags:0:id"]);
+            Assert.Null(config["feature_management:feature_flags:1:requirement_type"]);
+            Assert.Equal("Feature_NoFilters", config["feature_management:feature_flags:1:id"]);
+            Assert.Equal("All", config["feature_management:feature_flags:2:conditions:requirement_type"]);
+            Assert.Equal("Feature_RequireAll", config["feature_management:feature_flags:2:id"]);
+            Assert.Equal("Any", config["feature_management:feature_flags:3:conditions:requirement_type"]);
+            Assert.Equal("Feature_RequireAny", config["feature_management:feature_flags:3:id"]);
         }
 
         Response<ConfigurationSetting> GetIfChanged(ConfigurationSetting setting, bool onlyIfChanged, CancellationToken cancellationToken)

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -15,7 +15,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;

--- a/tests/Tests.AzureAppConfiguration/JsonContentTypeTests.cs
+++ b/tests/Tests.AzureAppConfiguration/JsonContentTypeTests.cs
@@ -221,9 +221,9 @@ namespace Tests.AzureAppConfiguration
                 .AddAzureAppConfiguration(options => options.ClientManager = mockClientManager)
                 .Build();
 
-            Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
-            Assert.Equal("Firefox", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
-            Assert.Equal("Safari", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:1"]);
+            Assert.Equal("Browser", config["feature_management:feature_flags:0:conditions:client_filters:0:name"]);
+            Assert.Equal("Firefox", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:0"]);
+            Assert.Equal("Safari", config["feature_management:feature_flags:0:conditions:client_filters:0:parameters:AllowedBrowsers:1"]);
         }
 
         [Fact]

--- a/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
@@ -424,7 +424,8 @@ namespace Tests.AzureAppConfiguration
                 .Returns(true);
             mockKeyValueAdapter.Setup(adapter => adapter.ProcessKeyValue(_kv, It.IsAny<Uri>(), It.IsAny<Logger>(), It.IsAny<CancellationToken>()))
                 .Throws(new KeyVaultReferenceException("Key vault error", null));
-            mockKeyValueAdapter.Setup(adapter => adapter.ProcessProviderRefresh(null));
+            mockKeyValueAdapter.Setup(adapter => adapter.OnConfigurationRefresh(null));
+            mockKeyValueAdapter.Setup(adapter => adapter.OnConfigurationUpdated());
 
             new ConfigurationBuilder()
             .AddAzureAppConfiguration(options =>

--- a/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
@@ -424,8 +424,7 @@ namespace Tests.AzureAppConfiguration
                 .Returns(true);
             mockKeyValueAdapter.Setup(adapter => adapter.ProcessKeyValue(_kv, It.IsAny<Uri>(), It.IsAny<Logger>(), It.IsAny<CancellationToken>()))
                 .Throws(new KeyVaultReferenceException("Key vault error", null));
-            mockKeyValueAdapter.Setup(adapter => adapter.InvalidateCache(null));
-            mockKeyValueAdapter.Setup(adapter => adapter.ResetState());
+            mockKeyValueAdapter.Setup(adapter => adapter.ProcessProviderRefresh(null));
 
             new ConfigurationBuilder()
             .AddAzureAppConfiguration(options =>

--- a/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
@@ -424,8 +424,8 @@ namespace Tests.AzureAppConfiguration
                 .Returns(true);
             mockKeyValueAdapter.Setup(adapter => adapter.ProcessKeyValue(_kv, It.IsAny<Uri>(), It.IsAny<Logger>(), It.IsAny<CancellationToken>()))
                 .Throws(new KeyVaultReferenceException("Key vault error", null));
-            mockKeyValueAdapter.Setup(adapter => adapter.OnConfigurationRefresh(null));
-            mockKeyValueAdapter.Setup(adapter => adapter.OnConfigurationUpdated());
+            mockKeyValueAdapter.Setup(adapter => adapter.OnChangeDetected(null));
+            mockKeyValueAdapter.Setup(adapter => adapter.OnConfigUpdated());
 
             new ConfigurationBuilder()
             .AddAzureAppConfiguration(options =>

--- a/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
@@ -425,6 +425,7 @@ namespace Tests.AzureAppConfiguration
             mockKeyValueAdapter.Setup(adapter => adapter.ProcessKeyValue(_kv, It.IsAny<Uri>(), It.IsAny<Logger>(), It.IsAny<CancellationToken>()))
                 .Throws(new KeyVaultReferenceException("Key vault error", null));
             mockKeyValueAdapter.Setup(adapter => adapter.InvalidateCache(null));
+            mockKeyValueAdapter.Setup(adapter => adapter.ResetState());
 
             new ConfigurationBuilder()
             .AddAzureAppConfiguration(options =>


### PR DESCRIPTION
Emits the feature flag schema defined [here](https://github.com/Azure/AppConfiguration/blob/main/docs/FeatureManagement/FeatureFlag.v2.0.0.schema.json).

Added to avoid resolving conflicts with main branch, main will be merged in after to ensure necessary tests are added and branches are up to date.