### PR TITLE
Fix integration test bug

### DIFF
--- a/tests/Tests.AzureAppConfiguration/Integration/IntegrationTests.cs
+++ b/tests/Tests.AzureAppConfiguration/Integration/IntegrationTests.cs
@@ -124,7 +124,7 @@ namespace Tests.AzureAppConfiguration
             ConfigurationSnapshot snapshot = new ConfigurationSnapshot(settingsToInclude);
 
             snapshot.SnapshotComposition = snapshotComposition;
-            snapshot.RetentionPeriod = TimeSpan.FromMinutes(5);
+            snapshot.RetentionPeriod = TimeSpan.FromHours(1);
 
             CreateSnapshotOperation operation = await _configClient.CreateSnapshotAsync(
                 WaitUntil.Completed,

--- a/tests/Tests.AzureAppConfiguration/Integration/IntegrationTests.cs
+++ b/tests/Tests.AzureAppConfiguration/Integration/IntegrationTests.cs
@@ -344,10 +344,11 @@ namespace Tests.AzureAppConfiguration
         {
             if (_configClient != null)
             {
-                await CreateSnapshot(context.SnapshotName, new List<ConfigurationSettingsFilter>
+                var settingsToInclude = new List<ConfigurationSettingsFilter>
                 {
                     new ConfigurationSettingsFilter(context.KeyPrefix + ":*")
-                });
+                };
+                await CreateSnapshot(context.SnapshotName, settingsToInclude, SnapshotComposition.Key);
 
                 ConfigurationSetting snapshotReferenceSetting = ConfigurationModelFactory.ConfigurationSetting(
                     context.SnapshotReferenceKey,
@@ -1236,7 +1237,7 @@ namespace Tests.AzureAppConfiguration
             string snapshotName = $"snapshot-{testContext.KeyPrefix}";
 
             // Create a snapshot with the test keys
-            await CreateSnapshot(snapshotName, new List<ConfigurationSettingsFilter> { new ConfigurationSettingsFilter(testContext.KeyPrefix + "*") });
+            await CreateSnapshot(snapshotName, new List<ConfigurationSettingsFilter> { new ConfigurationSettingsFilter(testContext.KeyPrefix + "*") }, SnapshotComposition.Key);
 
             // Update values after snapshot is taken to verify snapshot has original values
             await _configClient.SetConfigurationSettingAsync(new ConfigurationSetting($"{testContext.KeyPrefix}:Setting1", "UpdatedAfterSnapshot"));
@@ -1295,8 +1296,8 @@ namespace Tests.AzureAppConfiguration
             string snapshotName2 = $"snapshot-{testContext2.KeyPrefix}";
 
             // Create snapshots
-            await CreateSnapshot(snapshotName1, new List<ConfigurationSettingsFilter> { new ConfigurationSettingsFilter(testContext1.KeyPrefix + "*") });
-            await CreateSnapshot(snapshotName2, new List<ConfigurationSettingsFilter> { new ConfigurationSettingsFilter(testContext2.KeyPrefix + "*") });
+            await CreateSnapshot(snapshotName1, new List<ConfigurationSettingsFilter> { new ConfigurationSettingsFilter(testContext1.KeyPrefix + "*") }, SnapshotComposition.Key);
+            await CreateSnapshot(snapshotName2, new List<ConfigurationSettingsFilter> { new ConfigurationSettingsFilter(testContext2.KeyPrefix + "*") }, SnapshotComposition.Key);
 
             try
             {
@@ -1480,9 +1481,9 @@ namespace Tests.AzureAppConfiguration
             string snapshot2 = $"snapshot-{secondContext.KeyPrefix}-2";
             string snapshot3 = $"snapshot-{thirdContext.KeyPrefix}-3";
 
-            await CreateSnapshot(snapshot1, new List<ConfigurationSettingsFilter> { new ConfigurationSettingsFilter(mainContext.KeyPrefix + "*") });
-            await CreateSnapshot(snapshot2, new List<ConfigurationSettingsFilter> { new ConfigurationSettingsFilter(secondContext.KeyPrefix + "*") });
-            await CreateSnapshot(snapshot3, new List<ConfigurationSettingsFilter> { new ConfigurationSettingsFilter(thirdContext.KeyPrefix + "*") });
+            await CreateSnapshot(snapshot1, new List<ConfigurationSettingsFilter> { new ConfigurationSettingsFilter(mainContext.KeyPrefix + "*") }, SnapshotComposition.Key);
+            await CreateSnapshot(snapshot2, new List<ConfigurationSettingsFilter> { new ConfigurationSettingsFilter(secondContext.KeyPrefix + "*") }, SnapshotComposition.Key);
+            await CreateSnapshot(snapshot3, new List<ConfigurationSettingsFilter> { new ConfigurationSettingsFilter(thirdContext.KeyPrefix + "*") }, SnapshotComposition.Key);
 
             try
             {
@@ -1811,10 +1812,11 @@ namespace Tests.AzureAppConfiguration
                 await _configClient.SetConfigurationSettingAsync(keyVaultRefSetting);
             }
 
-            await CreateSnapshot(testContext.SnapshotName, new List<ConfigurationSettingsFilter>
+            var settingsToInclude = new List<ConfigurationSettingsFilter>
             {
                 new ConfigurationSettingsFilter(testContext.KeyPrefix + "*")
-            });
+            };
+            await CreateSnapshot(testContext.SnapshotName, settingsToInclude, SnapshotComposition.Key);
 
             ConfigurationSetting snapshotReferenceSetting = ConfigurationModelFactory.ConfigurationSetting(
                 testContext.SnapshotReferenceKey,


### PR DESCRIPTION
Snapshots are created in the integration test without setting retention period. The default retention period is one month. So in the App Config resource (we used for integration test), there are thousands of archived snapshots.


<img width="1353" height="517" alt="image" src="https://github.com/user-attachments/assets/16db1643-8e55-4e69-903a-2a5b4a640024" />


The above logic makes it even worse, we will iterate all existing snapshots and try to archive it. That's why we saw tons of PATCH request in the backend log.

<img width="1201" height="375" alt="image" src="https://github.com/user-attachments/assets/1ef2ab99-ae9f-4810-a4c2-5a6b763bab90" />

This explains why it takes so long to run the integration test and it sometimes got 429.