### PR TITLE
Included Tag filters in KeyValueWatcher HashCode and Equals , just like KeyValueSelector had [issue705]

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
         {
             if (obj is KeyValueWatcher kvWatcher)
             {
-                 return Key == kvWatcher.Key && 
-                     Label.NormalizeNull() == kvWatcher.Label.NormalizeNull() &&
-                     (Tags == null ? kvWatcher.Tags == null : kvWatcher.Tags != null && new HashSet<string>(Tags).SetEquals(kvWatcher.Tags));
+                return Key == kvWatcher.Key &&
+                    Label.NormalizeNull() == kvWatcher.Label.NormalizeNull() &&
+                    (Tags == null ? kvWatcher.Tags == null : kvWatcher.Tags != null && new HashSet<string>(Tags).SetEquals(kvWatcher.Tags));
             }
 
             return false;
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
                 var sortedTags = new SortedSet<string>(Tags);
                 tagFiltersString = string.Join("\n", sortedTags);
             }
-            
+
             return HashCode.Combine(
                 Key,
                 Label.NormalizeNull(),

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
 {

--- a/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureAppConfiguration/Models/KeyValueWatcher.cs
@@ -43,7 +43,9 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
         {
             if (obj is KeyValueWatcher kvWatcher)
             {
-                return Key == kvWatcher.Key && Label.NormalizeNull() == kvWatcher.Label.NormalizeNull();
+                 return Key == kvWatcher.Key && 
+                     Label.NormalizeNull() == kvWatcher.Label.NormalizeNull() &&
+                     (Tags == null ? kvWatcher.Tags == null : kvWatcher.Tags != null && new HashSet<string>(Tags).SetEquals(kvWatcher.Tags));
             }
 
             return false;
@@ -51,7 +53,19 @@ namespace Microsoft.Extensions.Configuration.AzureAppConfiguration.Models
 
         public override int GetHashCode()
         {
-            return Label != null ? Key.GetHashCode() ^ Label.GetHashCode() : Key.GetHashCode();
+            string tagFiltersString = string.Empty;
+
+            // Consistency with KeyValueSelector: Normalize tags into a sorted string
+            if (Tags != null && Tags.Any())
+            {
+                var sortedTags = new SortedSet<string>(Tags);
+                tagFiltersString = string.Join("\n", sortedTags);
+            }
+            
+            return HashCode.Combine(
+                Key,
+                Label.NormalizeNull(),
+                tagFiltersString);
         }
     }
 }

--- a/tests/Tests.AzureAppConfiguration/Unit/TagFiltersTests.cs
+++ b/tests/Tests.AzureAppConfiguration/Unit/TagFiltersTests.cs
@@ -163,7 +163,7 @@ namespace Tests.AzureAppConfiguration
         public void KeyValueWatcher_EqualityAndHash_IncludesTags()
         {
             var tags = new List<string> { "v1", "v2" };
-            
+
             var watcher1 = new KeyValueWatcher { Key = "TestKey", Tags = tags };
             var watcher2 = new KeyValueWatcher { Key = "TestKey", Tags = new List<string> { "v2", "v1" } }; // Different order
 
@@ -172,13 +172,13 @@ namespace Tests.AzureAppConfiguration
 
             // Test HashCode
             Assert.Equal(watcher1.GetHashCode(), watcher2.GetHashCode());
-        
+
             var watcher3 = new KeyValueWatcher { Key = "TestKey", Tags = tags };
             var watcher4 = new KeyValueWatcher { Key = "TestKey", Tags = new List<string> { "v2", "v1", "v3" } }; // Different tags
-            
+
             // Test Equality (should be true if you updated Equals to use SetEquals)
             Assert.NotEqual(watcher3, watcher4);
-        
+
             // Test HashCode
             Assert.NotEqual(watcher3.GetHashCode(), watcher4.GetHashCode());
         }

--- a/tests/Tests.AzureAppConfiguration/Unit/TagFiltersTests.cs
+++ b/tests/Tests.AzureAppConfiguration/Unit/TagFiltersTests.cs
@@ -159,6 +159,30 @@ namespace Tests.AzureAppConfiguration
         }
 
         [Fact]
+        public void KeyValueWatcher_EqualityAndHash_IncludesTags()
+        {
+            var tags = new List<string> { "v1", "v2" };
+        
+            var watcher1 = new KeyValueWatcher { Key = "TestKey", Tags = tags };
+            var watcher2 = new KeyValueWatcher { Key = "TestKey", Tags = new List<string> { "v2", "v1" } }; // Different order
+        
+            // Test Equality (should be true if you updated Equals to use SetEquals)
+            Assert.Equal(watcher1, watcher2);
+        
+            // Test HashCode
+            Assert.Equal(watcher1.GetHashCode(), watcher2.GetHashCode());
+        
+            var watcher3 = new KeyValueWatcher { Key = "TestKey", Tags = tags };
+            var watcher4 = new KeyValueWatcher { Key = "TestKey", Tags = new List<string> { "v2", "v1", "v3" } }; // Different tags
+        
+            // Test Equality (should be true if you updated Equals to use SetEquals)
+            Assert.NotEqual(watcher3, watcher4);
+        
+            // Test HashCode
+            Assert.NotEqual(watcher3.GetHashCode(), watcher4.GetHashCode());
+        }
+
+        [Fact]
         public void TagFiltersTests_BasicTagFiltering()
         {
             var mockClient = new Mock<ConfigurationClient>(MockBehavior.Strict);

--- a/tests/Tests.AzureAppConfiguration/Unit/TagFiltersTests.cs
+++ b/tests/Tests.AzureAppConfiguration/Unit/TagFiltersTests.cs
@@ -6,6 +6,7 @@ using Azure.Data.AppConfiguration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration.FeatureManagement;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration.Models;
 using Moq;
 using System;
 using System.Collections.Generic;
@@ -162,19 +163,19 @@ namespace Tests.AzureAppConfiguration
         public void KeyValueWatcher_EqualityAndHash_IncludesTags()
         {
             var tags = new List<string> { "v1", "v2" };
-        
+            
             var watcher1 = new KeyValueWatcher { Key = "TestKey", Tags = tags };
             var watcher2 = new KeyValueWatcher { Key = "TestKey", Tags = new List<string> { "v2", "v1" } }; // Different order
-        
+
             // Test Equality (should be true if you updated Equals to use SetEquals)
             Assert.Equal(watcher1, watcher2);
-        
+
             // Test HashCode
             Assert.Equal(watcher1.GetHashCode(), watcher2.GetHashCode());
         
             var watcher3 = new KeyValueWatcher { Key = "TestKey", Tags = tags };
             var watcher4 = new KeyValueWatcher { Key = "TestKey", Tags = new List<string> { "v2", "v1", "v3" } }; // Different tags
-        
+            
             // Test Equality (should be true if you updated Equals to use SetEquals)
             Assert.NotEqual(watcher3, watcher4);
         


### PR DESCRIPTION
Fix for the Issue: https://github.com/Azure/AppConfiguration-DotnetProvider/issues/705