### PR TITLE
Fix test secret not being cleaned up

### DIFF
--- a/tests/Tests.AzureAppConfiguration/Integration/IntegrationTests.cs
+++ b/tests/Tests.AzureAppConfiguration/Integration/IntegrationTests.cs
@@ -1661,13 +1661,15 @@ namespace Tests.AzureAppConfiguration
             TestContext testContext = CreateTestContext("KeyVaultDifferentIntervals");
             IConfigurationRefresher refresher = null;
 
-            // Create a secret in Key Vault with short refresh interval
-            string secretName1 = $"test-secret1-{Guid.NewGuid().ToString("N").Substring(0, 8)}";
+            // Create a secret in Key Vault with short refresh interval.
+            // Name must start with TestKeyPrefix so CleanupStaleResources() can find and delete it.
+            string secretName1 = $"{testContext.KeyPrefix}-secret1";
             string secretValue1 = $"SecretValue1-{Guid.NewGuid().ToString("N").Substring(0, 8)}";
             await _secretClient.SetSecretAsync(secretName1, secretValue1);
 
-            // Create another secret in Key Vault with long refresh interval
-            string secretName2 = $"test-secret2-{Guid.NewGuid().ToString("N").Substring(0, 8)}";
+            // Create another secret in Key Vault with long refresh interval.
+            // Name must start with TestKeyPrefix so CleanupStaleResources() can find and delete it.
+            string secretName2 = $"{testContext.KeyPrefix}-secret2";
             string secretValue2 = $"SecretValue2-{Guid.NewGuid().ToString("N").Substring(0, 8)}";
             await _secretClient.SetSecretAsync(secretName2, secretValue2);
 

--- a/tests/Tests.AzureAppConfiguration/Unit/KeyVaultReferenceTests.cs
+++ b/tests/Tests.AzureAppConfiguration/Unit/KeyVaultReferenceTests.cs
@@ -744,7 +744,7 @@ namespace Tests.AzureAppConfiguration
 
             // Update sentinel key-value
             sentinelKv = TestHelpers.ChangeValue(sentinelKv, "Value2");
-            Thread.Sleep(refreshInterval);
+            Thread.Sleep(refreshInterval + TimeSpan.FromSeconds(1)); // buffer avoids the boundary race on the refresh interval
             await refresher.RefreshAsync();
 
             Assert.Equal("Value2", config["Sentinel"]);
@@ -816,7 +816,7 @@ namespace Tests.AzureAppConfiguration
 
             // Update sentinel key-value to trigger refresh operation
             sentinelKv = TestHelpers.ChangeValue(sentinelKv, "Value2");
-            Thread.Sleep(refreshInterval);
+            Thread.Sleep(refreshInterval + TimeSpan.FromSeconds(1)); // buffer avoids the boundary race on the refresh interval
             await refresher.RefreshAsync();
 
             Assert.Equal("Value2", config["Sentinel"]);
@@ -861,7 +861,7 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal(_secretValue, config[_kv.Key]);
 
             // Sleep to let the secret cache expire 
-            Thread.Sleep(refreshInterval);
+            Thread.Sleep(refreshInterval + TimeSpan.FromSeconds(1)); // buffer avoids the boundary race on the refresh interval
             await refresher.RefreshAsync();
 
             Assert.Equal(_secretValue, config[_kv.Key]);
@@ -905,7 +905,7 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal(_secretValue, config["TK2"]);
 
             // Sleep to let the secret cache expire for both secrets 
-            Thread.Sleep(shortRefreshInterval);
+            Thread.Sleep(shortRefreshInterval + TimeSpan.FromSeconds(1)); // buffer avoids the boundary race on the refresh interval
             await refresher.RefreshAsync();
 
             Assert.Equal(_secretValue, config["TK1"]);
@@ -951,8 +951,8 @@ namespace Tests.AzureAppConfiguration
             Assert.Equal(_secretValue, config["TK1"]);
             Assert.Equal(_secretValue, config["TK2"]);
 
-            // Sleep to let the secret cache expire for one secret 
-            Thread.Sleep(shortRefreshInterval);
+            // Sleep past the short interval (plus a small buffer to avoid a boundary race) so only that secret's cache expires
+            Thread.Sleep(shortRefreshInterval + TimeSpan.FromSeconds(1));
             await refresher.RefreshAsync();
 
             Assert.Equal(_secretValue, config["TK1"]);


### PR DESCRIPTION
KeyVaultReference_DifferentRefreshIntervals named its secrets test-secret1/2-*, which don't match the prefix filter in `CleanupStaleResources()`— so they were never deleted and accumulated to 3,982 leftover secrets

Cleanup lists all secrets every run; at 25/page that's ~160 requests (~100s) just to enumerate, on every test run.
