### PR TITLE
Fix xUnit1031 warning

### DIFF
--- a/tests/Tests.AzureAppConfiguration/FailoverTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FailoverTests.cs
@@ -23,7 +23,7 @@ namespace Tests.AzureAppConfiguration
                                                                                           contentType: "text");
 
         [Fact]
-        public void FailOverTests_ReturnsAllClientsIfAllBackedOff()
+        public async Task FailOverTests_ReturnsAllClientsIfAllBackedOff()
         {
             // Arrange
             IConfigurationRefresher refresher = null;
@@ -85,7 +85,7 @@ namespace Tests.AzureAppConfiguration
             // Assert the inner request failed exceptions
             Assert.True((exception.InnerException as AggregateException)?.InnerExceptions?.All(e => e is RequestFailedException) ?? false);
 
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             // The client manager should have called RefreshClients when all clients were backed off
             Assert.Equal(1, configClientManager.RefreshClientsCalled);
@@ -144,7 +144,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void FailOverTests_BackoffStateIsUpdatedOnSuccessfulRequest()
+        public async Task FailOverTests_BackoffStateIsUpdatedOnSuccessfulRequest()
         {
             // Arrange
             IConfigurationRefresher refresher = null;
@@ -199,7 +199,7 @@ namespace Tests.AzureAppConfiguration
                     refresher = options.GetRefresher();
                 }).Build();
 
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             // The first client should not have been called during refresh
             mockClient1.Verify(mc => mc.GetConfigurationSettingAsync(It.IsAny<ConfigurationSetting>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Exactly(0));
@@ -211,7 +211,7 @@ namespace Tests.AzureAppConfiguration
             // Wait for client 1 backoff to end
             Thread.Sleep(2500);
             
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             // The first client should have been called now with refresh after the backoff time ends
             mockClient1.Verify(mc => mc.GetConfigurationSettingAsync(It.IsAny<ConfigurationSetting>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Exactly(1));

--- a/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FeatureManagementTests.cs
@@ -452,7 +452,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void WatchesFeatureFlags()
+        public async Task WatchesFeatureFlags()
         {
             var featureFlags = new List<ConfigurationSetting> { _kv };
 
@@ -513,7 +513,7 @@ namespace Tests.AzureAppConfiguration
 
             // Sleep to let the cache expire
             Thread.Sleep(cacheExpirationTimeSpan);
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
             Assert.Equal("Chrome", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
@@ -523,7 +523,7 @@ namespace Tests.AzureAppConfiguration
 
 
         [Fact]
-        public void SkipRefreshIfCacheNotExpired()
+        public async Task SkipRefreshIfCacheNotExpired()
         {
             var featureFlags = new List<ConfigurationSetting> { _kv };
 
@@ -581,7 +581,7 @@ namespace Tests.AzureAppConfiguration
 
             featureFlags.Add(_kv2);
 
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal("Browser", config["FeatureManagement:Beta:EnabledFor:0:Name"]);
             Assert.Equal("Firefox", config["FeatureManagement:Beta:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
@@ -618,7 +618,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void QueriesFeatureFlags()
+        public async Task QueriesFeatureFlags()
         {
             var mockTransport = new MockTransport(req =>
             {
@@ -646,7 +646,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void UsesEtagForFeatureFlagRefresh()
+        public async Task UsesEtagForFeatureFlagRefresh()
         {
             var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
             mockClient.Setup(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()))
@@ -667,7 +667,7 @@ namespace Tests.AzureAppConfiguration
             // Sleep to let the cache expire
             Thread.Sleep(cacheExpirationTimeSpan);
 
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
             mockClient.Verify(c => c.GetConfigurationSettingsAsync(It.IsAny<SettingSelector>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
         }
 
@@ -1025,7 +1025,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void DifferentCacheExpirationsForMultipleFeatureFlagRegistrations()
+        public async Task DifferentCacheExpirationsForMultipleFeatureFlagRegistrations()
         {
             var mockResponse = new Mock<Response>();
             var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
@@ -1111,7 +1111,7 @@ namespace Tests.AzureAppConfiguration
 
             // Sleep to let the cache for feature flag with label1 expire
             Thread.Sleep(cacheExpiration1);
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal("Browser", config["FeatureManagement:App1_Feature1:EnabledFor:0:Name"]);
             Assert.Equal("Chrome", config["FeatureManagement:App1_Feature1:EnabledFor:0:Parameters:AllowedBrowsers:0"]);
@@ -1125,7 +1125,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void OverwrittenCacheExpirationForSameFeatureFlagRegistrations()
+        public async Task OverwrittenCacheExpirationForSameFeatureFlagRegistrations()
         {
             var mockResponse = new Mock<Response>();
             var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
@@ -1188,7 +1188,7 @@ namespace Tests.AzureAppConfiguration
                 eTag: new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1" + "f"));
 
             Thread.Sleep(cacheExpiration1);
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             // The cache expiration time for feature flags was overwritten by second call to UseFeatureFlags.
             // Sleeping for cacheExpiration1 time should not update feature flags.
@@ -1200,7 +1200,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void SelectAndRefreshSingleFeatureFlag()
+        public async Task SelectAndRefreshSingleFeatureFlag()
         {
             var mockResponse = new Mock<Response>();
             var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
@@ -1258,7 +1258,7 @@ namespace Tests.AzureAppConfiguration
 
             // Sleep to let the cache for feature flag with label1 expire
             Thread.Sleep(cacheExpiration);
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal("Browser", config["FeatureManagement:Feature1:EnabledFor:0:Name"]);
             Assert.Equal("Chrome", config["FeatureManagement:Feature1:EnabledFor:0:Parameters:AllowedBrowsers:0"]);

--- a/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/KeyVaultReferenceTests.cs
@@ -683,7 +683,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void SecretIsReturnedFromCacheIfSecretCacheHasNotExpired()
+        public async Task SecretIsReturnedFromCacheIfSecretCacheHasNotExpired()
         {
             IConfigurationRefresher refresher = null;
             TimeSpan cacheExpirationTime = TimeSpan.FromSeconds(1);
@@ -745,7 +745,7 @@ namespace Tests.AzureAppConfiguration
             // Update sentinel key-value
             sentinelKv.Value = "Value2";
             Thread.Sleep(cacheExpirationTime);
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal("Value2", config["Sentinel"]);
             Assert.Equal(_secretValue, config[_kv.Key]);
@@ -756,7 +756,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void CachedSecretIsInvalidatedWhenRefreshAllIsTrue()
+        public async Task CachedSecretIsInvalidatedWhenRefreshAllIsTrue()
         {
             IConfigurationRefresher refresher = null;
             TimeSpan cacheExpirationTime = TimeSpan.FromSeconds(1);
@@ -817,7 +817,7 @@ namespace Tests.AzureAppConfiguration
             // Update sentinel key-value to trigger refresh operation
             sentinelKv.Value = "Value2";
             Thread.Sleep(cacheExpirationTime);
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal("Value2", config["Sentinel"]);
             Assert.Equal(_secretValue, config[_kv.Key]);
@@ -828,7 +828,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void SecretIsReloadedFromKeyVaultWhenCacheExpires()
+        public async Task SecretIsReloadedFromKeyVaultWhenCacheExpires()
         {
             IConfigurationRefresher refresher = null;
             TimeSpan cacheExpirationTime = TimeSpan.FromSeconds(1);
@@ -862,7 +862,7 @@ namespace Tests.AzureAppConfiguration
 
             // Sleep to let the secret cache expire 
             Thread.Sleep(cacheExpirationTime);
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal(_secretValue, config[_kv.Key]);
 
@@ -871,7 +871,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void SecretsWithDefaultRefreshInterval()
+        public async Task SecretsWithDefaultRefreshInterval()
         {
             IConfigurationRefresher refresher = null;
             TimeSpan shortCacheExpirationTime = TimeSpan.FromSeconds(1);
@@ -906,7 +906,7 @@ namespace Tests.AzureAppConfiguration
 
             // Sleep to let the secret cache expire for both secrets 
             Thread.Sleep(shortCacheExpirationTime);
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal(_secretValue, config["TK1"]);
             Assert.Equal(_secretValue, config["TK2"]);
@@ -916,7 +916,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void SecretsWithDifferentRefreshIntervals()
+        public async Task SecretsWithDifferentRefreshIntervals()
         {
             IConfigurationRefresher refresher = null;
             TimeSpan shortCacheExpirationTime = TimeSpan.FromSeconds(1);
@@ -953,7 +953,7 @@ namespace Tests.AzureAppConfiguration
 
             // Sleep to let the secret cache expire for one secret 
             Thread.Sleep(shortCacheExpirationTime);
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal(_secretValue, config["TK1"]);
             Assert.Equal(_secretValue, config["TK2"]);

--- a/tests/Tests.AzureAppConfiguration/LoggingTests.cs
+++ b/tests/Tests.AzureAppConfiguration/LoggingTests.cs
@@ -55,7 +55,7 @@ namespace Tests.AzureAppConfiguration
         TimeSpan CacheExpirationTime = TimeSpan.FromSeconds(1);
 
         [Fact]
-        public void ValidateExceptionLoggedDuringRefresh()
+        public async Task ValidateExceptionLoggedDuringRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -92,14 +92,14 @@ namespace Tests.AzureAppConfiguration
             FirstKeyValue.Value = "newValue1";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.NotEqual("newValue1", config["TestKey1"]);
             Assert.Contains(LoggingConstants.RefreshFailedError, warningInvocation);
         }
 
         [Fact]
-        public void ValidateUnauthorizedExceptionLoggedDuringRefresh()
+        public async Task ValidateUnauthorizedExceptionLoggedDuringRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -134,14 +134,14 @@ namespace Tests.AzureAppConfiguration
             FirstKeyValue.Value = "newValue1";
             
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.NotEqual("newValue1", config["TestKey1"]);
             Assert.Contains(LoggingConstants.RefreshFailedDueToAuthenticationError, warningInvocation);
         }
 
         [Fact]
-        public void ValidateInvalidOperationExceptionLoggedDuringRefresh()
+        public async Task ValidateInvalidOperationExceptionLoggedDuringRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -176,14 +176,14 @@ namespace Tests.AzureAppConfiguration
             FirstKeyValue.Value = "newValue1";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.NotEqual("newValue1", config["TestKey1"]);
             Assert.Contains(LoggingConstants.RefreshFailedError, warningInvocation);
         }
 
         [Fact]
-        public void ValidateKeyVaultExceptionLoggedDuringRefresh()
+        public async Task ValidateKeyVaultExceptionLoggedDuringRefresh()
         {
             IConfigurationRefresher refresher = null;
 
@@ -242,13 +242,13 @@ namespace Tests.AzureAppConfiguration
             // Update sentinel key-value to trigger refreshAll operation
             sentinelKv.Value = "UpdatedSentinelValue";
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.Contains(LoggingConstants.RefreshFailedDueToKeyVaultError + "\nNo key vault credential or secret resolver callback configured, and no matching secret client could be found.", warningInvocation);
         }
 
         [Fact]
-        public void ValidateAggregateExceptionWithInnerOperationCanceledExceptionLoggedDuringRefresh()
+        public async Task ValidateAggregateExceptionWithInnerOperationCanceledExceptionLoggedDuringRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -283,14 +283,14 @@ namespace Tests.AzureAppConfiguration
             FirstKeyValue.Value = "newValue1";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.NotEqual("newValue1", config["TestKey1"]);
             Assert.Contains(LoggingConstants.RefreshFailedError, warningInvocation);
         }
 
         [Fact]
-        public void ValidateOperationCanceledExceptionLoggedDuringRefresh()
+        public async Task ValidateOperationCanceledExceptionLoggedDuringRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -326,14 +326,14 @@ namespace Tests.AzureAppConfiguration
 
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
-            refresher.TryRefreshAsync(cancellationSource.Token).Wait();
+            await refresher.TryRefreshAsync(cancellationSource.Token);
 
             Assert.NotEqual("newValue1", config["TestKey1"]);
             Assert.Contains(LoggingConstants.RefreshCanceledError, warningInvocation);
         }
 
         [Fact]
-        public void ValidateFailoverToDifferentEndpointMessageLoggedAfterFailover()
+        public async Task ValidateFailoverToDifferentEndpointMessageLoggedAfterFailover()
         {
             IConfigurationRefresher refresher = null;
             var mockClient1 = GetMockConfigurationClient();
@@ -381,7 +381,7 @@ namespace Tests.AzureAppConfiguration
             FirstKeyValue.Value = "newValue1";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.Equal("newValue1", config["TestKey1"]);
             Assert.Contains(LogHelper.BuildFailoverMessage(TestHelpers.PrimaryConfigStoreEndpoint.ToString(), TestHelpers.SecondaryConfigStoreEndpoint.ToString()), warningInvocation);
@@ -393,14 +393,14 @@ namespace Tests.AzureAppConfiguration
             FirstKeyValue.Value = "TestValue1";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.Equal("newValue1", config["TestKey1"]);
             Assert.Contains(LogHelper.BuildLastEndpointFailedMessage(TestHelpers.SecondaryConfigStoreEndpoint.ToString()), warningInvocation);
         }
 
         [Fact]
-        public void ValidateConfigurationUpdatedSuccessLoggedDuringRefresh()
+        public async Task ValidateConfigurationUpdatedSuccessLoggedDuringRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -435,14 +435,14 @@ namespace Tests.AzureAppConfiguration
             FirstKeyValue.Value = "newValue1";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.Equal("newValue1", config["TestKey1"]);
             Assert.Contains(LogHelper.BuildConfigurationUpdatedMessage(), invocation);
         }
 
         [Fact]
-        public void ValidateCorrectEndpointLoggedOnConfigurationUpdate()
+        public async Task ValidateCorrectEndpointLoggedOnConfigurationUpdate()
         {
             IConfigurationRefresher refresher = null;
             var mockClient1 = new Mock<ConfigurationClient>();
@@ -484,14 +484,14 @@ namespace Tests.AzureAppConfiguration
             FirstKeyValue.Value = "newValue1";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             // We should see the second client's endpoint logged since the first client is backed off
             Assert.Contains(LogHelper.BuildKeyValueReadMessage(KeyValueChangeType.Modified, _kvCollection[0].Key, _kvCollection[0].Label, TestHelpers.SecondaryConfigStoreEndpoint.ToString().TrimEnd('/')), invocation);
         }
 
         [Fact]
-        public void ValidateCorrectKeyValueLoggedDuringRefresh()
+        public async Task ValidateCorrectKeyValueLoggedDuringRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -531,7 +531,7 @@ namespace Tests.AzureAppConfiguration
             FirstKeyValue.Value = "newValue1";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.Equal("newValue1", config["TestKey1"]);
             Assert.Contains(LogHelper.BuildKeyValueReadMessage(KeyValueChangeType.Modified, _kvCollection[0].Key, _kvCollection[0].Label, TestHelpers.PrimaryConfigStoreEndpoint.ToString().TrimEnd('/')), verboseInvocation);
@@ -540,7 +540,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void ValidateCorrectKeyVaultSecretLoggedDuringRefresh()
+        public async Task ValidateCorrectKeyVaultSecretLoggedDuringRefresh()
         {
             string _secretValue = "SecretValue from KeyVault";
             Uri vaultUri = new Uri("https://keyvault-theclassics.vault.azure.net");
@@ -594,7 +594,7 @@ namespace Tests.AzureAppConfiguration
                     }
                    ";
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
             Assert.Contains(LogHelper.BuildKeyVaultSecretReadMessage(_kvr.Key, _kvr.Label), verboseInvocation);
             Assert.Contains(LogHelper.BuildKeyVaultSettingUpdatedMessage(_kvr.Key), informationalInvocation);
         }

--- a/tests/Tests.AzureAppConfiguration/MapTests.cs
+++ b/tests/Tests.AzureAppConfiguration/MapTests.cs
@@ -130,7 +130,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void MapTransformWithRefresh()
+        public async Task MapTransformWithRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -176,14 +176,14 @@ namespace Tests.AzureAppConfiguration
             FirstKeyValue.Value = "newValue1";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.Equal("newValue1 mapped first", config["TestKey1"]);
             Assert.Equal("TestValue2 second", config["TestKey2"]);
         }
 
         [Fact]
-        public void MapTransformSettingKeyWithRefresh()
+        public async Task MapTransformSettingKeyWithRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -226,14 +226,14 @@ namespace Tests.AzureAppConfiguration
             _kvCollection.Last().Value = "newValue2";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.Equal("newValue1 changed", config["newTestKey1"]);
             Assert.Equal("newValue2", config["TestKey2"]);
         }
 
         [Fact]
-        public void MapTransformSettingLabelWithRefresh()
+        public async Task MapTransformSettingLabelWithRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -274,14 +274,14 @@ namespace Tests.AzureAppConfiguration
             _kvCollection.Last().Value = "newValue2";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.Equal("newValue1 changed", config["TestKey1"]);
             Assert.Equal("newValue2 changed", config["TestKey2"]);
         }
 
         [Fact]
-        public void MapTransformSettingCreateDuplicateKeyWithRefresh()
+        public async Task MapTransformSettingCreateDuplicateKeyWithRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -322,14 +322,14 @@ namespace Tests.AzureAppConfiguration
             FirstKeyValue.Value = "newValue1";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.Equal("TestValue2 changed", config["TestKey2"]);
             Assert.Null(config["TestKey1"]);
         }
 
         [Fact]
-        public void MapCreateNewSettingWithRefresh()
+        public async Task MapCreateNewSettingWithRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -367,7 +367,7 @@ namespace Tests.AzureAppConfiguration
             FirstKeyValue.Value = "newValue1";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.Equal("mappedValue1", config["TestKey1"]);
             Assert.Equal("TestValue2", config["TestKey2"]);
@@ -450,7 +450,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void MapTransformSettingKeyWithLogAndRefresh()
+        public async Task MapTransformSettingKeyWithLogAndRefresh()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -508,7 +508,7 @@ namespace Tests.AzureAppConfiguration
             _kvCollection.Last().Value = "newValue2";
 
             Thread.Sleep(CacheExpirationTime);
-            refresher.TryRefreshAsync().Wait();
+            await refresher.TryRefreshAsync();
 
             Assert.Equal("newValue1 changed", config["newTestKey1"]);
             Assert.Equal("newValue2", config["TestKey2"]);

--- a/tests/Tests.AzureAppConfiguration/PushRefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/PushRefreshTests.cs
@@ -286,7 +286,7 @@ namespace Tests.AzureAppConfiguration
 		}
 
 		[Fact]
-		public void SyncTokenUpdatesCorrectNumberOfTimes()
+		public async Task SyncTokenUpdatesCorrectNumberOfTimes()
 		{
 			// Arrange
 			var mockResponse = new Mock<Response>();
@@ -312,7 +312,7 @@ namespace Tests.AzureAppConfiguration
 			foreach (PushNotification pushNotification in _pushNotificationList)
 			{
 				refresher.ProcessPushNotification(pushNotification, TimeSpan.FromSeconds(0));
-				refresher.RefreshAsync().Wait();
+				await refresher.RefreshAsync();
 			}
 
 			var validNotificationKVWatcherCount = 8;
@@ -324,7 +324,7 @@ namespace Tests.AzureAppConfiguration
 		}
 
 		[Fact]
-		public void RefreshAsyncUpdatesConfig()
+		public async Task RefreshAsyncUpdatesConfig()
 		{
 			// Arrange
 			var mockResponse = new Mock<Response>();
@@ -351,7 +351,7 @@ namespace Tests.AzureAppConfiguration
 			FirstKeyValue.Value = "newValue1";
 
 			refresher.ProcessPushNotification(_pushNotificationList.First(), TimeSpan.FromSeconds(0));
-			refresher.RefreshAsync().Wait();
+			await refresher.RefreshAsync();
 
 			Assert.Equal("newValue1", config["TestKey1"]);
 		}

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -130,7 +130,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void RefreshTests_RefreshIsSkippedIfCacheIsNotExpired()
+        public async Task RefreshTests_RefreshIsSkippedIfCacheIsNotExpired()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -152,13 +152,13 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("TestValue1", config["TestKey1"]);
             FirstKeyValue.Value = "newValue1";
 
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal("TestValue1", config["TestKey1"]);
         }
 
         [Fact]
-        public void RefreshTests_RefreshIsSkippedIfKvNotInSelectAndCacheIsNotExpired()
+        public async Task RefreshTests_RefreshIsSkippedIfKvNotInSelectAndCacheIsNotExpired()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClientSelectKeyLabel();
@@ -181,13 +181,13 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal("TestValue1", config["TestKey1"]);
             FirstKeyValue.Value = "newValue1";
 
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal("TestValue1", config["TestKey1"]);
         }
 
         [Fact]
-        public void RefreshTests_RefreshIsNotSkippedIfCacheIsExpired()
+        public async Task RefreshTests_RefreshIsNotSkippedIfCacheIsExpired()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -213,13 +213,13 @@ namespace Tests.AzureAppConfiguration
             // Wait for the cache to expire
             Thread.Sleep(1500);
 
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal("newValue", config["TestKey1"]);
         }
 
         [Fact]
-        public void RefreshTests_RefreshAllFalseDoesNotUpdateEntireConfiguration()
+        public async Task RefreshTests_RefreshAllFalseDoesNotUpdateEntireConfiguration()
         {
             var keyValueCollection = new List<ConfigurationSetting>(_kvCollection);
             IConfigurationRefresher refresher = null;
@@ -249,7 +249,7 @@ namespace Tests.AzureAppConfiguration
             // Wait for the cache to expire
             Thread.Sleep(1500);
 
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal("newValue", config["TestKey1"]);
             Assert.NotEqual("newValue", config["TestKey2"]);
@@ -257,7 +257,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void RefreshTests_RefreshAllTrueUpdatesEntireConfiguration()
+        public async Task RefreshTests_RefreshAllTrueUpdatesEntireConfiguration()
         {
             var keyValueCollection = new List<ConfigurationSetting>(_kvCollection);
             IConfigurationRefresher refresher = null;
@@ -287,7 +287,7 @@ namespace Tests.AzureAppConfiguration
             // Wait for the cache to expire
             Thread.Sleep(1500);
 
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal("newValue", config["TestKey1"]);
             Assert.Equal("newValue", config["TestKey2"]);
@@ -295,7 +295,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void RefreshTests_RefreshAllTrueRemovesDeletedConfiguration()
+        public async Task RefreshTests_RefreshAllTrueRemovesDeletedConfiguration()
         {
             var keyValueCollection = new List<ConfigurationSetting>(_kvCollection);
             var mockResponse = new Mock<Response>();
@@ -359,7 +359,7 @@ namespace Tests.AzureAppConfiguration
             // Wait for the cache to expire
             Thread.Sleep(1500);
 
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal("newValue", config["TestKey1"]);
             Assert.Equal("TestValue2", config["TestKey2"]);
@@ -367,7 +367,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void RefreshTests_RefreshAllForNonExistentSentinelDoesNothing()
+        public async Task RefreshTests_RefreshAllForNonExistentSentinelDoesNothing()
         {
             var keyValueCollection = new List<ConfigurationSetting>(_kvCollection);
             var mockResponse = new Mock<Response>();
@@ -433,7 +433,7 @@ namespace Tests.AzureAppConfiguration
             // Wait for the cache to expire
             Thread.Sleep(1500);
 
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             // Validate that key-values registered for refresh were updated
             Assert.Equal("newValue1", config["TestKey1"]);
@@ -444,7 +444,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void RefreshTests_SingleServerCallOnSimultaneousMultipleRefresh()
+        public async void RefreshTests_SingleServerCallOnSimultaneousMultipleRefresh()
         {
             var keyValueCollection = new List<ConfigurationSetting>(_kvCollection);
             var requestCount = 0;
@@ -505,7 +505,8 @@ namespace Tests.AzureAppConfiguration
             var task1 = Task.Run(() => WaitAndRefresh(refresher, 1500));
             var task2 = Task.Run(() => WaitAndRefresh(refresher, 3000));
             var task3 = Task.Run(() => WaitAndRefresh(refresher, 4500));
-            Task.WaitAll(task1, task2, task3);
+
+            await Task.WhenAll(task1, task2, task3);
 
             Assert.Equal("newValue", config["TestKey1"]);
             Assert.Equal(2, requestCount);
@@ -548,7 +549,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void RefreshTests_TryRefreshAsyncReturnsFalseOnRequestFailedException()
+        public async Task RefreshTests_TryRefreshAsyncReturnsFalseOnRequestFailedException()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -577,14 +578,14 @@ namespace Tests.AzureAppConfiguration
             // Wait for the cache to expire
             Thread.Sleep(1500);
 
-            bool result = refresher.TryRefreshAsync().Result;
+            bool result = await refresher.TryRefreshAsync();
             Assert.False(result);
 
             Assert.NotEqual("newValue", config["TestKey1"]);
         }
 
         [Fact]
-        public void RefreshTests_TryRefreshAsyncUpdatesConfigurationAndReturnsTrueOnSuccess()
+        public async Task RefreshTests_TryRefreshAsyncUpdatesConfigurationAndReturnsTrueOnSuccess()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();
@@ -610,14 +611,14 @@ namespace Tests.AzureAppConfiguration
             // Wait for the cache to expire
             Thread.Sleep(1500);
 
-            bool result = refresher.TryRefreshAsync().Result;
+            bool result = await refresher.TryRefreshAsync();
             Assert.True(result);
 
             Assert.Equal("newValue", config["TestKey1"]);
         }
 
         [Fact]
-        public void RefreshTests_TryRefreshAsyncReturnsFalseForAuthenticationFailedException()
+        public async Task RefreshTests_TryRefreshAsyncReturnsFalseForAuthenticationFailedException()
         {
             IConfigurationRefresher refresher = null;
             var mockResponse = new Mock<Response>();
@@ -654,13 +655,13 @@ namespace Tests.AzureAppConfiguration
             Thread.Sleep(1500);
 
             // First call to GetConfigurationSettingAsync does not throw
-            Assert.True(refresher.TryRefreshAsync().Result);
+            Assert.True(await refresher.TryRefreshAsync());
 
             // Wait for the cache to expire
             Thread.Sleep(1500);
 
             // Second call to GetConfigurationSettingAsync throws KeyVaultReferenceException
-            Assert.False(refresher.TryRefreshAsync().Result);
+            Assert.False(await refresher.TryRefreshAsync());
         }
 
         [Fact]
@@ -774,7 +775,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void RefreshTests_SentinelKeyNotUpdatedOnRefreshAllFailure()
+        public async Task RefreshTests_SentinelKeyNotUpdatedOnRefreshAllFailure()
         {
             var keyValueCollection = new List<ConfigurationSetting>(_kvCollection);
             var mockResponse = new Mock<Response>();
@@ -827,7 +828,7 @@ namespace Tests.AzureAppConfiguration
             // Wait for the cache to expire
             Thread.Sleep(1500);
 
-            bool firstRefreshResult = refresher.TryRefreshAsync().Result;
+            bool firstRefreshResult = await refresher.TryRefreshAsync();
             Assert.False(firstRefreshResult);
 
             Assert.Equal("TestValue1", config["TestKey1"]);
@@ -837,7 +838,7 @@ namespace Tests.AzureAppConfiguration
             // Wait for the cache to expire
             Thread.Sleep(1500);
 
-            bool secondRefreshResult = refresher.TryRefreshAsync().Result;
+            bool secondRefreshResult = await refresher.TryRefreshAsync();
             Assert.True(secondRefreshResult);
 
             Assert.Equal("newValue", config["TestKey1"]);
@@ -846,7 +847,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void RefreshTests_RefreshAllTrueForOverwrittenSentinelUpdatesEntireConfiguration()
+        public async Task RefreshTests_RefreshAllTrueForOverwrittenSentinelUpdatesEntireConfiguration()
         {
             var keyValueCollection = new List<ConfigurationSetting>(_kvCollection);
             IConfigurationRefresher refresher = null;
@@ -878,7 +879,7 @@ namespace Tests.AzureAppConfiguration
             // Wait for the cache to expire
             Thread.Sleep(1500);
 
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             Assert.Equal("newValue", config["TestKey1"]);
             Assert.Equal("newValue", config["TestKey2"]);
@@ -887,7 +888,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void RefreshTests_RefreshAllFalseForOverwrittenSentinelUpdatesConfig()
+        public async Task RefreshTests_RefreshAllFalseForOverwrittenSentinelUpdatesConfig()
         {
             var keyValueCollection = new List<ConfigurationSetting>(_kvCollection);
             ConfigurationSetting refreshRegisteredSetting = keyValueCollection.FirstOrDefault(s => s.Key == "TestKeyWithMultipleLabels" && s.Label == "label1");
@@ -920,7 +921,7 @@ namespace Tests.AzureAppConfiguration
             // Wait for the cache to expire
             Thread.Sleep(1500);
 
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             // Validate that refresh registered key-value was updated
             Assert.Equal("TestValue1", config["TestKey1"]);
@@ -930,7 +931,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void RefreshTests_RefreshRegisteredKvOverwritesSelectedKv()
+        public async Task RefreshTests_RefreshRegisteredKvOverwritesSelectedKv()
         {
             var keyValueCollection = new List<ConfigurationSetting>(_kvCollection);
             ConfigurationSetting refreshAllRegisteredSetting = keyValueCollection.FirstOrDefault(s => s.Key == "TestKeyWithMultipleLabels" && s.Label == "label1");
@@ -963,7 +964,7 @@ namespace Tests.AzureAppConfiguration
             // Wait for the cache to expire
             Thread.Sleep(1500);
 
-            refresher.RefreshAsync().Wait();
+            await refresher.RefreshAsync();
 
             // Validate that only the refresh registered key-value was updated
             Assert.Equal("TestValue1", config["TestKey1"]);


### PR DESCRIPTION
## Why this PR?
To fix [xUnit1031](https://xunit.net/xunit.analyzers/rules/xUnit1031) warning.

## Visible changes
Update testcases to use async&await.