### PR TITLE
Shorten default timeout of individual calls to backend

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 //
 using Azure.Core;
-using Azure.Core.Pipeline;
 using Azure.Data.AppConfiguration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions;
@@ -11,7 +10,6 @@ using Microsoft.Extensions.Configuration.AzureAppConfiguration.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
@@ -20,7 +18,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     /// Options used to configure the behavior of an Azure App Configuration provider.         
     /// If neither <see cref="Select"/> nor <see cref="SelectSnapshot"/> is ever called, all key-values with no label are included in the configuration provider.
     /// </summary>
-    public class AzureAppConfigurationOptions : IDisposable
+    public class AzureAppConfigurationOptions
     {
         private const int MaxRetries = 2;
         private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(1);
@@ -34,10 +32,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         private List<KeyValueSelector> _selectors;
         private IConfigurationRefresher _refresher = new AzureAppConfigurationRefresher();
         private bool _selectCalled = false;
-        private HttpClientTransport _clientOptionsTransport = new HttpClientTransport(new HttpClient()
-        {
-            Timeout = NetworkTimeout
-        });
 
         // The following set is sorted in descending order.
         // Since multiple prefixes could start with the same characters, we need to trim the longest prefix first.
@@ -132,7 +126,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// Options used to configure the client used to communicate with Azure App Configuration.
         /// </summary>
-        internal ConfigurationClientOptions ClientOptions { get; }
+        internal ConfigurationClientOptions ClientOptions { get; } = GetDefaultClientOptions();
 
         /// <summary>
         /// Flag to indicate whether Key Vault options have been configured.
@@ -168,8 +162,6 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
             // Adds the default query to App Configuration if <see cref="Select"/> and <see cref="SelectSnapshot"/> are never called.
             _selectors = new List<KeyValueSelector> { DefaultQuery };
-
-            ClientOptions = GetDefaultClientOptions();
         }
 
         /// <summary>
@@ -532,27 +524,16 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             return this;
         }
 
