### PR TITLE
Add request tracing for Aspire usage

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -1331,6 +1331,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
                     _requestTracingOptions.FeatureManagementAspNetCoreVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.FeatureManagementAspNetCoreAssemblyName);
 
+                    _requestTracingOptions.AspireComponentVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.AspireComponentAssemblyName);
+
                     if (TracingUtils.GetAssemblyVersion(RequestTracingConstants.SignalRAssemblyName) != null)
                     {
                         _requestTracingOptions.IsSignalRUsed = true;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public const string EnvironmentKey = "Env";
         public const string FeatureManagementVersionKey = "FMVer";
         public const string FeatureManagementAspNetCoreVersionKey = "FMANCVer";
+        public const string AspireComponentVersionKey = "ACVer";
         public const string DevEnvironmentValue = "Dev";
         public const string KeyVaultConfiguredTag = "UsesKeyVault";
         public const string KeyVaultRefreshConfiguredTag = "RefreshesKeyVault";
@@ -53,6 +54,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         public const string FeatureManagementAssemblyName = "Microsoft.FeatureManagement";
         public const string FeatureManagementAspNetCoreAssemblyName = "Microsoft.FeatureManagement.AspNetCore";
+        public const string AspireComponentAssemblyName = "Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration";
         public const string SignalRAssemblyName = "Microsoft.AspNetCore.SignalR";
 
         public const string Delimiter = "+";

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/RequestTracingOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/RequestTracingOptions.cs
@@ -51,6 +51,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public string FeatureManagementAspNetCoreVersion { get; set; }
 
         /// <summary>
+        /// Version of the Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration assembly, if present in the application.
+        /// </summary>
+        public string AspireComponentVersion { get; set; }
+
+        /// <summary>
         /// Flag to indicate whether Microsoft.AspNetCore.SignalR assembly is present in the application.
         /// </summary>
         public bool IsSignalRUsed { get; set; } = false;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -181,6 +181,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 correlationContextKeyValues.Add(new KeyValuePair<string, string>(RequestTracingConstants.FeatureManagementAspNetCoreVersionKey, requestTracingOptions.FeatureManagementAspNetCoreVersion));
             }
 
+            if (requestTracingOptions.AspireComponentVersion != null)
+            {
+                correlationContextKeyValues.Add(new KeyValuePair<string, string>(RequestTracingConstants.AspireComponentVersionKey, requestTracingOptions.AspireComponentVersion));
+            }
+
             if (requestTracingOptions.UsesAnyTracingFeature())
             {
                 correlationContextKeyValues.Add(new KeyValuePair<string, string>(RequestTracingConstants.FeaturesKey, requestTracingOptions.CreateFeaturesString()));


### PR DESCRIPTION
Add `ACVer=<assembly version>` to request tracing

We can only inspect the Aspire component package `Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration`.This package actually has dependency on .net provider.

Another Aspire hosting package `Aspire.Hosting.Azure.AppConfiguration` will be loaded by the AppHost project, so it cannot be inspected by the project which used configuration provider.