### PR TITLE
Adding Snapshot References Feature

### DIFF
--- a/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
+++ b/src/Microsoft.Azure.AppConfiguration.AspNetCore/Microsoft.Azure.AppConfiguration.AspNetCore.csproj
@@ -21,7 +21,7 @@
   <!-- Nuget Package Version Settings -->
 
   <PropertyGroup>
-    <OfficialVersion>8.3.0</OfficialVersion>
+    <OfficialVersion>8.4.0</OfficialVersion>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'=='Official'">

--- a/src/Microsoft.Azure.AppConfiguration.Functions.Worker/Microsoft.Azure.AppConfiguration.Functions.Worker.csproj
+++ b/src/Microsoft.Azure.AppConfiguration.Functions.Worker/Microsoft.Azure.AppConfiguration.Functions.Worker.csproj
@@ -24,7 +24,7 @@
   <!-- Nuget Package Version Settings -->
 
   <PropertyGroup>
-    <OfficialVersion>8.3.0</OfficialVersion>
+    <OfficialVersion>8.4.0</OfficialVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'=='Official'">

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationProvider.cs
@@ -1284,7 +1284,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
                         do
                         {
-                            UpdateClientBackoffStatus(previousEndpoint, success);
+                            UpdateClientBackoffStatus(_configClientManager.GetEndpointForClient(currentClient), success);
 
                             clientEnumerator.MoveNext();
 
@@ -1400,6 +1400,8 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                     _requestTracingOptions.FeatureManagementVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.FeatureManagementAssemblyName);
 
                     _requestTracingOptions.FeatureManagementAspNetCoreVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.FeatureManagementAspNetCoreAssemblyName);