-        private ConfigurationClientOptions GetDefaultClientOptions()
+        private static ConfigurationClientOptions GetDefaultClientOptions()
         {
             var clientOptions = new ConfigurationClientOptions(ConfigurationClientOptions.ServiceVersion.V2023_10_01);
             clientOptions.Retry.MaxRetries = MaxRetries;
             clientOptions.Retry.MaxDelay = MaxRetryDelay;
             clientOptions.Retry.Mode = RetryMode.Exponential;
+            clientOptions.Retry.NetworkTimeout = NetworkTimeout;
             clientOptions.AddPolicy(new UserAgentHeaderPolicy(), HttpPipelinePosition.PerCall);
-            clientOptions.Transport = _clientOptionsTransport;
 
             return clientOptions;
-        }
-
-        /// <summary>
-        /// Disposes of this instance of <see cref="AzureAppConfigurationOptions"/> and any resources it holds.
-        /// </summary>
-        public void Dispose()
-        {
-            if (_clientOptionsTransport != null)
-            {
-                _clientOptionsTransport.Dispose();
-            }
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     /// Options used to configure the behavior of an Azure App Configuration provider.         
     /// If neither <see cref="Select"/> nor <see cref="SelectSnapshot"/> is ever called, all key-values with no label are included in the configuration provider.
     /// </summary>
-    public class AzureAppConfigurationOptions
+    public class AzureAppConfigurationOptions : IDisposable
     {
         private const int MaxRetries = 2;
         private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(1);
@@ -513,13 +513,23 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             clientOptions.Retry.MaxDelay = MaxRetryDelay;
             clientOptions.Retry.Mode = RetryMode.Exponential;
             clientOptions.AddPolicy(new UserAgentHeaderPolicy(), HttpPipelinePosition.PerCall);
-            // Need to dispose this HttpClientTransport when no longer needed
             clientOptions.Transport = new HttpClientTransport(new HttpClient()
             {
                 Timeout = NetworkTimeout
             });
 
             return clientOptions;
+        }
+
+        /// <summary>
+        /// Disposes of this instance of <see cref="AzureAppConfigurationOptions"/> and any resources it holds.
+        /// </summary>
+        public void Dispose()
+        {
+            if (ClientOptions?.Transport is HttpClientTransport transport)
+            {
+                transport.Dispose();
+            }
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -526,7 +526,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// </summary>
         public void Dispose()
         {
-            if (ClientOptions?.Transport is HttpClientTransport transport)
+            if (ClientOptions.Transport is HttpClientTransport transport)
             {
                 transport.Dispose();
             }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -539,6 +539,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             clientOptions.Retry.MaxDelay = MaxRetryDelay;
             clientOptions.Retry.Mode = RetryMode.Exponential;
             clientOptions.AddPolicy(new UserAgentHeaderPolicy(), HttpPipelinePosition.PerCall);
+            clientOptions.Transport = _clientOptionsTransport;
 
             return clientOptions;
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 //
 using Azure.Core;
+using Azure.Core.Pipeline;
 using Azure.Data.AppConfiguration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureKeyVault;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions;
@@ -10,6 +11,7 @@ using Microsoft.Extensions.Configuration.AzureAppConfiguration.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
@@ -22,6 +24,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
     {
         private const int MaxRetries = 2;
         private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(1);
+        private static readonly TimeSpan NetworkTimeout = TimeSpan.FromSeconds(10);
         private static readonly KeyValueSelector DefaultQuery = new KeyValueSelector { KeyFilter = KeyFilter.Any, LabelFilter = LabelFilter.Null };
 
         private List<KeyValueWatcher> _individualKvWatchers = new List<KeyValueWatcher>();
@@ -510,6 +513,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
             clientOptions.Retry.MaxDelay = MaxRetryDelay;
             clientOptions.Retry.Mode = RetryMode.Exponential;
             clientOptions.AddPolicy(new UserAgentHeaderPolicy(), HttpPipelinePosition.PerCall);
+            // Need to dispose this HttpClientTransport when no longer needed
+            clientOptions.Transport = new HttpClientTransport(new HttpClient()
+            {
+                Timeout = NetworkTimeout
+            });
 
             return clientOptions;
         }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -1234,7 +1234,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         {
             TaskCanceledException tce = ex.InnerExceptions?.LastOrDefault(e => e is TaskCanceledException) as TaskCanceledException;
 
-            if (tce != null && tce.InnerException is TaskCanceledException)
+            if (tce != null)
             {
                 return true;
             }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -1221,6 +1221,13 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         private bool IsFailOverable(AggregateException ex)
         {
+            TaskCanceledException tce = ex.InnerExceptions?.LastOrDefault(e => e is TaskCanceledException) as TaskCanceledException;
+
+            if (tce != null && tce.InnerException is TimeoutException)
+            {
+                return true;
+            }
+
             RequestFailedException rfe = ex.InnerExceptions?.LastOrDefault(e => e is RequestFailedException) as RequestFailedException;
 
             return rfe != null ? IsFailOverable(rfe) : false;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -1234,7 +1234,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         {
             TaskCanceledException tce = ex.InnerExceptions?.LastOrDefault(e => e is TaskCanceledException) as TaskCanceledException;
 
-            if (tce != null && tce.InnerException is TimeoutException)
+            if (tce != null && tce.InnerException is TaskCanceledException)
             {
                 return true;
             }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -1232,9 +1232,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         private bool IsFailOverable(AggregateException ex)
         {
-            TaskCanceledException tce = ex.InnerExceptions?.LastOrDefault(e => e is TaskCanceledException) as TaskCanceledException;
-
-            if (tce != null)
+            if (ex.InnerExceptions?.Any(e => e is TaskCanceledException) == true)
             {
                 return true;
             }

--- a/tests/Tests.AzureAppConfiguration/FailoverTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FailoverTests.cs
@@ -410,6 +410,7 @@ namespace Tests.AzureAppConfiguration
             });
 
             // Make sure the startup exception is due to network timeout
+            // Aggregate exception is nested due to how provider stores all startup exceptions thrown
             Assert.True(exception.InnerException is AggregateException ae &&
                 ae.InnerException is AggregateException ae2 &&
                 ae2.InnerException is TaskCanceledException tce &&

--- a/tests/Tests.AzureAppConfiguration/FailoverTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FailoverTests.cs
@@ -413,6 +413,7 @@ namespace Tests.AzureAppConfiguration
             // Aggregate exception is nested due to how provider stores all startup exceptions thrown
             Assert.True(exception.InnerException is AggregateException ae &&
                 ae.InnerException is AggregateException ae2 &&
+                ae2.InnerExceptions.All(ex => ex is TaskCanceledException) &&
                 ae2.InnerException is TaskCanceledException tce &&
                 tce.InnerException is TaskCanceledException);
         }

--- a/tests/Tests.AzureAppConfiguration/FailoverTests.cs
+++ b/tests/Tests.AzureAppConfiguration/FailoverTests.cs
@@ -414,8 +414,7 @@ namespace Tests.AzureAppConfiguration
             Assert.True(exception.InnerException is AggregateException ae &&
                 ae.InnerException is AggregateException ae2 &&
                 ae2.InnerExceptions.All(ex => ex is TaskCanceledException) &&
-                ae2.InnerException is TaskCanceledException tce &&
-                tce.InnerException is TaskCanceledException);
+                ae2.InnerException is TaskCanceledException tce);
         }
     }
 }


### PR DESCRIPTION
This is a redo of a PR that was previously merged and reverted: #620

This PR adds a way to dispose of the `HttpClientTransport` class that was added, but otherwise the change is intended to be the same.