### PR TITLE
Bugfix for collection monitoring etag logic

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -822,6 +822,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                                 }
                             }
 
+                            // The ETag will never be null here because it's not a conditional request
+                            // Each successful response should have 200 status code and an ETag
                             matchConditions.Add(new MatchConditions { IfNoneMatch = response.Headers.ETag });
                         }
                     }).ConfigureAwait(false);

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -812,8 +812,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                         {
                             using Response response = page.GetRawResponse();
 
-                            ETag serverEtag = (ETag)response.Headers.ETag;
-
                             foreach (ConfigurationSetting setting in page.Values)
                             {
                                 data[setting.Key] = setting;
@@ -824,7 +822,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                                 }
                             }
 
-                            matchConditions.Add(new MatchConditions { IfNoneMatch = serverEtag });
+                            matchConditions.Add(new MatchConditions { IfNoneMatch = response.Headers.ETag });
                         }
                     }).ConfigureAwait(false);
 

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
@@ -95,12 +95,10 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
             {
                 using Response response = page.GetRawResponse();
 
-                ETag serverEtag = (ETag)response.Headers.ETag;
-
                 // Return true if the lists of etags are different
-                if ((!existingMatchConditionsEnumerator.MoveNext() ||
-                    !existingMatchConditionsEnumerator.Current.IfNoneMatch.Equals(serverEtag)) &&
-                    response.Status == (int)HttpStatusCode.OK)
+                if (response.Status == (int)HttpStatusCode.OK &&
+                    (!existingMatchConditionsEnumerator.MoveNext() ||
+                    !existingMatchConditionsEnumerator.Current.IfNoneMatch.Equals(response.Headers.ETag)))
                 {
                     return true;
                 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Extensions/ConfigurationClientExtensions.cs
@@ -96,9 +96,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions
                 using Response response = page.GetRawResponse();
 
                 // Return true if the lists of etags are different
-                if (response.Status == (int)HttpStatusCode.OK &&
-                    (!existingMatchConditionsEnumerator.MoveNext() ||
-                    !existingMatchConditionsEnumerator.Current.IfNoneMatch.Equals(response.Headers.ETag)))
+                if ((!existingMatchConditionsEnumerator.MoveNext() ||
+                    !existingMatchConditionsEnumerator.Current.IfNoneMatch.Equals(response.Headers.ETag)) &&
+                    response.Status == (int)HttpStatusCode.OK)
                 {
                     return true;
                 }

--- a/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/MockResponse.cs
+++ b/tests/Tests.AzureAppConfiguration/Azure.Core.Testing/MockResponse.cs
@@ -18,7 +18,10 @@ namespace Azure.Core.Testing
             Status = status;
             ReasonPhrase = reasonPhrase;
 
-            AddHeader(new HttpHeader(HttpHeader.Names.ETag, "\"" + Guid.NewGuid().ToString() + "\""));
+            if (status == 200)
+            {
+                AddHeader(new HttpHeader(HttpHeader.Names.ETag, "\"" + Guid.NewGuid().ToString() + "\""));
+            }
         }
 
         public override int Status { get; }

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -1069,7 +1069,7 @@ namespace Tests.AzureAppConfiguration
                 .AddAzureAppConfiguration(options =>
                 {
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
-                    options.Select("TestKey*");
+                    options.Select("TestKey*", "label");
                     options.ConfigurationSettingPageIterator = new MockConfigurationSettingPageIterator();
                     options.ConfigureRefresh(refreshOptions =>
                     {
@@ -1159,7 +1159,7 @@ namespace Tests.AzureAppConfiguration
                 .AddAzureAppConfiguration(options =>
                 {
                     options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
-                    options.Select("TestKey*");
+                    options.Select("TestKey*", "label");
                     options.ConfigurationSettingPageIterator = new MockConfigurationSettingPageIterator();
                     options.ConfigureRefresh(refreshOptions =>
                     {


### PR DESCRIPTION
Discovered a bug in collection monitoring where an `InvalidOperationException` could happen when casting a null `ETag` from a response. This PR fixes tests that check if kvs/flags don't change to correctly fail when this happens and removes the casting from the `HaveCollectionsChanged` method.