### PR TITLE
Clarify client factory comment

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -175,8 +175,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// Sets the client factory used to create ConfigurationClient instances.
         /// If a client factory is provided using this method, a call to Connect is
-        /// still required to provide an endpoint for the Azure App Configuration store
-        /// but will not be used to authenticate a <see cref="ConfigurationClient"/>.
+        /// still required to identify an Azure App Configuration store but will not
+        /// be used to authenticate a <see cref="ConfigurationClient"/>.
         /// </summary>
         /// <param name="factory">The client factory.</param>
         /// <returns>The current <see cref="AzureAppConfigurationOptions"/> instance.</returns>

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -174,6 +174,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         /// <summary>
         /// Sets the client factory used to create ConfigurationClient instances.
+        /// If a client factory is provided using this method, a call to Connect is
+        /// still required to provide an endpoint for the Azure App Configuration store
+        /// but will not be used to authenticate a <see cref="ConfigurationClient"/>.
         /// </summary>
         /// <param name="factory">The client factory.</param>
         /// <returns>The current <see cref="AzureAppConfigurationOptions"/> instance.</returns>

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationOptions.cs
@@ -175,8 +175,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         /// <summary>
         /// Sets the client factory used to create ConfigurationClient instances.
         /// If a client factory is provided using this method, a call to Connect is
-        /// still required to identify an Azure App Configuration store but will not
-        /// be used to authenticate a <see cref="ConfigurationClient"/>.
+        /// still required to identify one or more Azure App Configuration stores but
+        /// will not be used to authenticate a <see cref="ConfigurationClient"/>.
         /// </summary>
         /// <param name="factory">The client factory.</param>
         /// <returns>The current <see cref="AzureAppConfigurationOptions"/> instance.</returns>


### PR DESCRIPTION
The `SetClientFactory` method currently does not replace the `Connect` method, and the way this works may be unclear to users.