+
+                    _requestTracingOptions.AspireComponentVersion = TracingUtils.GetAssemblyVersion(RequestTracingConstants.AspireComponentAssemblyName);
 
                     if (TracingUtils.GetAssemblyVersion(RequestTracingConstants.SignalRAssemblyName) != null)
                     {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Constants/RequestTracingConstants.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public const string EnvironmentKey = "Env";
         public const string FeatureManagementVersionKey = "FMVer";
         public const string FeatureManagementAspNetCoreVersionKey = "FMANCVer";
+        public const string AspireComponentVersionKey = "DNACVer";
         public const string DevEnvironmentValue = "Dev";
         public const string KeyVaultConfiguredTag = "UsesKeyVault";
         public const string KeyVaultRefreshConfiguredTag = "RefreshesKeyVault";
@@ -53,6 +54,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
         public const string FeatureManagementAssemblyName = "Microsoft.FeatureManagement";
         public const string FeatureManagementAspNetCoreAssemblyName = "Microsoft.FeatureManagement.AspNetCore";
+        public const string AspireComponentAssemblyName = "Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration";
         public const string SignalRAssemblyName = "Microsoft.AspNetCore.SignalR";
 
         public const string Delimiter = "+";

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/JsonKeyValueAdapter.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 {
     internal class JsonKeyValueAdapter : IKeyValueAdapter
     {
+        private static readonly JsonDocumentOptions JsonParseOptions = new JsonDocumentOptions
+        {
+            CommentHandling = JsonCommentHandling.Skip
+        };
+
         public Task<IEnumerable<KeyValuePair<string, string>>> ProcessKeyValue(ConfigurationSetting setting, Uri endpoint, Logger logger, CancellationToken cancellationToken)
         {
             if (setting == null)
@@ -28,7 +33,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
 
             try
             {
-                using (JsonDocument document = JsonDocument.Parse(rootJson))
+                using (JsonDocument document = JsonDocument.Parse(rootJson, JsonParseOptions))
                 {
                     keyValuePairs = new JsonFlattener().FlattenJson(document.RootElement);
                 }

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -38,7 +38,7 @@
   <!-- Nuget Package Version Settings -->
   
   <PropertyGroup>
-    <OfficialVersion>8.3.0</OfficialVersion>
+    <OfficialVersion>8.4.0</OfficialVersion>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(CDP_PATCH_NUMBER)'!='' AND '$(CDP_BUILD_TYPE)'=='Official'">

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/RequestTracingOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/RequestTracingOptions.cs
@@ -52,6 +52,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
         public string FeatureManagementAspNetCoreVersion { get; set; }
 
         /// <summary>
+        /// Version of the Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration assembly, if present in the application.
+        /// </summary>
+        public string AspireComponentVersion { get; set; }
+
+        /// <summary>
         /// Flag to indicate whether Microsoft.AspNetCore.SignalR assembly is present in the application.
         /// </summary>
         public bool IsSignalRUsed { get; set; } = false;

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/TracingUtils.cs
@@ -181,6 +181,11 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration
                 correlationContextKeyValues.Add(new KeyValuePair<string, string>(RequestTracingConstants.FeatureManagementAspNetCoreVersionKey, requestTracingOptions.FeatureManagementAspNetCoreVersion));
             }
 
+            if (requestTracingOptions.AspireComponentVersion != null)
+            {
+                correlationContextKeyValues.Add(new KeyValuePair<string, string>(RequestTracingConstants.AspireComponentVersionKey, requestTracingOptions.AspireComponentVersion));
+            }
+
             if (requestTracingOptions.UsesAnyTracingFeature())
             {
                 correlationContextKeyValues.Add(new KeyValuePair<string, string>(RequestTracingConstants.FeaturesKey, requestTracingOptions.CreateFeaturesString()));

--- a/tests/Tests.AzureAppConfiguration/Unit/Tests.cs
+++ b/tests/Tests.AzureAppConfiguration/Unit/Tests.cs
@@ -352,10 +352,12 @@ namespace Tests.AzureAppConfiguration
         [Fact]
         public void TestActivitySource()
         {
+            string activitySourceName = Guid.NewGuid().ToString();
+
             var _activities = new List<Activity>();
             var _activityListener = new ActivityListener
             {
-                ShouldListenTo = source => source.Name == "Microsoft.Extensions.Configuration.AzureAppConfiguration",
+                ShouldListenTo = source => source.Name == activitySourceName,
                 Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
                 ActivityStarted = activity => _activities.Add(activity),
             };
@@ -371,7 +373,11 @@ namespace Tests.AzureAppConfiguration
                 .ReturnsAsync(Response.FromValue(_kv, mockResponse.Object));
 
             var config = new ConfigurationBuilder()
-                .AddAzureAppConfiguration(options => options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object))
+                .AddAzureAppConfiguration(options =>
+                {
+                    options.ClientManager = TestHelpers.CreateMockedConfigurationClientManager(mockClient.Object);
+                    options.ActivitySourceName = activitySourceName;
+                })
                 .Build();
 
             Assert.Contains(_activities, a => a.OperationName == "Load");


### PR DESCRIPTION
**Overview**
Adds Snapshot References to the .NET configuration provider for dynamic updates via the cloud portal, with automatic resolution and no code changes.

**Key Changes**
**AzureAppConfigurationProvider.cs**
- Detects snapshot references via custom content type.
- Implements ParseSnapshotReference() for JSON parsing.
- Adds Resolve() for snapshot resolution.
- Updates LoadSelected() to auto-resolve references.
- Triggers refreshAll for snapshot references.

**SnapshotReference.cs (New)**
Model for snapshot reference: name, client, cancellation token.
**SnapshotReferenceConstants.cs (New)**
Shared constants for content type and JSON fields.

**Test Coverage**
Includes unit and integration tests for resolution, refresh behavior, and edge cases.

**Key Callouts**
Resolution: Auto-detected by content type; lexicographic “last wins” for duplicates.
Exceptions:
- Invalid JSON → FormatException
- Invalid composition → InvalidOperationException

Refresh: Always triggers refreshAll, regardless of settings.
JSON Handling: Ignores extra fields, validates snapshot_name, handles empty values.
Edge Cases: Non-existent references and empty names return empty config without exceptions.