### PR TITLE
Ensure kv collection refresh settings are not considered unless the feature is enabled.

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -118,6 +118,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
             if (options.RegisterAllEnabled)
             {
+                if (options.KvCollectionRefreshInterval <= TimeSpan.Zero)
+                {
+                    throw new ArgumentException(
+                        $"{nameof(options.KvCollectionRefreshInterval)} must be greater than zero seconds when using RegisterAll for refresh",
+                        nameof(options));
+                }
+
                 MinRefreshInterval = TimeSpan.FromTicks(Math.Min(minWatcherRefreshInterval.Ticks, options.KvCollectionRefreshInterval.Ticks));
             }
             else if (hasWatchers)
@@ -206,7 +213,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     var utcNow = DateTimeOffset.UtcNow;
                     IEnumerable<KeyValueWatcher> refreshableIndividualKvWatchers = _options.IndividualKvWatchers.Where(kvWatcher => utcNow >= kvWatcher.NextRefreshTime);
                     IEnumerable<KeyValueWatcher> refreshableFfWatchers = _options.FeatureFlagWatchers.Where(ffWatcher => utcNow >= ffWatcher.NextRefreshTime);
-                    bool isRefreshDue = utcNow >= _nextCollectionRefreshTime;
+                    bool isRefreshDue = _options.RegisterAllEnabled && utcNow >= _nextCollectionRefreshTime;
 
                     // Skip refresh if mappedData is loaded, but none of the watchers or adapters are refreshable.
                     if (_mappedData != null &&
@@ -412,7 +419,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                         }
                     }
 
-                    if (isRefreshDue)
+                    if (_options.RegisterAllEnabled && isRefreshDue)
                     {
                         _nextCollectionRefreshTime = DateTimeOffset.UtcNow.Add(_options.KvCollectionRefreshInterval);
                     }

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -457,7 +457,6 @@ namespace Tests.AzureAppConfiguration
                 .Returns(() =>
                 {
                     requestCount++;
-                    
                     var copy = new List<ConfigurationSetting>();
                     foreach (var setting in keyValueCollection)
                     {
@@ -1022,7 +1021,7 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
-        public void RefreshTests_RefreshIsCancelled()
+        public async Task RefreshTests_RefreshIsCancelled()
         {
             IConfigurationRefresher refresher = null;
             var mockClient = GetMockConfigurationClient();

--- a/tests/Tests.AzureAppConfiguration/RefreshTests.cs
+++ b/tests/Tests.AzureAppConfiguration/RefreshTests.cs
@@ -449,7 +449,7 @@ namespace Tests.AzureAppConfiguration
             var requestCount = 0;
             var mockResponse = new Mock<Response>();
             var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);
-            
+
             // Define delay for async operations
             var operationDelay = TimeSpan.FromSeconds(6);
 

--- a/tests/Tests.AzureAppConfiguration/TestHelper.cs
+++ b/tests/Tests.AzureAppConfiguration/TestHelper.cs
@@ -215,7 +215,7 @@ namespace Tests.AzureAppConfiguration
             {
                 await Task.Delay(_delay.Value);
             }
-            
+
             yield return Page<ConfigurationSetting>.FromValues(_collection, null, new MockResponse(_status));
         }
     }

--- a/tests/Tests.AzureAppConfiguration/TestHelper.cs
+++ b/tests/Tests.AzureAppConfiguration/TestHelper.cs
@@ -164,8 +164,9 @@ namespace Tests.AzureAppConfiguration
     {
         private readonly List<ConfigurationSetting> _collection = new List<ConfigurationSetting>();
         private int _status;
+        private readonly TimeSpan? _delay;
 
-        public MockAsyncPageable(List<ConfigurationSetting> collection)
+        public MockAsyncPageable(List<ConfigurationSetting> collection, TimeSpan? delay = null)
         {
             foreach (ConfigurationSetting setting in collection)
             {
@@ -177,6 +178,7 @@ namespace Tests.AzureAppConfiguration
             }
 
             _status = 200;
+            _delay = delay;
         }
 
         public void UpdateCollection(List<ConfigurationSetting> newCollection)
@@ -207,10 +209,13 @@ namespace Tests.AzureAppConfiguration
             }
         }
 
-#pragma warning disable 1998
-        public async override IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(string continuationToken = null, int? pageSizeHint = null)
-#pragma warning restore 1998
+        public override async IAsyncEnumerable<Page<ConfigurationSetting>> AsPages(string continuationToken = null, int? pageSizeHint = null)
         {
+            if (_delay.HasValue)
+            {
+                await Task.Delay(_delay.Value);
+            }
+            
             yield return Page<ConfigurationSetting>.FromValues(_collection, null, new MockResponse(_status));
         }
     }


### PR DESCRIPTION
This PR does the following:

* Ensure that kv collection refresh interval is not used unless collection based refresh of key-values is enabled.
* Fix short circuit code path when no refresh is due.
* Add tests to ensure that minimum refresh interval is respected for key-values and feature flags.

Impact wise, these changes should have little to no behavioral/performance impact. Mostly code clarity.

In response to https://github.com/Azure/AppConfiguration-DotnetProvider/issues/632