### PR TITLE
Fix activity source test bug

### DIFF
--- a/tests/Tests.AzureAppConfiguration/Unit/Tests.cs
+++ b/tests/Tests.AzureAppConfiguration/Unit/Tests.cs
@@ -352,10 +352,12 @@ namespace Tests.AzureAppConfiguration
         [Fact]
         public void TestActivitySource()
         {
+            string activitySourceName = Guid.NewGuid().ToString();
+
             var _activities = new List<Activity>();
             var _activityListener = new ActivityListener
             {
-                ShouldListenTo = source => source.Name == "Microsoft.Extensions.Configuration.AzureAppConfiguration",
+                ShouldListenTo = source => source.Name == activitySourceName,
                 Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
                 ActivityStarted = activity => _activities.Add(activity),
             };
@@ -371,7 +373,11 @@ namespace Tests.AzureAppConfiguration
                 .ReturnsAsync(Response.FromValue(_kv, mockResponse.Object));
 
             var config = new ConfigurationBuilder()
-                .AddAzureAppConfiguration(options => options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object))
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
+                    options.ActivitySourceName = activitySourceName;
+                })
                 .Build();
 
             Assert.Contains(_activities, a => a.OperationName == "Load");


### PR DESCRIPTION
## Why this PR?

Sometimes, the CI pipeline will report the following error:

```
Error message
System.InvalidOperationException : Collection was modified; enumeration operation may not execute.



Stack trace
at System.Collections.Generic.List`1.Enumerator.MoveNext()
at Tests.AzureAppConfiguration.Tests.TestActivitySource() in C:\__w\1\s\AppConfiguration-DotnetProvider\tests\Tests.AzureAppConfiguration\Unit\Tests.cs:line 377
at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```

The issue is that the `ActivityListener` callback can be invoked on different threads. The fix is to ensure that each test thread is listen to diffferent activity source.

