### PR TITLE
Adds helper overload of AddAzureAppConfiguration for using EntraId (token credential)

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using Azure.Core;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -61,6 +62,29 @@ namespace Microsoft.Extensions.Configuration
             bool optional = false)
         {
             return configurationBuilder.AddAzureAppConfiguration(options => options.Connect(connectionStrings), optional);
+        }
+
+        /// <summary>
+        /// Adds key-value data from an Azure App Configuration store to a configuration builder.
+        /// </summary>
+        /// <param name="configurationBuilder">The configuration builder to add key-values to.</param>
+        /// <param name="endpoint">The endpoint used to connect to the configuration store.</param>
+        /// <param name="credential">The <see cref="TokenCredential"/> used to authenticate requests to the configuration store.</param>
+        /// <param name="optional">Determines the behavior of the App Configuration provider when an exception occurs while loading data from server. If false, the exception is thrown. If true, the exception is suppressed and no settings are populated from Azure App Configuration.
+        /// <exception cref="ArgumentException"/> will always be thrown when the caller gives an invalid input configuration (connection strings, endpoints, key/label filters...etc).
+        /// </param>
+        /// <returns>The provided configuration builder.</returns>
+        public static IConfigurationBuilder AddAzureAppConfiguration(
+            this IConfigurationBuilder configurationBuilder,
+            Uri endpoint,
+            TokenCredential credential,
+            bool optional = false)
+        {
+            var source = new AzureAppConfigurationSource((options) =>
+            {
+                options.Connect(endpoint, credential);
+            }, optional);
+            return configurationBuilder.Add(source);
         }
 
         /// <summary>

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/AzureAppConfigurationExtensions.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Extensions.Configuration
             {
                 options.Connect(endpoint, credential);
             }, optional);
+
             return configurationBuilder.Add(source);
         }
 


### PR DESCRIPTION
fixes #693 

It's now possible to do:
```csharp
builder.AddAzureAppConfiguration(endpoint, credentials);
```

instead of, less discoverable,:
```csharp
builder.AddAzureAppConfiguration(options => {
    options.Connect(endpoint, credentials);
});
```


